### PR TITLE
fix(#32): per-run point colors on scatter/line charts

### DIFF
--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -148,21 +148,34 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
             const datasets = [];
             vehicleMap.forEach(({ name, runs }) => {
                 if (runs.length === 0) return;
+                // Include run metadata in each point so tooltip and per-point
+                // color can reference it; Chart.js ignores extra fields on {x,y}.
                 const points = runs
-                    .map(r => ({ x: isSpeed ? r.speed_mph : r.temperature_f, y: getY(r) }))
+                    .map(r => ({
+                        x:        isSpeed ? r.speed_mph : r.temperature_f,
+                        y:        getY(r),
+                        _color:   r.color   || '#3b82f6',
+                        _runName: r.name,
+                    }))
                     .filter(p => p.x != null && p.y != null)
                     .sort((a, b) => a.x - b.x);
                 if (points.length === 0) return;
-                // Line color = first run's color
-                const color = runs[0].color || '#3b82f6';
+
+                // Line stroke = first run's color; individual points use their
+                // own run color so multiple runs per vehicle are distinguishable.
+                const lineColor   = runs[0].color || '#3b82f6';
+                const pointColors = points.map(p => p._color);
+
                 datasets.push({
-                    label: name,
-                    data: points,
-                    backgroundColor: color,
-                    borderColor: color,
-                    pointRadius: 6,
-                    pointHoverRadius: 9,
-                    tension: 0.2,
+                    label:                name,
+                    data:                 points,
+                    borderColor:          lineColor,
+                    backgroundColor:      lineColor,   // legend swatch
+                    pointBackgroundColor: pointColors,
+                    pointBorderColor:     pointColors,
+                    pointRadius:          6,
+                    pointHoverRadius:     9,
+                    tension:              0.2,
                 });
             });
 
@@ -347,7 +360,12 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                 if (built.kind === 'bar') {
                                     return `${ctx.dataset.label}: ${ctx.parsed.y ?? '—'}`;
                                 }
-                                return `${ctx.dataset.label}: ${ctx.parsed.y ?? ctx.raw?.y ?? '—'}`;
+                                // For line charts, show run name if the point carries one
+                                const runName = ctx.raw?._runName;
+                                const val     = ctx.parsed.y ?? ctx.raw?.y ?? '—';
+                                return runName
+                                    ? `${runName}: ${val}`
+                                    : `${ctx.dataset.label}: ${val}`;
                             },
                         },
                     },


### PR DESCRIPTION
## Problem

Line/scatter charts (range-by-speed, efficiency-by-temp, etc.) grouped all runs for a vehicle into a single dataset using one shared color — the first run's color. When a vehicle had multiple range runs tested at different speeds or temperatures, every point on the line looked identical, making it impossible to tell which run each point came from.

## Solution

Each point's data object is extended with `_color` and `_runName` (Chart.js ignores extra fields on `{x, y}` objects but exposes them via `ctx.raw` in tooltip callbacks).

- **`pointBackgroundColor`** and **`pointBorderColor`** are now per-point arrays, so each dot renders in its own run color
- **`borderColor`** (line stroke) remains the first run's color, giving each vehicle's line a stable, consistent appearance
- Tooltip `label` callback changed from `"VehicleName: value"` → **`"RunName: value"`** so hovering a point tells you exactly which run it represents
- Vehicles where all runs share the same color are visually unchanged

## Test plan

- [ ] Line chart with one vehicle, multiple runs with **different colors** → each scatter point is a different color, line stays one color
- [ ] Line chart with one vehicle, multiple runs with **same color** → all points same color (no regression)  
- [ ] Line chart with multiple vehicles → each vehicle's line color is stable (first run's color), points may vary
- [ ] Hover tooltip on a line-chart point → shows `"RunName: value"` not `"VehicleName: value"`
- [ ] Bar charts unaffected
- [ ] Legend still shows correct vehicle-level color swatch

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)