### PR TITLE
Soft-delete queue with 5s undo window

### DIFF
--- a/src/components/DeleteQueueBar.jsx
+++ b/src/components/DeleteQueueBar.jsx
@@ -1,0 +1,69 @@
+/**
+ * Fixed bottom bar with two modes:
+ *
+ * Queue mode  (pendingCount > 0, no undoState):
+ *   Shows how many items are queued, with Clear and Commit buttons.
+ *
+ * Undo mode   (undoState is set):
+ *   Shows a draining CSS progress bar and an Undo button. The actual
+ *   DB delete fires after the 5 s window if Undo is not clicked.
+ *
+ * Returns null when there is nothing to show.
+ */
+export default function DeleteQueueBar({
+    pendingCount,
+    onClearQueue,
+    onCommit,
+    undoState,
+    secondsLeft,
+    onUndo,
+    noun = 'item',
+}) {
+    const plural = (n) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+    // ── Undo toast ────────────────────────────────────────────────────────────
+    if (undoState) {
+        return (
+            <div className="fixed bottom-0 left-0 right-0 z-50 bg-gray-800 text-white shadow-2xl overflow-hidden">
+                {/* Draining progress bar — CSS animation restarts on each new undoState */}
+                <div
+                    key={undoState.startTime}
+                    className="h-1 bg-blue-400"
+                    style={{ animation: 'drain 5s linear forwards' }}
+                />
+                <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+                    <span className="font-medium flex-1">
+                        ✓ {plural(undoState.count)} deleted
+                    </span>
+                    <span className="text-gray-400 text-sm tabular-nums w-6 text-right">
+                        {secondsLeft}s
+                    </span>
+                    <button onClick={onUndo} className="btn btn-primary text-sm">
+                        ↩ Undo
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    // ── Queue bar ─────────────────────────────────────────────────────────────
+    if (pendingCount > 0) {
+        return (
+            <div className="fixed bottom-0 left-0 right-0 z-50 bg-red-50 border-t-2 border-red-200 shadow-2xl">
+                <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+                    <span className="text-red-700 font-medium flex-1">
+                        🗑 {plural(pendingCount)} queued for deletion
+                    </span>
+                    <button onClick={onClearQueue} className="btn btn-secondary text-sm">
+                        Clear queue
+                    </button>
+                    <button onClick={onCommit} className="btn btn-danger text-sm">
+                        Delete {plural(pendingCount)} →
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return null;
+}

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { parseCSV } from '../utils/parseCSV';
+import { useDeleteQueue } from '../hooks/useDeleteQueue';
+import DeleteQueueBar from './DeleteQueueBar';
 
 export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onViewChart }) {
     const [showUpload, setShowUpload] = useState(false);
@@ -14,6 +16,11 @@ export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultR
     });
     const [editingRunId, setEditingRunId] = useState(null);
     const [editFormData, setEditFormData] = useState({});
+
+    const {
+        pendingDeletes, committedDeletes, undoState, secondsLeft,
+        queueDelete, restoreItem, clearQueue, commitDeletes, undoDelete,
+    } = useDeleteQueue(onDeleteRun);
 
     const handleFileUpload = async (e) => {
         const file = e.target.files[0];
@@ -93,9 +100,11 @@ export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultR
     };
 
     const availableFields = csvData?.meta.fields || [];
+    const displayRuns     = (vehicle.runs || []).filter(r => !committedDeletes.has(r.id));
+    const barVisible      = pendingDeletes.size > 0 || !!undoState;
 
     return (
-        <div>
+        <div className={barVisible ? 'pb-20' : ''}>
             <div className="flex justify-between items-center mb-6">
                 <div>
                     <h2 className="text-2xl font-bold">{vehicle.name} - Test Runs</h2>
@@ -239,8 +248,13 @@ export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultR
             )}
 
             <div className="space-y-4">
-                {vehicle.runs?.map(run => (
-                    <div key={run.id} className="card">
+                {displayRuns.map(run => {
+                  const isPending = pendingDeletes.has(run.id);
+                  return (
+                    <div
+                        key={run.id}
+                        className={`card${isPending ? ' opacity-60 border-2 border-red-200' : ''}`}
+                    >
                         {editingRunId === run.id ? (
                             <div>
                                 <h3 className="text-lg font-bold mb-4">Edit Run</h3>
@@ -352,16 +366,17 @@ export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultR
                                         Edit
                                     </button>
                                     <button
-                                        onClick={() => onDeleteRun(run.id)}
-                                        className="btn btn-danger"
+                                        onClick={() => isPending ? restoreItem(run.id) : queueDelete(run.id)}
+                                        className={`btn text-sm ${isPending ? 'bg-orange-100 text-orange-700 hover:bg-orange-200 border-0 rounded-md px-3 py-1 font-medium' : 'btn-danger'}`}
                                     >
-                                        Delete
+                                        {isPending ? '↩ Restore' : 'Delete'}
                                     </button>
                                 </div>
                             </div>
                         )}
                     </div>
-                ))}
+                  );
+                })}
             </div>
 
             {vehicle.runs?.length === 0 && !showUpload && (
@@ -369,6 +384,16 @@ export default function RunsView({ vehicle, onAddRun, onUpdateRun, onSetDefaultR
                     <p className="text-lg">No test runs yet. Upload a CSV to get started!</p>
                 </div>
             )}
+
+            <DeleteQueueBar
+                pendingCount={pendingDeletes.size}
+                onClearQueue={clearQueue}
+                onCommit={commitDeletes}
+                undoState={undoState}
+                secondsLeft={secondsLeft}
+                onUndo={undoDelete}
+                noun="run"
+            />
         </div>
     );
 }

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useDeleteQueue } from '../hooks/useDeleteQueue';
+import DeleteQueueBar from './DeleteQueueBar';
 
 // Icons for view toggle
 const CardViewIcon = () => (
@@ -164,6 +166,11 @@ export default function VehiclesView({
     const [imageUploading, setImageUploading] = useState(false);
     const [viewMode, setViewMode] = useState('card'); // 'card' | 'list'
 
+    const {
+        pendingDeletes, committedDeletes, undoState, secondsLeft,
+        queueDelete, restoreItem, clearQueue, commitDeletes, undoDelete,
+    } = useDeleteQueue(onDelete);
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (editingId) {
@@ -243,11 +250,12 @@ export default function VehiclesView({
         );
     };
 
-    const filteredVehicles = activeTagFilters.length === 0
+    const filteredVehicles = (activeTagFilters.length === 0
         ? vehicles
         : vehicles.filter(v =>
             activeTagFilters.every(tagId => v.tags?.some(t => t.id === tagId))
-        );
+        )
+    ).filter(v => !committedDeletes.has(v.id));
 
     const availableTagsForForm = tags.filter(t => !formTags.some(ft => ft.id === t.id));
     const editingVehicle = editingId ? vehicles.find(v => v.id === editingId) : null;
@@ -295,14 +303,24 @@ export default function VehiclesView({
                         Edit
                     </button>
                 )}
-                {isOwner && (
-                    <button
-                        onClick={(e) => { e.stopPropagation(); onDelete(vehicle.id); }}
-                        className="px-3 py-1 rounded-md text-xs font-medium bg-red-50 text-red-600 hover:bg-red-100 transition"
-                    >
-                        Delete
-                    </button>
-                )}
+                {isOwner && (() => {
+                    const isPending = pendingDeletes.has(vehicle.id);
+                    return (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                isPending ? restoreItem(vehicle.id) : queueDelete(vehicle.id);
+                            }}
+                            className={`px-3 py-1 rounded-md text-xs font-medium transition${isVertical ? '' : ''} ${
+                                isPending
+                                    ? 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+                                    : 'bg-red-50 text-red-600 hover:bg-red-100'
+                            }`}
+                        >
+                            {isPending ? '↩ Restore' : 'Delete'}
+                        </button>
+                    );
+                })()}
             </div>
         );
     };
@@ -338,8 +356,10 @@ export default function VehiclesView({
 
     // ────────────────────────────────────────────────────────────────────────
 
+    const barVisible = pendingDeletes.size > 0 || !!undoState;
+
     return (
-        <div>
+        <div className={barVisible ? 'pb-20' : ''}>
             {/* Header */}
             <div className="flex justify-between items-center mb-4">
                 <h2 className="text-2xl font-bold">Vehicles</h2>
@@ -411,15 +431,16 @@ export default function VehiclesView({
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                     {filteredVehicles.map(vehicle => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
+                        const isPending  = pendingDeletes.has(vehicle.id);
                         return (
                             <div key={vehicle.id} className="contents">
                                 <div
                                     onClick={() => handleCardClick(vehicle)}
-                                    className="card hover:shadow-lg transition cursor-pointer relative overflow-hidden flex flex-col"
+                                    className={`card hover:shadow-lg transition cursor-pointer relative overflow-hidden flex flex-col${isPending ? ' opacity-60' : ''}`}
                                     style={{
                                         borderWidth: '2px',
                                         borderStyle: 'solid',
-                                        borderColor: isSelected ? 'var(--color-primary)' : 'transparent'
+                                        borderColor: isPending ? 'rgb(252,165,165)' : isSelected ? 'var(--color-primary)' : 'transparent'
                                     }}
                                 >
                                     {/* Background image + overlay */}
@@ -491,15 +512,16 @@ export default function VehiclesView({
                 <div className="flex flex-col gap-2">
                     {filteredVehicles.map(vehicle => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
+                        const isPending  = pendingDeletes.has(vehicle.id);
                         return (
                             <div key={vehicle.id}>
                                 <div
                                     onClick={() => handleCardClick(vehicle)}
-                                    className="card hover:shadow-lg transition cursor-pointer flex items-center gap-4 py-3 px-4 relative overflow-hidden"
+                                    className={`card hover:shadow-lg transition cursor-pointer flex items-center gap-4 py-3 px-4 relative overflow-hidden${isPending ? ' opacity-60' : ''}`}
                                     style={{
                                         borderWidth: '2px',
                                         borderStyle: 'solid',
-                                        borderColor: isSelected ? 'var(--color-primary)' : 'transparent'
+                                        borderColor: isPending ? 'rgb(252,165,165)' : isSelected ? 'var(--color-primary)' : 'transparent'
                                     }}
                                 >
                                     {isSelected && (
@@ -561,6 +583,16 @@ export default function VehiclesView({
                     }
                 </div>
             )}
+
+            <DeleteQueueBar
+                pendingCount={pendingDeletes.size}
+                onClearQueue={clearQueue}
+                onCommit={commitDeletes}
+                undoState={undoState}
+                secondsLeft={secondsLeft}
+                onUndo={undoDelete}
+                noun="vehicle"
+            />
         </div>
     );
 }

--- a/src/hooks/useDeleteQueue.js
+++ b/src/hooks/useDeleteQueue.js
@@ -1,0 +1,127 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const UNDO_WINDOW_MS = 5000;
+
+/**
+ * Two-phase soft-delete queue.
+ *
+ * Phase 1 — Queue:
+ *   Items are flagged with queueDelete(id). No DB write happens yet.
+ *   restoreItem(id) or clearQueue() removes items from the queue.
+ *
+ * Phase 2 — Undo window:
+ *   commitDeletes() moves queued ids to committedDeletes (items disappear
+ *   from the UI immediately) and starts a 5 s countdown. If undoDelete()
+ *   is called before the timer fires, no DB write happens and items
+ *   reappear. After 5 s the real onDelete(id) calls are made in batch.
+ *
+ * On unmount: any committed-but-not-yet-deleted items are deleted
+ * immediately so navigating away never silently preserves data.
+ *
+ * @param {function} onDelete  called with (id) per item after the undo window
+ */
+export function useDeleteQueue(onDelete) {
+    const [pendingDeletes, setPendingDeletes]     = useState(new Set());
+    const [committedDeletes, setCommittedDeletes] = useState(new Set());
+    const [undoState, setUndoState]               = useState(null); // { count, startTime }
+    const [secondsLeft, setSecondsLeft]           = useState(0);
+
+    const deleteTimerRef    = useRef(null);
+    const countdownRef      = useRef(null);
+    // Ref so the cleanup effect can fire remaining deletes without stale closures
+    const pendingCommitRef  = useRef(null); // { toDelete: Set } | null
+    const onDeleteRef       = useRef(onDelete);
+    useEffect(() => { onDeleteRef.current = onDelete; });
+
+    const stopTimers = useCallback(() => {
+        clearTimeout(deleteTimerRef.current);
+        clearInterval(countdownRef.current);
+    }, []);
+
+    // ── Phase 1 helpers ─────────────────────────────────────────────────────
+
+    const queueDelete = useCallback((id) => {
+        setPendingDeletes(prev => new Set([...prev, id]));
+    }, []);
+
+    const restoreItem = useCallback((id) => {
+        setPendingDeletes(prev => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+        });
+    }, []);
+
+    const clearQueue = useCallback(() => {
+        setPendingDeletes(new Set());
+    }, []);
+
+    // ── Phase 2: commit → undo window → actual delete ────────────────────────
+
+    const commitDeletes = useCallback(() => {
+        if (pendingDeletes.size === 0) return;
+
+        const toDelete = new Set(pendingDeletes);
+        const count    = toDelete.size;
+
+        stopTimers();
+        setPendingDeletes(new Set());
+        setCommittedDeletes(toDelete);
+        setUndoState({ count, startTime: Date.now() });
+        setSecondsLeft(5);
+
+        pendingCommitRef.current = { toDelete };
+
+        // Visual countdown (1 s ticks)
+        countdownRef.current = setInterval(() => {
+            setSecondsLeft(s => Math.max(0, s - 1));
+        }, 1000);
+
+        // Actual DB deletes after the window
+        deleteTimerRef.current = setTimeout(async () => {
+            clearInterval(countdownRef.current);
+            pendingCommitRef.current = null;
+            for (const id of toDelete) {
+                await onDeleteRef.current(id);
+            }
+            setCommittedDeletes(new Set());
+            setUndoState(null);
+            setSecondsLeft(0);
+        }, UNDO_WINDOW_MS);
+    }, [pendingDeletes, stopTimers]);
+
+    const undoDelete = useCallback(() => {
+        stopTimers();
+        pendingCommitRef.current = null;
+        setCommittedDeletes(new Set());
+        setUndoState(null);
+        setSecondsLeft(0);
+    }, [stopTimers]);
+
+    // ── Cleanup on unmount ───────────────────────────────────────────────────
+
+    useEffect(() => {
+        return () => {
+            stopTimers();
+            // Fire any committed-but-not-yet-deleted items immediately so
+            // navigating away doesn't silently cancel a user-confirmed delete.
+            if (pendingCommitRef.current) {
+                for (const id of pendingCommitRef.current.toDelete) {
+                    onDeleteRef.current(id);
+                }
+            }
+        };
+    }, [stopTimers]);
+
+    return {
+        pendingDeletes,
+        committedDeletes,
+        undoState,
+        secondsLeft,
+        queueDelete,
+        restoreItem,
+        clearQueue,
+        commitDeletes,
+        undoDelete,
+    };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,9 @@ body {
 .card:hover {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
 }
+
+/* Draining countdown bar used in the soft-delete undo toast */
+@keyframes drain {
+    from { width: 100%; }
+    to   { width: 0%; }
+}


### PR DESCRIPTION
Closes #9

## What this does

Replaces the immediate single-click delete on vehicles and runs with a two-phase safety system — no confirmation dialogs, just two natural opportunities to change your mind.

## Phase 1 — Queue (before commit)

- Clicking **Delete** flags the item: `opacity-60`, red border, button swaps to **↩ Restore** (orange)
- A **red bar pins to the bottom** of the screen showing the queue count
- **Clear queue** dequeues everything; **Delete N items →** advances to Phase 2

## Phase 2 — Undo window (5 seconds)

- Items disappear from the UI immediately (filtered locally — no DB write yet)
- Bar switches to a **dark undo toast** with a draining blue progress bar + live countdown
- **↩ Undo** cancels all pending DB writes and items reappear instantly
- After 5 s the real `onDelete` calls fire in batch

## On navigate-away
If the user navigates away during the undo window, committed deletes fire immediately via the `useEffect` cleanup — so navigating away never silently cancels a user-confirmed delete.

## Files
| File | Change |
|---|---|
| `src/hooks/useDeleteQueue.js` | New — reusable hook (phase 1 + phase 2 state, timers, cleanup) |
| `src/components/DeleteQueueBar.jsx` | New — fixed bottom bar (queue mode + undo toast mode) |
| `src/components/VehiclesView.jsx` | Integrated — vehicles |
| `src/components/RunsView.jsx` | Integrated — runs |
| `src/index.css` | `@keyframes drain` for progress bar animation |

## Test plan
- [ ] Click Delete on a vehicle → item dims, red border, button becomes ↩ Restore, red bar appears
- [ ] Click ↩ Restore → item returns to normal, bar disappears
- [ ] Queue multiple items, click Clear queue → all restored
- [ ] Click Delete N vehicles → items vanish, undo toast appears with countdown
- [ ] Click ↩ Undo within 5 s → items reappear, no DB change
- [ ] Let timer expire → items permanently deleted from DB
- [ ] Repeat all above for runs in RunsView
- [ ] Navigate away during undo window → items are deleted (not silently preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)