### PR TITLE
style: replace Tailwind utility clusters with semantic CSS class names

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -261,7 +261,7 @@ export default function App() {
                             </div>
                         </div>
                     )}
-                    <div className="relative max-w-7xl mx-auto px-6 py-6">
+                    <div className="relative page-container py-6">
                         {/* Clickable title → home */}
                         <button
                             onClick={() => navigateTo('vehicles')}
@@ -287,7 +287,7 @@ export default function App() {
                 </header>
 
                 <nav className="bg-white shadow-sm border-b">
-                    <div className="max-w-7xl mx-auto px-6 pt-3 pb-2">
+                    <div className="page-container pt-3 pb-2">
                         {/*
                           * flex-col-reverse on mobile: DOM order is tabs first, actions second,
                           * but col-reverse flips that so actions render on TOP and tabs below.
@@ -295,7 +295,7 @@ export default function App() {
                           */}
                         <div className={`flex flex-col-reverse gap-y-2 sm:flex-row sm:items-center ${view === 'chart' ? 'mb-1' : 'mb-3'}`}>
                             {/* Tab group */}
-                            <div className="flex gap-1 items-center flex-wrap">
+                            <div className="nav-tab-group">
                                 <button
                                     onClick={() => navigateTo('vehicles')}
                                     className={`btn-tab ${view === 'vehicles' ? 'active' : ''}`}
@@ -324,12 +324,12 @@ export default function App() {
                                 </button>
                             </div>
                             {/* Action group — right-aligned on desktop, full-width right-justified on mobile */}
-                            <div className="flex gap-2 items-center justify-end sm:ml-auto">
+                            <div className="nav-actions sm:ml-auto">
                                 {user ? (
                                     <>
                                         <span className="text-sm text-gray-600">
                                             {user.email}
-                                            {isOwner && <span className="ml-2 px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs font-bold">OWNER</span>}
+                                            {isOwner && <span className="owner-badge">OWNER</span>}
                                         </span>
                                         <button onClick={signOut} className="btn btn-secondary">
                                             Sign Out
@@ -354,9 +354,9 @@ export default function App() {
                                     {showImportMenu && (
                                         <>
                                             <div className="fixed inset-0 z-10" onClick={() => setShowImportMenu(false)} />
-                                            <div className="absolute right-0 mt-1 w-44 bg-white border rounded-lg shadow-lg z-20 overflow-hidden">
+                                            <div className="dropdown-menu w-44">
                                                 <label
-                                                    className="flex items-center gap-2 px-4 py-2.5 text-sm hover:bg-gray-50 cursor-pointer"
+                                                    className="dropdown-item cursor-pointer"
                                                     onClick={() => setShowImportMenu(false)}
                                                 >
                                                     📄 App JSON
@@ -369,7 +369,7 @@ export default function App() {
                                                     />
                                                 </label>
                                                 <button
-                                                    className="flex items-center gap-2 px-4 py-2.5 text-sm hover:bg-gray-50 w-full text-left"
+                                                    className="dropdown-item w-full text-left"
                                                     onClick={() => { setShowImportMenu(false); setShowTableauModal(true); }}
                                                 >
                                                     📊 Tableau CSV
@@ -401,9 +401,9 @@ export default function App() {
 
                     </div>
                     <div className="border-t">
-                        <div className="max-w-7xl mx-auto px-6 py-2">
+                        <div className="page-container py-2">
                         {/* Selected vehicles row */}
-                        <div className="flex gap-2 items-center flex-wrap">
+                        <div className="inline-row flex-wrap">
                             <span className="text-sm text-gray-600 font-medium">Selected:</span>
                             {selectedVehicles.length === 0 ? (
                                 <div className="px-3 py-1 bg-gray-100 text-gray-500 rounded-full text-sm">
@@ -417,7 +417,7 @@ export default function App() {
                                         return (
                                             <div
                                                 key={vehicleId}
-                                                className="flex items-center gap-1 px-3 py-1 rounded-full text-sm"
+                                                className="selected-vehicle-chip"
                                                 style={{backgroundColor: 'var(--color-primary-light)', color: 'var(--color-primary-text)'}}
                                             >
                                                 <span>{vehicle.name}</span>
@@ -444,7 +444,7 @@ export default function App() {
                     </div>
                 </nav>
 
-                <main className="max-w-7xl mx-auto p-6">
+                <main className="page-container py-6">
                     {view === 'vehicles' && (
                         <VehiclesView
                             vehicles={vehicles}
@@ -504,7 +504,7 @@ export default function App() {
                         ? 'bg-red-50 border-red-400'
                         : 'bg-green-50 border-green-500'
                 }`}>
-                    <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+                    <div className="page-container py-3 flex items-center gap-4">
                         <span className="text-xl">{appNotification.type === 'error' ? '⚠️' : '✓'}</span>
                         <p className={`flex-1 text-sm font-medium ${
                             appNotification.type === 'error' ? 'text-red-900' : 'text-green-900'

--- a/src/components/AuthModal.jsx
+++ b/src/components/AuthModal.jsx
@@ -30,9 +30,9 @@ export default function AuthModal({ onClose, onAuthSuccess }) {
     };
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-            <div className="bg-white rounded-lg p-8 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
-                <div className="flex justify-between items-center mb-6">
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-panel rounded-lg p-8 max-w-md" onClick={(e) => e.stopPropagation()}>
+                <div className="modal-header mb-6">
                     <h2 className="text-2xl font-bold">Sign In</h2>
                     <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
                 </div>
@@ -54,7 +54,7 @@ export default function AuthModal({ onClose, onAuthSuccess }) {
                     <button
                         onClick={() => handleOAuthSignIn('github')}
                         disabled={loading}
-                        className="w-full flex items-center justify-center gap-3 bg-gray-800 hover:bg-gray-900 text-white font-medium py-3 px-4 rounded-lg transition"
+                        className="auth-provider-btn bg-gray-800 hover:bg-gray-900 text-white"
                     >
                         <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
@@ -65,7 +65,7 @@ export default function AuthModal({ onClose, onAuthSuccess }) {
                     <button
                         onClick={() => handleOAuthSignIn('google')}
                         disabled={loading}
-                        className="w-full flex items-center justify-center gap-3 bg-white hover:bg-gray-50 text-gray-800 font-medium py-3 px-4 rounded-lg border-2 border-gray-300 transition"
+                        className="auth-provider-btn bg-white hover:bg-gray-50 text-gray-800 border-2 border-gray-300"
                     >
                         <svg className="w-5 h-5" viewBox="0 0 24 24">
                             <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>

--- a/src/components/AxisScaleControls.jsx
+++ b/src/components/AxisScaleControls.jsx
@@ -12,10 +12,6 @@
  *                                    Set true when a secondary Y axis is active.
  */
 
-const numInputCls =
-    'px-2 py-1 border rounded text-sm ' +
-    '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none';
-
 export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max, onChange, showX = true, showY2 = false }) {
     const colCount = 1 + (showX ? 1 : 0) + (showY2 ? 1 : 0);
     const gridClass = colCount === 3 ? 'grid-cols-3'
@@ -38,7 +34,7 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
                         </button>
                     )}
                 </div>
-                <div className="flex flex-col gap-1.5">
+                <div className="axis-scale-group">
                     <div className="flex items-center gap-2">
                         <span className="text-xs text-gray-400 w-7 text-right">Max</span>
                         <input
@@ -46,7 +42,7 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
                             placeholder="Auto"
                             value={yMax ?? ''}
                             onChange={e => onChange('yMax', e.target.value === '' ? null : Number(e.target.value))}
-                            className={`w-24 ${numInputCls}`}
+                            className="axis-input"
                         />
                     </div>
                     <div className="flex items-center gap-2">
@@ -56,7 +52,7 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
                             placeholder="Auto"
                             value={yMin ?? ''}
                             onChange={e => onChange('yMin', e.target.value === '' ? null : Number(e.target.value))}
-                            className={`w-24 ${numInputCls}`}
+                            className="axis-input"
                         />
                     </div>
                 </div>
@@ -76,25 +72,25 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
                             </button>
                         )}
                     </div>
-                    <div className="flex flex-col gap-1.5">
-                        <div className="flex items-center gap-2">
+                    <div className="axis-scale-group">
+                        <div className="inline-row">
                             <span className="text-xs text-gray-400 w-7 text-right">Max</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
                                 value={xMax ?? ''}
                                 onChange={e => onChange('xMax', e.target.value === '' ? null : Number(e.target.value))}
-                                className={`w-24 ${numInputCls}`}
+                                className="axis-input"
                             />
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="inline-row">
                             <span className="text-xs text-gray-400 w-7 text-right">Min</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
                                 value={xMin ?? ''}
                                 onChange={e => onChange('xMin', e.target.value === '' ? null : Number(e.target.value))}
-                                className={`w-24 ${numInputCls}`}
+                                className="axis-input"
                             />
                         </div>
                     </div>
@@ -113,25 +109,25 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
                             Reset
                         </button>
                     </div>
-                    <div className="flex flex-col gap-1.5">
-                        <div className="flex items-center gap-2">
+                    <div className="axis-scale-group">
+                        <div className="inline-row">
                             <span className="text-xs text-gray-400 w-7 text-right">Max</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
                                 value={y2Max ?? ''}
                                 onChange={e => onChange('y2Max', e.target.value === '' ? null : Number(e.target.value))}
-                                className={`w-24 ${numInputCls}`}
+                                className="axis-input"
                             />
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="inline-row">
                             <span className="text-xs text-gray-400 w-7 text-right">Min</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
                                 value={y2Min ?? ''}
                                 onChange={e => onChange('y2Min', e.target.value === '' ? null : Number(e.target.value))}
-                                className={`w-24 ${numInputCls}`}
+                                className="axis-input"
                             />
                         </div>
                     </div>

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -424,9 +424,6 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         }
     };
 
-    // ── Shared input class ────────────────────────────────────────────────────
-    const numInputCls = 'px-2 py-1 border rounded text-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none';
-
     // ── Render ────────────────────────────────────────────────────────────────
 
     if (chartMode === 'range') {
@@ -445,7 +442,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             {/* ── Top card: presets, axis selectors, run selector ── */}
             <div className="card mb-6">
                 <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-bold">Chart Options — Charging Performance</h3>
+                    <h3 className="section-title">Chart Options — Charging Performance</h3>
                     <button
                         onClick={() => {
                             navigator.clipboard.writeText(window.location.href).then(() => {
@@ -453,7 +450,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                 setTimeout(() => setCopied(false), 2000);
                             });
                         }}
-                        className={`text-sm flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-colors ${
+                        className={`chart-copy-btn ${
                             copied
                                 ? 'bg-green-50 border-green-200 text-green-700'
                                 : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
@@ -479,7 +476,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 </div>
 
                 {/* Axis selectors */}
-                <div className="grid grid-cols-3 gap-4 mb-6">
+                <div className="axis-selectors">
                     <div>
                         <label className="block font-medium mb-2">X-Axis:</label>
                         <select
@@ -520,8 +517,8 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 </div>
 
                 {/* ── Line / points toggles ── */}
-                <div className="flex flex-wrap gap-4 mb-4">
-                    <label className="flex items-center gap-2 cursor-pointer select-none w-fit">
+                <div className="chart-toggles">
+                    <label className="toggle-label">
                         <input
                             type="checkbox"
                             checked={chartConfig.showLine ?? true}
@@ -534,7 +531,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                         />
                         <span className="text-sm font-medium">Connect points with lines</span>
                     </label>
-                    <label className="flex items-center gap-2 cursor-pointer select-none w-fit">
+                    <label className="toggle-label">
                         <input
                             type="checkbox"
                             checked={chartConfig.showPoints || false}
@@ -553,7 +550,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 <div>
                     <button
                         onClick={() => setRunsExpanded(prev => !prev)}
-                        className="flex items-center gap-2 w-full text-left font-medium hover:text-gray-600 transition-colors mb-1"
+                        className="run-selector-header"
                     >
                         <span
                             style={{ display: 'inline-block', transform: runsExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}
@@ -567,7 +564,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     {runsExpanded && (
                         <div className="mt-3">
                         {/* chartMode === 'charging' is guaranteed here — range mode returns early above */}
-                        <div className="space-y-4">
+                        <div className="runs-list">
                             {selectedVehicles.map(vehicle => {
                                 const isExpanded = expandedVehicles[vehicle.id];
                                 // Only show runs that have charging data in charging mode
@@ -581,7 +578,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                     const offset = getRaceOffset(run.id);
                                     const noTrim = offset !== null && offset === 0;
                                     return (
-                                        <span className="flex-1 flex items-center gap-2 flex-wrap">
+                                        <span className="run-label">
                                             <span>
                                                 {run.name}
                                                 {run.url && (
@@ -602,24 +599,24 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                                 )}
                                                 <span className="text-sm text-gray-500"> ({run.date})</span>
                                                 {run.isDefault && (
-                                                    <span className="ml-2 text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded"
+                                                    <span className="badge-default ml-2"
                                                         style={{ backgroundColor: 'var(--color-primary-light)', color: 'var(--color-primary-text)' }}>
                                                         Default
                                                     </span>
                                                 )}
                                             </span>
                                             {exclusionReason && (
-                                                <span className="text-xs bg-amber-50 text-amber-700 border border-amber-200 px-1.5 py-0.5 rounded-full" title={`Hidden in race mode: ${exclusionReason}`}>
+                                                <span className="badge-status bg-amber-50 text-amber-700 border-amber-200" title={`Hidden in race mode: ${exclusionReason}`}>
                                                     ⚠ {exclusionReason}
                                                 </span>
                                             )}
                                             {!exclusionReason && offset !== null && (
                                                 noTrim ? (
-                                                    <span className="text-xs bg-red-50 text-red-700 border border-red-200 px-1.5 py-0.5 rounded-full" title="Data starts at or above the threshold — no time was trimmed">
+                                                    <span className="badge-status bg-red-50 text-red-700 border-red-200" title="Data starts at or above the threshold — no time was trimmed">
                                                         no offset
                                                     </span>
                                                 ) : (
-                                                    <span className="text-xs bg-gray-100 text-gray-500 border border-gray-200 px-1.5 py-0.5 rounded-full" title={`${offset} min of pre-threshold data trimmed`}>
+                                                    <span className="badge-status bg-gray-100 text-gray-500 border-gray-200" title={`${offset} min of pre-threshold data trimmed`}>
                                                         −{offset} min offset
                                                     </span>
                                                 )
@@ -656,7 +653,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                 );
 
                                 return (
-                                    <div key={vehicle.id} className="border-l-4 pl-4" style={{ borderColor: 'var(--color-primary)' }}>
+                                    <div key={vehicle.id} className="vehicle-run-group" style={{ borderColor: 'var(--color-primary)' }}>
                                         <div className="flex items-center gap-2 mb-2">
                                             <h4 className="font-semibold text-gray-700">{vehicle.name}</h4>
                                             {hasInactiveRuns && (
@@ -669,7 +666,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                                 </button>
                                             )}
                                         </div>
-                                        <div className="space-y-2">
+                                        <div className="run-items">
                                             {/* Active runs — always shown */}
                                             {activeRuns.map(run => (
                                                 <label key={run.id} className="flex items-center gap-2">
@@ -724,7 +721,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 <div className="mt-3 flex items-center gap-3">
                     <button
                         onClick={handleExportImage}
-                        className={`text-sm flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-colors ${
+                        className={`chart-copy-btn ${
                             imageCopied
                                 ? 'bg-green-50 border-green-200 text-green-700'
                                 : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
@@ -769,9 +766,9 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
 
                 {/* ── Race mode panel — only visible when X = Time ── */}
                 {chartConfig.xAxis === 'time' && (
-                    <div className={`mt-4 p-3 rounded-lg border ${chartConfig.raceMode ? 'bg-indigo-50 border-indigo-200' : 'bg-gray-50 border-gray-200'}`}>
+                    <div className={`race-mode-panel ${chartConfig.raceMode ? 'bg-indigo-50 border-indigo-200' : 'bg-gray-50 border-gray-200'}`}>
                         <div className="flex flex-wrap items-center gap-3">
-                            <label className="flex items-center gap-2 cursor-pointer select-none">
+                            <label className="toggle-label">
                                 <input
                                     type="checkbox"
                                     checked={chartConfig.raceMode || false}

--- a/src/components/DeleteQueueBar.jsx
+++ b/src/components/DeleteQueueBar.jsx
@@ -24,14 +24,14 @@ export default function DeleteQueueBar({
     // ── Undo toast ────────────────────────────────────────────────────────────
     if (undoState) {
         return (
-            <div className="fixed bottom-0 left-0 right-0 z-50 bg-gray-800 text-white shadow-2xl overflow-hidden">
+            <div className="fixed-action-bar z-50 bg-gray-800 text-white overflow-hidden">
                 {/* Draining progress bar — CSS animation restarts on each new undoState */}
                 <div
                     key={undoState.startTime}
                     className="h-1 bg-blue-400"
                     style={{ animation: 'drain 5s linear forwards' }}
                 />
-                <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+                <div className="page-container py-3 flex items-center gap-4">
                     <span className="font-medium flex-1">
                         ✓ {plural(undoState.count)} deleted
                     </span>
@@ -49,8 +49,8 @@ export default function DeleteQueueBar({
     // ── Queue bar ─────────────────────────────────────────────────────────────
     if (pendingCount > 0) {
         return (
-            <div className="fixed bottom-0 left-0 right-0 z-50 bg-red-50 border-t-2 border-red-200 shadow-2xl">
-                <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+            <div className="fixed-action-bar z-50 bg-red-50 border-t-2 border-red-200">
+                <div className="page-container py-3 flex items-center gap-4">
                     <span className="text-red-700 font-medium flex-1">
                         🗑 {plural(pendingCount)} queued for deletion
                     </span>

--- a/src/components/ImportTableauModal.jsx
+++ b/src/components/ImportTableauModal.jsx
@@ -138,11 +138,11 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
     // ────────────────────────────────────────────────────────────────────────
 
     return (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-            <div className="bg-white rounded-xl shadow-2xl w-full max-w-5xl max-h-[90vh] flex flex-col">
+        <div className="modal-overlay p-4">
+            <div className="modal-panel rounded-xl shadow-2xl max-w-5xl max-h-[90vh] flex flex-col">
 
                 {/* Header */}
-                <div className="flex items-center justify-between px-6 py-4 border-b flex-shrink-0">
+                <div className="modal-header px-6 py-4 border-b flex-shrink-0">
                     <div>
                         <h2 className="text-xl font-bold">Import Tableau CSV</h2>
                         <p className="text-sm text-gray-500 mt-0.5">
@@ -156,7 +156,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                 </div>
 
                 {/* Body */}
-                <div className="overflow-y-auto flex-1 px-6 py-5">
+                <div className="modal-body">
 
                     {/* ── UPLOAD STEP ── */}
                     {step === 'upload' && (
@@ -245,10 +245,10 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                 return (
                                     <div
                                         key={raw}
-                                        className={`border rounded-lg overflow-hidden transition ${skipped ? 'opacity-50' : ''}`}
+                                        className={`import-vehicle-panel ${skipped ? 'opacity-50' : ''}`}
                                     >
                                         {/* Vehicle header */}
-                                        <div className="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b">
+                                        <div className="import-vehicle-header">
                                             <button
                                                 type="button"
                                                 onClick={() => toggleSkip(raw)}
@@ -288,7 +288,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                         {!skipped && (
                                             <div className="divide-y">
                                                 {vehicleSessions.map(({ idx, date, synthetic }) => (
-                                                    <div key={idx} className="px-4 py-2 flex items-center gap-2">
+                                                    <div key={idx} className="import-session-row">
                                                         <input
                                                             type="text"
                                                             value={sessionNames[idx] ?? ''}
@@ -380,7 +380,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                 </div>
 
                 {/* Footer */}
-                <div className="px-6 py-4 border-t flex-shrink-0 flex justify-end gap-2">
+                <div className="modal-footer">
                     {step === 'upload' && (
                         <button onClick={onClose} className="btn btn-secondary">Cancel</button>
                     )}

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -421,7 +421,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                 <div className="flex items-center justify-between mb-4">
                     <h3 className="text-lg font-bold">Chart Options — Range &amp; Efficiency</h3>
                     {/* Efficiency unit toggle — relevant for efficiency charts */}
-                    <div className="flex gap-1 p-1 bg-gray-100 rounded-lg">
+                    <div className="efficiency-unit-toggle">
                         {[{ key: 'mi_kwh', label: 'mi/kWh' }, { key: 'wh_mi', label: 'Wh/mi' }].map(({ key, label }) => (
                             <button
                                 key={key}
@@ -436,7 +436,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                 </div>
 
                 {/* Chart type buttons */}
-                <div className="flex flex-wrap gap-2 mb-4">
+                <div className="chart-type-buttons mb-4">
                     {CHART_TYPES.map(t => (
                         <button
                             key={t.key}
@@ -457,7 +457,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                 {/* Show points toggle — only relevant for line charts */}
                 {CHART_TYPES.find(t => t.key === chartType)?.kind === 'line' && (
                     <div className="mb-6">
-                        <label className="flex items-center gap-2 cursor-pointer select-none w-fit">
+                        <label className="toggle-label">
                             <input
                                 type="checkbox"
                                 checked={showPoints}
@@ -473,7 +473,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                 <div>
                     <button
                         onClick={() => setRunsExpanded(prev => !prev)}
-                        className="flex items-center gap-2 w-full text-left font-medium hover:text-gray-600 transition-colors mb-1"
+                        className="run-selector-header"
                     >
                         <span style={{ display: 'inline-block', transform: runsExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
                         Select Runs to Display
@@ -490,7 +490,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                     <p className="text-xs mt-1">Add records using the Test Runs tab with "Range Test" type.</p>
                                 </div>
                             ) : (
-                                <div className="space-y-4">
+                                <div className="runs-list">
                                     {selectedVehicles.map(vehicle => {
                                         const rangeRuns    = (vehicle.runs || []).filter(r => r.has_range);
                                         const activeRuns   = rangeRuns.filter(r =>  selectedRuns.some(id => String(id) === String(r.id)));
@@ -578,7 +578,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                         };
 
                                         return (
-                                            <div key={vehicle.id} className="border-l-4 pl-4" style={{ borderColor: 'var(--color-primary)' }}>
+                                            <div key={vehicle.id} className="vehicle-run-group" style={{ borderColor: 'var(--color-primary)' }}>
                                                 <div className="flex items-center gap-2 mb-2">
                                                     <h4 className="font-semibold text-gray-700">{vehicle.name}</h4>
                                                     {inactiveRuns.length > 0 && (
@@ -594,7 +594,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                                 {rangeRuns.length === 0 ? (
                                                     <p className="text-sm text-gray-400 italic">No range test records</p>
                                                 ) : (
-                                                    <div className="space-y-2">
+                                                    <div className="run-items">
                                                         {activeRuns.map(run => <RunRow key={run.id} run={run} dimmed={false} />)}
                                                         {isVehicleExpanded && inactiveRuns.map(run => <RunRow key={run.id} run={run} dimmed={true} />)}
                                                         {activeRuns.length === 0 && !isVehicleExpanded && (
@@ -641,7 +641,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                     <button
                         onClick={handleCopyImage}
                         disabled={plottableRuns.length === 0}
-                        className={`text-sm flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                        className={`chart-copy-btn disabled:opacity-40 disabled:cursor-not-allowed ${
                             copied
                                 ? 'bg-green-50 border-green-200 text-green-700'
                                 : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -535,9 +535,9 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
 
     return (
         <div className={barVisible ? 'pb-20' : ''}>
-            <div className="flex justify-between items-center mb-6">
+            <div className="runs-view-header">
                 <div>
-                    <h2 className="text-2xl font-bold">{vehicle.name} - Test Runs</h2>
+                    <h2 className="page-title">{vehicle.name} - Test Runs</h2>
                     <p className="text-gray-600">Manage charging test data for this vehicle</p>
                 </div>
                 <div className="flex gap-2">
@@ -573,7 +573,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                 <div className="card mb-6">
                     {/* ── Merge-mode banner ── */}
                     {uploadMode === 'merge' && mergeTargetRun && (
-                        <div className="mb-4 px-4 py-3 bg-blue-50 border border-blue-200 rounded-lg flex items-center justify-between">
+                        <div className="merge-target-banner">
                             <div>
                                 <span className="text-sm font-semibold text-blue-800">Adding data to: </span>
                                 <span className="text-sm text-blue-700">{mergeTargetRun.name}</span>
@@ -586,7 +586,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
 
                     {uploadStep === 'file' && (
                         <div>
-                            <h3 className="text-lg font-bold mb-4">
+                            <h3 className="section-title mb-4">
                                 {uploadMode === 'merge' ? 'Upload Additional Data' : 'Add new record'}
                             </h3>
                             <div className="space-y-4">
@@ -596,7 +596,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                         {/* Data-type flags — multi-select, at least one must remain active */}
                                         <div>
                                             <p className="text-xs text-gray-500 mb-1">Data types (select all that apply)</p>
-                                            <div className="flex gap-2 flex-wrap">
+                                            <div className="data-type-flags">
                                                 {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                     const active = runMetadata.dataFlags.includes(key);
                                                     return (
@@ -624,31 +624,31 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                             placeholder="Name (e.g., Highway Test - Winter 2024)"
                                             value={runMetadata.name}
                                             onChange={(e) => setRunMetadata({...runMetadata, name: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                             required
                                         />
                                         <input
                                             type="date"
                                             value={runMetadata.date}
                                             onChange={(e) => setRunMetadata({...runMetadata, date: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
                                         <input
                                             placeholder="Software Version (e.g., 2024.1.5)"
                                             value={runMetadata.softwareVersion}
                                             onChange={(e) => setRunMetadata({...runMetadata, softwareVersion: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
                                         <input
                                             placeholder="Notes (e.g., 20°F, highway speeds)"
                                             value={runMetadata.conditions}
                                             onChange={(e) => setRunMetadata({...runMetadata, conditions: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
 
                                         {/* Charging energy field (create mode) */}
                                         {runMetadata.dataFlags.includes('charging') && (
-                                            <div className="border rounded-lg p-3 bg-gray-50">
+                                            <div className="data-subpanel p-3">
                                                 <p className="text-sm font-semibold text-gray-700 mb-2">Charging Energy <span className="font-normal text-gray-400">(optional)</span></p>
                                                 <input
                                                     type="number"
@@ -656,7 +656,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                     title="Energy measured at charger or vehicle — energy in"
                                                     value={runMetadata.energyKwh}
                                                     onChange={(e) => setRunMetadata({...runMetadata, energyKwh: e.target.value})}
-                                                    className="border p-2 rounded w-full"
+                                                    className="form-input w-full"
                                                 />
                                                 <p className="text-xs text-gray-400 mt-1">
                                                     Energy measured at charger or vehicle — <em>energy in</em>
@@ -666,28 +666,28 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                     placeholder="Charging source URL (optional)"
                                                     value={runMetadata.chargingUrl}
                                                     onChange={(e) => setRunMetadata({...runMetadata, chargingUrl: e.target.value})}
-                                                    className="border p-2 rounded w-full mt-2"
+                                                    className="form-input w-full mt-2"
                                                 />
                                             </div>
                                         )}
 
                                         {/* Range test fields */}
                                         {runMetadata.dataFlags.includes('range') && (
-                                            <div className="border rounded-lg p-4 space-y-3 bg-gray-50">
+                                            <div className="data-subpanel p-4 space-y-3">
                                                 <p className="text-sm font-semibold text-gray-700">Range Test Details</p>
-                                                <div className="grid grid-cols-2 gap-3">
+                                                <div className="form-grid gap-3">
                                                     <input
                                                         placeholder="Source (e.g., Out of Spec)"
                                                         value={runMetadata.source}
                                                         onChange={(e) => setRunMetadata({...runMetadata, source: e.target.value})}
-                                                        className="border p-2 rounded col-span-2"
+                                                        className="form-input col-span-2"
                                                     />
                                                     <input
                                                         type="number"
                                                         placeholder="Start SoC (%)"
                                                         value={runMetadata.startSoc}
                                                         onChange={(e) => setRunMetadata({...runMetadata, startSoc: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                         min="0" max="100"
                                                     />
                                                     <input
@@ -695,7 +695,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                         placeholder="End SoC (%)"
                                                         value={runMetadata.endSoc}
                                                         onChange={(e) => setRunMetadata({...runMetadata, endSoc: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                         min="0" max="100"
                                                     />
                                                     <input
@@ -703,14 +703,14 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                         placeholder="Speed (mph)"
                                                         value={runMetadata.speedMph}
                                                         onChange={(e) => setRunMetadata({...runMetadata, speedMph: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                     />
                                                     <input
                                                         type="number"
                                                         placeholder="Distance (miles)"
                                                         value={runMetadata.distanceMiles}
                                                         onChange={(e) => setRunMetadata({...runMetadata, distanceMiles: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                     />
                                                     <input
                                                         type="number"
@@ -718,28 +718,28 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                         title="Energy consumed on the drive — energy out"
                                                         value={runMetadata.energyKwh}
                                                         onChange={(e) => setRunMetadata({...runMetadata, energyKwh: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                     />
                                                     <input
                                                         type="number"
                                                         placeholder="Ambient temp (°F)"
                                                         value={runMetadata.temperatureF}
                                                         onChange={(e) => setRunMetadata({...runMetadata, temperatureF: e.target.value})}
-                                                        className="border p-2 rounded"
+                                                        className="form-input"
                                                     />
                                                     <input
                                                         type="number"
                                                         placeholder="Elevation gain (ft)"
                                                         value={runMetadata.elevationGainFt}
                                                         onChange={(e) => setRunMetadata({...runMetadata, elevationGainFt: e.target.value})}
-                                                        className="border p-2 rounded col-span-2"
+                                                        className="form-input col-span-2"
                                                     />
                                                     <input
                                                         type="url"
                                                         placeholder="Source URL"
                                                         value={runMetadata.url}
                                                         onChange={(e) => setRunMetadata({...runMetadata, url: e.target.value})}
-                                                        className="border p-2 rounded col-span-2"
+                                                        className="form-input col-span-2"
                                                     />
                                                 </div>
                                             </div>
@@ -762,7 +762,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                         />
                                         CSV has no header row (use column numbers)
                                     </label>
-                                    <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
+                                    <div className="csv-drop-zone">
                                         <label className="cursor-pointer">
                                             <span className="text-blue-600 font-medium">Click to upload CSV file</span>
                                             <span className="block text-xs text-gray-400 mt-1">Optional — attach data points to this record</span>
@@ -781,12 +781,12 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                             placeholder={"soc,chargeRate,time\n50,100,0\n80,75,15\n…"}
                                             value={csvText}
                                             onChange={e => handleCsvTextPaste(e.target.value)}
-                                            className="border p-2 rounded w-full text-xs font-mono resize-y"
+                                            className="form-input w-full text-xs font-mono resize-y"
                                         />
                                     </div>
                                 </div>
                                 {uploadMode === 'create' && (
-                                    <div className="flex gap-2">
+                                    <div className="form-actions">
                                         <button
                                             onClick={handleSaveRecord}
                                             disabled={!runMetadata.name}
@@ -805,7 +805,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
 
                     {uploadStep === 'mapping' && (
                         <div>
-                            <h3 className="text-lg font-bold mb-4">Map CSV Fields</h3>
+                            <h3 className="section-title mb-4">Map CSV Fields</h3>
                             <p className="text-gray-600 mb-4">Match your CSV columns to standard fields. We've auto-detected some for you.</p>
 
                             {/* In create mode, allow editing metadata here too */}
@@ -817,26 +817,26 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                             placeholder="Name (e.g., Highway Test - Winter 2024)"
                                             value={runMetadata.name}
                                             onChange={(e) => setRunMetadata({...runMetadata, name: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                             required
                                         />
                                         <input
                                             type="date"
                                             value={runMetadata.date}
                                             onChange={(e) => setRunMetadata({...runMetadata, date: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
                                         <input
                                             placeholder="Software Version (e.g., 2024.1.5)"
                                             value={runMetadata.softwareVersion}
                                             onChange={(e) => setRunMetadata({...runMetadata, softwareVersion: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
                                         <input
                                             placeholder="Notes (e.g., 20°F, highway speeds)"
                                             value={runMetadata.conditions}
                                             onChange={(e) => setRunMetadata({...runMetadata, conditions: e.target.value})}
-                                            className="border p-2 rounded w-full"
+                                            className="form-input w-full"
                                         />
                                     </div>
                                 </div>
@@ -845,12 +845,12 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                             <h4 className="font-semibold mb-3">Field Mapping</h4>
                             <div className="space-y-3">
                                 {['soc', 'chargeRate', 'time', 'range', 'temperature', 'frame'].map(field => (
-                                    <div key={field} className="flex items-center gap-4">
+                                    <div key={field} className="field-mapping-row">
                                         <label className="w-40 font-medium capitalize">{field.replace(/([A-Z])/g, ' $1')}:</label>
                                         <select
                                             value={fieldMapping[field] || ''}
                                             onChange={(e) => setFieldMapping({...fieldMapping, [field]: e.target.value})}
-                                            className="border p-2 rounded flex-1"
+                                            className="form-input flex-1"
                                         >
                                             <option value="">-- Not mapped --</option>
                                             {availableFields.map((f, i) => (
@@ -868,7 +868,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                 <div className="mt-5 space-y-3">
                                     {/* Option 1: EPA rated range */}
                                     {offerRangeEstimate && (
-                                        <div className={`p-4 rounded-lg border flex items-start justify-between gap-4 ${estimations.range === 'epa' ? 'bg-green-50 border-green-200' : 'bg-blue-50 border-blue-200'}`}>
+                                        <div className={`estimation-panel ${estimations.range === 'epa' ? 'bg-green-50 border-green-200' : 'bg-blue-50 border-blue-200'}`}>
                                             <div>
                                                 <p className={`text-sm font-semibold ${estimations.range === 'epa' ? 'text-green-800' : 'text-blue-800'}`}>
                                                     {estimations.range === 'epa' ? '✓ Range will be estimated (EPA)' : 'ℹ No Range column mapped'}
@@ -894,7 +894,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
 
                                     {/* Option 2: Measured range from test data */}
                                     {offerRangeEstimateTest && (
-                                        <div className={`p-4 rounded-lg border flex items-start justify-between gap-4 ${estimations.range === 'measured' ? 'bg-green-50 border-green-200' : 'bg-amber-50 border-amber-200'}`}>
+                                        <div className={`estimation-panel ${estimations.range === 'measured' ? 'bg-green-50 border-green-200' : 'bg-amber-50 border-amber-200'}`}>
                                             <div className="flex-1 min-w-0">
                                                 <p className={`text-sm font-semibold ${estimations.range === 'measured' ? 'text-green-800' : 'text-amber-800'}`}>
                                                     {estimations.range === 'measured' ? '✓ Range will be estimated (test data)' : '📏 Estimate from measured range test'}
@@ -935,7 +935,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
 
                             {/* Join key selector — merge mode only */}
                             {uploadMode === 'merge' && (
-                                <div className={`mt-5 p-4 rounded-lg border ${missingJoinKey ? 'bg-red-50 border-red-200' : showJoinSelector ? 'bg-yellow-50 border-yellow-200' : 'bg-green-50 border-green-200'}`}>
+                                <div className={`join-key-panel ${missingJoinKey ? 'bg-red-50 border-red-200' : showJoinSelector ? 'bg-yellow-50 border-yellow-200' : 'bg-green-50 border-green-200'}`}>
                                     {missingJoinKey ? (
                                         <p className="text-sm font-semibold text-red-700">
                                             ⚠ Map at least one of <strong>SoC</strong> or <strong>Time</strong> — it's needed to link incoming rows to existing ones.
@@ -966,7 +966,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                 </div>
                             )}
 
-                            <div className="mt-6 flex gap-2">
+                            <div className="form-actions mt-6">
                                 <button
                                     onClick={() => setUploadStep('file')}
                                     className="btn btn-secondary"
@@ -1005,12 +1005,12 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                     >
                         {editingRunId === run.id ? (
                             <div>
-                                <h3 className="text-lg font-bold mb-4">Edit Record</h3>
+                                <h3 className="section-title mb-4">Edit Record</h3>
                                 <div className="space-y-3">
                                     {/* Data-type flags — multi-select, at least one must remain active */}
                                     <div>
                                         <p className="text-xs text-gray-500 mb-1">Data types (select all that apply)</p>
-                                        <div className="flex gap-2 flex-wrap">
+                                        <div className="data-type-flags">
                                             {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                 const active = (editFormData.dataFlags || ['charging']).includes(key);
                                                 return (
@@ -1037,36 +1037,36 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                         placeholder="Name"
                                         value={editFormData.name}
                                         onChange={(e) => setEditFormData({...editFormData, name: e.target.value})}
-                                        className="border p-2 rounded w-full"
+                                        className="form-input w-full"
                                     />
                                     <input
                                         type="date"
                                         value={editFormData.date}
                                         onChange={(e) => setEditFormData({...editFormData, date: e.target.value})}
-                                        className="border p-2 rounded w-full"
+                                        className="form-input w-full"
                                     />
                                     <input
                                         placeholder="Software Version"
                                         value={editFormData.softwareVersion}
                                         onChange={(e) => setEditFormData({...editFormData, softwareVersion: e.target.value})}
-                                        className="border p-2 rounded w-full"
+                                        className="form-input w-full"
                                     />
                                     <input
                                         placeholder="Notes"
                                         value={editFormData.conditions}
                                         onChange={(e) => setEditFormData({...editFormData, conditions: e.target.value})}
-                                        className="border p-2 rounded w-full"
+                                        className="form-input w-full"
                                     />
                                     {/* Charging energy field — shows energy_kwh for charging runs */}
                                     {(editFormData.dataFlags || ['charging']).includes('charging') && (
-                                        <div className="border rounded-lg p-3 bg-gray-50">
+                                        <div className="data-subpanel p-3">
                                             <p className="text-sm font-semibold text-gray-700 mb-2">Charging Energy</p>
                                             <input
                                                 type="number"
                                                 placeholder="Energy added (kWh)"
                                                 value={editFormData.energyKwh}
                                                 onChange={(e) => setEditFormData({...editFormData, energyKwh: e.target.value})}
-                                                className="border p-2 rounded w-full"
+                                                className="form-input w-full"
                                             />
                                             <p className="text-xs text-gray-400 mt-1">
                                                 Energy measured at charger or vehicle — <em>energy in</em> (not equal to energy used driving due to charging losses)
@@ -1076,28 +1076,28 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                 placeholder="Charging source URL (optional)"
                                                 value={editFormData.chargingUrl ?? ''}
                                                 onChange={(e) => setEditFormData({...editFormData, chargingUrl: e.target.value})}
-                                                className="border p-2 rounded w-full mt-2"
+                                                className="form-input w-full mt-2"
                                             />
                                         </div>
                                     )}
 
                                     {/* Range test fields */}
                                     {(editFormData.dataFlags || ['charging']).includes('range') && (
-                                        <div className="border rounded-lg p-4 space-y-3 bg-gray-50">
+                                        <div className="data-subpanel p-4 space-y-3">
                                             <p className="text-sm font-semibold text-gray-700">Range Test Details</p>
-                                            <div className="grid grid-cols-2 gap-3">
+                                            <div className="form-grid gap-3">
                                                 <input
                                                     placeholder="Source (e.g., Out of Spec)"
                                                     value={editFormData.source}
                                                     onChange={(e) => setEditFormData({...editFormData, source: e.target.value})}
-                                                    className="border p-2 rounded col-span-2"
+                                                    className="form-input col-span-2"
                                                 />
                                                 <input
                                                     type="number"
                                                     placeholder="Start SoC (%)"
                                                     value={editFormData.startSoc}
                                                     onChange={(e) => setEditFormData({...editFormData, startSoc: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                     min="0" max="100"
                                                 />
                                                 <input
@@ -1105,7 +1105,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                     placeholder="End SoC (%)"
                                                     value={editFormData.endSoc}
                                                     onChange={(e) => setEditFormData({...editFormData, endSoc: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                     min="0" max="100"
                                                 />
                                                 <input
@@ -1113,14 +1113,14 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                     placeholder="Speed (mph)"
                                                     value={editFormData.speedMph}
                                                     onChange={(e) => setEditFormData({...editFormData, speedMph: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                 />
                                                 <input
                                                     type="number"
                                                     placeholder="Distance (miles)"
                                                     value={editFormData.distanceMiles}
                                                     onChange={(e) => setEditFormData({...editFormData, distanceMiles: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                 />
                                                 <input
                                                     type="number"
@@ -1128,34 +1128,34 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                                     title="Energy consumed on the drive — energy out"
                                                     value={editFormData.energyKwh}
                                                     onChange={(e) => setEditFormData({...editFormData, energyKwh: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                 />
                                                 <input
                                                     type="number"
                                                     placeholder="Ambient temp (°F)"
                                                     value={editFormData.temperatureF}
                                                     onChange={(e) => setEditFormData({...editFormData, temperatureF: e.target.value})}
-                                                    className="border p-2 rounded"
+                                                    className="form-input"
                                                 />
                                                 <input
                                                     type="number"
                                                     placeholder="Elevation gain (ft)"
                                                     value={editFormData.elevationGainFt}
                                                     onChange={(e) => setEditFormData({...editFormData, elevationGainFt: e.target.value})}
-                                                    className="border p-2 rounded col-span-2"
+                                                    className="form-input col-span-2"
                                                 />
                                                 <input
                                                     type="url"
                                                     placeholder="Source URL"
                                                     value={editFormData.url}
                                                     onChange={(e) => setEditFormData({...editFormData, url: e.target.value})}
-                                                    className="border p-2 rounded col-span-2"
+                                                    className="form-input col-span-2"
                                                 />
                                             </div>
                                         </div>
                                     )}
                                 </div>
-                                <div className="flex gap-2 mt-4">
+                                <div className="form-actions mt-4">
                                     <button
                                         onClick={() => handleSaveEdit(run.id)}
                                         disabled={savingData}
@@ -1350,10 +1350,10 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                 </div>
                             </div>
                         ) : (
-                            <div className="flex justify-between items-start">
+                            <div className="run-card-header">
                                 <div className="flex-1">
                                     <div className="flex items-center gap-2 flex-wrap">
-                                        <h3 className="text-lg font-bold">
+                                        <h3 className="section-title">
                                             {run.name}
                                             {run.url && (
                                                 <a href={run.url} target="_blank" rel="noopener noreferrer"
@@ -1389,13 +1389,13 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                             </span>
                                         )}
                                     </div>
-                                    <div className="text-sm text-gray-600 mt-2 space-y-1">
+                                    <div className="run-meta">
                                         <p>Date: {run.date}</p>
                                         {(run.softwareVersion || run.software_version) && <p>Software: {run.softwareVersion || run.software_version}</p>}
                                         {run.conditions && <p>Notes: {run.conditions}</p>}
                                         {/* Range data section — shown whenever the run has range data */}
                                         {inferRunFlags(run).includes('range') && (
-                                            <div className="flex flex-wrap gap-1.5 mt-1">
+                                            <div className="run-stat-badges">
                                                 {run.source && <span className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded">{run.source}</span>}
                                                 {run.speed_mph != null && <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">{run.speed_mph} mph</span>}
                                                 {run.distance_miles != null && <span className="text-xs bg-green-50 text-green-700 px-2 py-0.5 rounded border border-green-200">{run.distance_miles} mi</span>}
@@ -1419,7 +1419,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                         )}
                                         {/* Charging data section — shown whenever the run has time-series data */}
                                         {inferRunFlags(run).includes('charging') && (
-                                            <div className="flex flex-wrap gap-1.5 mt-1 items-center">
+                                            <div className="run-stat-badges items-center">
                                                 <span className="text-sm">Data Points: {run.dataPointCount ?? run.data?.length ?? 0}</span>
                                                 {/* energy_kwh for charging = energy in (measured at charger/vehicle) */}
                                                 {run.energy_kwh != null && !inferRunFlags(run).includes('range') && (
@@ -1483,7 +1483,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                             </div>
                                         );
                                     })()}
-                                    <div className="flex items-center gap-2 mt-3">
+                                    <div className="inline-row mt-3">
                                         <span className="text-sm text-gray-600">Plot Color:</span>
                                         <input
                                             type="color"
@@ -1513,7 +1513,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
                                         />
                                     </div>
                                 </div>
-                                <div className="flex gap-2 flex-wrap justify-end">
+                                <div className="run-actions">
                                     {!run.isDefault && (
                                         <button
                                             onClick={() => onSetDefaultRun(run.id)}
@@ -1569,7 +1569,7 @@ export default function RunsView({ vehicle, isOwner, onAddRun, onUpdateRun, onSe
             </div>
 
             {vehicle.runs?.length === 0 && !showUpload && (
-                <div className="text-center py-12 text-gray-500">
+                <div className="empty-state">
                     <p className="text-lg">No test runs yet. Add a record to get started!</p>
                 </div>
             )}

--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -5,13 +5,13 @@ export default function SpecsView({ vehicles, selectedVehicleIds }) {
 
     return (
         <div>
-            <h2 className="text-2xl font-bold mb-6">
+            <h2 className="page-title mb-6">
                 Vehicle Specifications Comparison
                 {selectedVehicleIds.length > 0 && ` (${selectedVehicleIds.length} Selected)`}
             </h2>
 
             {displayVehicles.length === 0 ? (
-                <div className="text-center py-12 text-gray-500">
+                <div className="empty-state">
                     <p className="text-lg">
                         {vehicles.length === 0
                             ? 'No vehicles to compare. Add vehicles first!'
@@ -19,7 +19,7 @@ export default function SpecsView({ vehicles, selectedVehicleIds }) {
                     </p>
                 </div>
             ) : (
-                <div className="bg-white rounded-lg shadow overflow-x-auto" style={{backgroundColor: 'var(--color-card)'}}>
+                <div className="specs-table-container">
                     <table className="w-full">
                         <thead className="bg-gray-50">
                             <tr>
@@ -31,32 +31,32 @@ export default function SpecsView({ vehicles, selectedVehicleIds }) {
                         </thead>
                         <tbody className="divide-y">
                             <tr>
-                                <td className="px-6 py-4 font-medium">Make</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.make || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">Make</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.make || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">Model</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.model || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">Model</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.model || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">Year</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.year || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">Year</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.year || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">Battery (kWh)</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.battery || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">Battery (kWh)</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.battery || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">EPA Range (mi)</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.range || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">EPA Range (mi)</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.range || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">Peak Power (kW)</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.power || '-'}</td>)}
+                                <td className="specs-table-cell font-medium">Peak Power (kW)</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.power || '-'}</td>)}
                             </tr>
                             <tr>
-                                <td className="px-6 py-4 font-medium">Test Runs</td>
-                                {displayVehicles.map(v => <td key={v.id} className="px-6 py-4">{v.runs?.length || 0}</td>)}
+                                <td className="specs-table-cell font-medium">Test Runs</td>
+                                {displayVehicles.map(v => <td key={v.id} className="specs-table-cell">{v.runs?.length || 0}</td>)}
                             </tr>
                         </tbody>
                     </table>

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -35,26 +35,26 @@ function EditForm({
 }) {
     return (
         <form onSubmit={onSubmit} className="card">
-            <h3 className="text-lg font-bold mb-4">{editingId ? 'Edit Vehicle' : 'Add New Vehicle'}</h3>
-            <div className="grid grid-cols-2 gap-4">
+            <h3 className="section-title mb-4">{editingId ? 'Edit Vehicle' : 'Add New Vehicle'}</h3>
+            <div className="form-grid gap-4">
                 <input
                     placeholder="Display Name (e.g., Model 3 LR 2024)"
                     value={formData.name}
                     onChange={(e) => onFormChange({ ...formData, name: e.target.value })}
-                    className="border p-2 rounded col-span-2"
+                    className="form-input col-span-2"
                     required
                 />
-                <input placeholder="Make"           value={formData.make}    onChange={(e) => onFormChange({ ...formData, make: e.target.value })}    className="border p-2 rounded" />
-                <input placeholder="Model"          value={formData.model}   onChange={(e) => onFormChange({ ...formData, model: e.target.value })}   className="border p-2 rounded" />
-                <input placeholder="Year"           value={formData.year}    onChange={(e) => onFormChange({ ...formData, year: e.target.value })}    className="border p-2 rounded" />
-                <input placeholder="Battery (kWh)"  value={formData.battery} onChange={(e) => onFormChange({ ...formData, battery: e.target.value })} className="border p-2 rounded" />
-                <input placeholder="EPA Range (mi)" value={formData.range}   onChange={(e) => onFormChange({ ...formData, range: e.target.value })}   className="border p-2 rounded" />
-                <input placeholder="Peak Power (kW)" value={formData.power}  onChange={(e) => onFormChange({ ...formData, power: e.target.value })}   className="border p-2 rounded" />
+                <input placeholder="Make"           value={formData.make}    onChange={(e) => onFormChange({ ...formData, make: e.target.value })}    className="form-input" />
+                <input placeholder="Model"          value={formData.model}   onChange={(e) => onFormChange({ ...formData, model: e.target.value })}   className="form-input" />
+                <input placeholder="Year"           value={formData.year}    onChange={(e) => onFormChange({ ...formData, year: e.target.value })}    className="form-input" />
+                <input placeholder="Battery (kWh)"  value={formData.battery} onChange={(e) => onFormChange({ ...formData, battery: e.target.value })} className="form-input" />
+                <input placeholder="EPA Range (mi)" value={formData.range}   onChange={(e) => onFormChange({ ...formData, range: e.target.value })}   className="form-input" />
+                <input placeholder="Peak Power (kW)" value={formData.power}  onChange={(e) => onFormChange({ ...formData, power: e.target.value })}   className="form-input" />
             </div>
 
             {/* Tags — edit mode only */}
             {editingId && (
-                <div className="mt-5 border-t pt-4">
+                <div className="form-section mt-5">
                     <label className="block font-medium mb-2">Tags</label>
                     {formTags.length > 0 && (
                         <div className="flex flex-wrap gap-2 mb-3">
@@ -85,7 +85,7 @@ function EditForm({
                                     if (tag) onAddTag(tag);
                                     e.target.value = '';
                                 }}
-                                className="border p-2 rounded text-sm w-full"
+                                className="form-input w-full text-sm"
                                 defaultValue=""
                             >
                                 <option value="" disabled>Add existing tag…</option>
@@ -102,7 +102,7 @@ function EditForm({
                             value={newTagName}
                             onChange={(e) => onNewTagNameChange(e.target.value)}
                             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onCreateTag(); } }}
-                            className="border p-2 rounded text-sm flex-1"
+                            className="form-input text-sm flex-1"
                         />
                         <button type="button" onClick={onCreateTag} className="btn btn-primary text-sm">
                             Create tag
@@ -113,7 +113,7 @@ function EditForm({
 
             {/* Image upload — edit mode only */}
             {editingId && (
-                <div className="mt-4 border-t pt-4">
+                <div className="form-section mt-4">
                     <label className="block font-medium mb-2">Card Background Image</label>
                     {editingVehicle?.image_url && (
                         <img
@@ -122,7 +122,7 @@ function EditForm({
                             className="h-24 w-full object-cover rounded mb-2 border"
                         />
                     )}
-                    <label className="flex items-center gap-2 cursor-pointer">
+                    <label className="image-upload-label">
                         <span className="btn btn-primary text-sm">
                             {imageUploading ? 'Uploading…' : editingVehicle?.image_url ? 'Replace image' : 'Upload image'}
                         </span>
@@ -138,7 +138,7 @@ function EditForm({
             )}
 
             {/* Footer: Cancel left, Save right, both text-sm to match image button */}
-            <div className="mt-4 flex gap-2 justify-end">
+            <div className="form-actions mt-4">
                 <button type="button" onClick={onCancel} className="btn btn-secondary text-sm">
                     Cancel
                 </button>
@@ -391,7 +391,7 @@ export default function VehiclesView({
     const TagPills = ({ vehicle }) => {
         if (!vehicle.tags?.length) return null;
         return (
-            <div className="flex flex-wrap gap-1">
+            <div className="vehicle-tags">
                 {vehicle.tags.map(tag => (
                     <span
                         key={tag.id}
@@ -499,9 +499,9 @@ export default function VehiclesView({
             {/* Header */}
             <div className="flex justify-between items-center mb-4">
                 <h2 className="text-2xl font-bold">Vehicles</h2>
-                <div className="flex items-center gap-2">
+                <div className="inline-row">
                     {/* View mode toggle */}
-                    <div className="flex border rounded-lg overflow-hidden text-gray-500">
+                    <div className="view-toggle">
                         <button
                             onClick={() => setViewMode('card')}
                             title="Card view"
@@ -527,18 +527,18 @@ export default function VehiclesView({
             </div>
 
             {/* Sort + search bar */}
-            <div className="flex gap-3 items-center mb-3">
+            <div className="vehicle-filter-bar">
                 <input
                     type="text"
                     placeholder="Search by name, make, model, year…"
                     value={textFilter}
                     onChange={e => setTextFilter(e.target.value)}
-                    className="border p-2 rounded text-sm flex-1"
+                    className="form-input text-sm flex-1"
                 />
                 <select
                     value={sortBy}
                     onChange={e => setSortBy(e.target.value)}
-                    className="border p-2 rounded text-sm"
+                    className="form-input text-sm"
                 >
                     <option value="default">Default Order</option>
                     <option value="date_newest">Date Added (Newest)</option>
@@ -567,7 +567,7 @@ export default function VehiclesView({
 
             {/* Tag filter bar */}
             {tags.length > 0 && (
-                <div className="flex flex-wrap gap-2 items-center mb-6">
+                <div className="tag-filter-bar">
                     <span className="text-sm font-medium text-gray-500">Filter:</span>
                     {tags.map(tag => (
                         <button
@@ -603,7 +603,7 @@ export default function VehiclesView({
 
             {/* ── CARD VIEW ── */}
             {viewMode === 'card' && (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                <div className="vehicle-grid">
                     {pagedVehicles.map(vehicle => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
                         const isPending  = pendingDeletes.has(vehicle.id);
@@ -647,10 +647,10 @@ export default function VehiclesView({
 
                                         {/* Reorder controls — shown in edit order mode */}
                                         {showReorderButtons && (
-                                            <div className="flex items-center gap-0.5 mb-2 flex-wrap" onClick={e => e.stopPropagation()}>
-                                                <button title="Top" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, 0); }} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500">⇈</button>
-                                                <button title="-10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos - 10); }} disabled={globalPos < 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▲▲</button>
-                                                <button title="Up" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'up'); }} disabled={globalPos === 0} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▲</button>
+                                            <div className="reorder-controls mb-2 flex-wrap" onClick={e => e.stopPropagation()}>
+                                                <button title="Top" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, 0); }} className="reorder-btn">⇈</button>
+                                                <button title="-10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos - 10); }} disabled={globalPos < 1} className="reorder-btn disabled:opacity-30">▲▲</button>
+                                                <button title="Up" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'up'); }} disabled={globalPos === 0} className="reorder-btn disabled:opacity-30">▲</button>
                                                 <input
                                                     type="number" min={1} max={totalCount}
                                                     defaultValue={globalPos + 1}
@@ -660,9 +660,9 @@ export default function VehiclesView({
                                                     onBlur={e => { const v = parseInt(e.target.value); if (!isNaN(v) && v !== globalPos + 1) handleMoveVehicleToIndex(vehicle.id, v - 1); }}
                                                     className="w-10 h-6 text-center text-xs border rounded bg-white [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                                                 />
-                                                <button title="Down" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'down'); }} disabled={globalPos === totalCount - 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▼</button>
-                                                <button title="+10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos + 10); }} disabled={globalPos >= totalCount - 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▼▼</button>
-                                                <button title="Bottom" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, totalCount - 1); }} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500">⇊</button>
+                                                <button title="Down" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'down'); }} disabled={globalPos === totalCount - 1} className="reorder-btn disabled:opacity-30">▼</button>
+                                                <button title="+10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos + 10); }} disabled={globalPos >= totalCount - 1} className="reorder-btn disabled:opacity-30">▼▼</button>
+                                                <button title="Bottom" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, totalCount - 1); }} className="reorder-btn">⇊</button>
                                             </div>
                                         )}
 
@@ -707,7 +707,7 @@ export default function VehiclesView({
 
             {/* ── LIST VIEW ── */}
             {viewMode === 'list' && (
-                <div className="flex flex-col gap-2">
+                <div className="vehicle-list">
                     {pagedVehicles.map(vehicle => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
                         const isPending  = pendingDeletes.has(vehicle.id);
@@ -735,10 +735,10 @@ export default function VehiclesView({
 
                                     {/* Reorder controls — owner only, default sort, no filters */}
                                     {showReorderButtons && (
-                                        <div className="flex items-center gap-0.5 flex-shrink-0" onClick={e => e.stopPropagation()}>
-                                            <button title="Top" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, 0); }} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500">⇈</button>
-                                            <button title="-10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos - 10); }} disabled={globalPos < 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▲▲</button>
-                                            <button title="Up" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'up'); }} disabled={globalPos === 0} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▲</button>
+                                        <div className="reorder-controls flex-shrink-0" onClick={e => e.stopPropagation()}>
+                                            <button title="Top" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, 0); }} className="reorder-btn">⇈</button>
+                                            <button title="-10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos - 10); }} disabled={globalPos < 1} className="reorder-btn disabled:opacity-30">▲▲</button>
+                                            <button title="Up" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'up'); }} disabled={globalPos === 0} className="reorder-btn disabled:opacity-30">▲</button>
                                             <input
                                                 type="number" min={1} max={totalCount}
                                                 defaultValue={globalPos + 1}
@@ -748,9 +748,9 @@ export default function VehiclesView({
                                                 onBlur={e => { const v = parseInt(e.target.value); if (!isNaN(v) && v !== globalPos + 1) handleMoveVehicleToIndex(vehicle.id, v - 1); }}
                                                 className="w-10 h-6 text-center text-xs border rounded bg-white [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                                             />
-                                            <button title="Down" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'down'); }} disabled={globalPos === totalCount - 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▼</button>
-                                            <button title="+10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos + 10); }} disabled={globalPos >= totalCount - 1} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500 disabled:opacity-30">▼▼</button>
-                                            <button title="Bottom" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, totalCount - 1); }} className="w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500">⇊</button>
+                                            <button title="Down" onClick={e => { e.stopPropagation(); handleMoveVehicle(vehicle.id, 'down'); }} disabled={globalPos === totalCount - 1} className="reorder-btn disabled:opacity-30">▼</button>
+                                            <button title="+10" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, globalPos + 10); }} disabled={globalPos >= totalCount - 1} className="reorder-btn disabled:opacity-30">▼▼</button>
+                                            <button title="Bottom" onClick={e => { e.stopPropagation(); handleMoveVehicleToIndex(vehicle.id, totalCount - 1); }} className="reorder-btn">⇊</button>
                                         </div>
                                     )}
 
@@ -798,17 +798,17 @@ export default function VehiclesView({
 
             {/* Pagination */}
             {totalPages > 1 && (
-                <div className="flex items-center justify-center gap-2 mt-6">
-                    <button onClick={() => setVehiclePage(1)} disabled={vehiclePage === 1} className="px-2 py-1 text-sm rounded border bg-white hover:bg-gray-50 disabled:opacity-40">«</button>
-                    <button onClick={() => setVehiclePage(p => p - 1)} disabled={vehiclePage === 1} className="px-2 py-1 text-sm rounded border bg-white hover:bg-gray-50 disabled:opacity-40">‹</button>
+                <div className="vehicle-pagination">
+                    <button onClick={() => setVehiclePage(1)} disabled={vehiclePage === 1} className="pagination-btn">«</button>
+                    <button onClick={() => setVehiclePage(p => p - 1)} disabled={vehiclePage === 1} className="pagination-btn">‹</button>
                     <span className="text-sm text-gray-600">Page {vehiclePage} of {totalPages}</span>
-                    <button onClick={() => setVehiclePage(p => p + 1)} disabled={vehiclePage === totalPages} className="px-2 py-1 text-sm rounded border bg-white hover:bg-gray-50 disabled:opacity-40">›</button>
-                    <button onClick={() => setVehiclePage(totalPages)} disabled={vehiclePage === totalPages} className="px-2 py-1 text-sm rounded border bg-white hover:bg-gray-50 disabled:opacity-40">»</button>
+                    <button onClick={() => setVehiclePage(p => p + 1)} disabled={vehiclePage === totalPages} className="pagination-btn">›</button>
+                    <button onClick={() => setVehiclePage(totalPages)} disabled={vehiclePage === totalPages} className="pagination-btn">»</button>
                 </div>
             )}
 
             {sortedFilteredVehicles.length === 0 && !showForm && (
-                <div className="text-center py-12 text-gray-500">
+                <div className="empty-state">
                     {textFilter.trim()
                         ? <p className="text-lg">No vehicles match "{textFilter.trim()}".</p>
                         : activeTagFilters.length > 0

--- a/src/index.css
+++ b/src/index.css
@@ -174,3 +174,372 @@ body {
     from { width: 100%; }
     to   { width: 0%; }
 }
+
+/* ── Shared Layout ──────────────────────────────────────────────────────────── */
+
+/* Centered page-width column used in header, nav, main, bars */
+.page-container {
+    @apply max-w-7xl mx-auto px-6;
+}
+
+/* Page-level heading (h2) */
+.page-title {
+    @apply text-2xl font-bold;
+}
+
+/* Card/section heading (h3, h4) */
+.section-title {
+    @apply text-lg font-bold;
+}
+
+/* Horizontal inline group — flex row with standard gap */
+.inline-row {
+    @apply flex items-center gap-2;
+}
+
+/* Fixed bottom action bar (delete queue, undo toast, notification) */
+.fixed-action-bar {
+    @apply fixed bottom-0 left-0 right-0 shadow-2xl;
+}
+
+/* Empty-state placeholder content */
+.empty-state {
+    @apply text-center py-12 text-gray-500;
+}
+
+
+/* ── Modals ─────────────────────────────────────────────────────────────────── */
+
+.modal-overlay {
+    @apply fixed inset-0 flex items-center justify-center z-50;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+.modal-panel {
+    @apply bg-white w-full;
+    background-color: var(--color-card);
+}
+.modal-header {
+    @apply flex items-center justify-between;
+}
+.modal-body {
+    @apply overflow-y-auto flex-1 px-6 py-5;
+}
+.modal-footer {
+    @apply px-6 py-4 border-t flex-shrink-0 flex justify-end gap-2;
+}
+
+
+/* ── Forms ──────────────────────────────────────────────────────────────────── */
+
+/* Two-column form field grid; gap added inline (gap-3 or gap-4) */
+.form-grid {
+    @apply grid grid-cols-2;
+}
+
+/* Divider between form sections; mt added inline (mt-4 or mt-5) */
+.form-section {
+    @apply border-t pt-4;
+}
+
+/* Action button row at the bottom of a form; mt added inline */
+.form-actions {
+    @apply flex gap-2 justify-end;
+}
+
+/* Standard text/select/number input field */
+.form-input {
+    @apply border p-2 rounded;
+}
+
+/* CSV file upload drag-drop target */
+.csv-drop-zone {
+    @apply border-2 border-dashed border-gray-300 rounded-lg p-6 text-center;
+}
+
+/* Label wrapping a file input (image or CSV upload) */
+.image-upload-label {
+    @apply flex items-center gap-2 cursor-pointer;
+}
+
+
+/* ── Badges and Tags ────────────────────────────────────────────────────────── */
+
+/* Base pill — full-radius small badge; color classes added inline */
+.tag-pill {
+    @apply px-2 py-0.5 rounded-full text-xs font-medium;
+}
+
+/* Square-radius informational badge (blue by default) */
+.badge-default {
+    @apply text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded;
+}
+
+/* Border-style status badge (full-radius); color classes added inline */
+.badge-status {
+    @apply text-xs px-1.5 py-0.5 rounded-full border;
+}
+
+
+/* ── Navigation (App.jsx) ───────────────────────────────────────────────────── */
+
+/* Tab button group in the main nav bar */
+.nav-tab-group {
+    @apply flex gap-1 items-center flex-wrap;
+}
+
+/* Right-side action buttons in the nav bar */
+.nav-actions {
+    @apply flex gap-2 items-center justify-end;
+}
+
+/* Selected vehicle chip in the nav selected-vehicles strip */
+.selected-vehicle-chip {
+    @apply flex items-center gap-1 px-3 py-1 rounded-full text-sm;
+}
+
+/* OWNER role badge next to user email */
+.owner-badge {
+    @apply ml-2 px-2 py-1 bg-yellow-100 text-yellow-800 rounded text-xs font-bold;
+}
+
+/* Import ▾ dropdown panel */
+.dropdown-menu {
+    @apply absolute right-0 mt-1 bg-white border rounded-lg shadow-lg z-20 overflow-hidden;
+}
+
+/* Single item inside a dropdown menu */
+.dropdown-item {
+    @apply flex items-center gap-2 px-4 py-2.5 text-sm hover:bg-gray-50;
+}
+
+
+/* ── Vehicles View ──────────────────────────────────────────────────────────── */
+
+/* Responsive card grid: 1 col mobile → 2 col tablet → 3 col desktop */
+.vehicle-grid {
+    @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3;
+}
+
+/* List-mode vehicle container */
+.vehicle-list {
+    @apply flex flex-col gap-2;
+}
+
+/* Search / filter row above the vehicle grid */
+.vehicle-filter-bar {
+    @apply flex gap-3 items-center mb-3;
+}
+
+/* Card / list view mode toggle widget */
+.view-toggle {
+    @apply flex border rounded-lg overflow-hidden text-gray-500;
+}
+
+/* Tag filter chip strip below the search bar */
+.tag-filter-bar {
+    @apply flex flex-wrap gap-2 items-center mb-6;
+}
+
+/* Vehicle tag chip cluster on a card or list row */
+.vehicle-tags {
+    @apply flex flex-wrap gap-1;
+}
+
+/* Reorder arrow button cluster (Up/Down/Top/Bottom/±10) */
+.reorder-controls {
+    @apply flex items-center gap-0.5;
+}
+
+/* Individual reorder direction button */
+.reorder-btn {
+    @apply w-6 h-6 flex items-center justify-center rounded text-[10px] bg-gray-100 border border-gray-200 hover:bg-gray-200 text-gray-500;
+}
+
+/* Pagination button strip below the vehicle grid */
+.vehicle-pagination {
+    @apply flex items-center justify-center gap-2 mt-6;
+}
+
+/* Individual pagination navigation button */
+.pagination-btn {
+    @apply px-2 py-1 text-sm rounded border bg-white hover:bg-gray-50 disabled:opacity-40;
+}
+
+
+/* ── Chart Views (Charging + Range) ────────────────────────────────────────── */
+
+/* X / Y / Y2 axis dropdown grid */
+.axis-selectors {
+    @apply grid grid-cols-3 gap-4 mb-6;
+}
+
+/* Chart type / preset button row; mb added inline */
+.chart-type-buttons {
+    @apply flex flex-wrap gap-2;
+}
+
+/* Checkbox toggle label (lines, points, race mode, etc.) */
+.toggle-label {
+    @apply flex items-center gap-2 cursor-pointer select-none w-fit;
+}
+
+/* Checkbox toggle row container */
+.chart-toggles {
+    @apply flex flex-wrap gap-4 mb-4;
+}
+
+/* Collapsible "Select Runs" section header button */
+.run-selector-header {
+    @apply flex items-center gap-2 w-full text-left font-medium hover:text-gray-600 transition-colors mb-1;
+}
+
+/* Vehicle group list inside the run selector */
+.runs-list {
+    @apply space-y-4;
+}
+
+/* Per-vehicle left-bordered group in the run selector */
+.vehicle-run-group {
+    @apply border-l-4 pl-4;
+}
+
+/* Run list within a vehicle group */
+.run-items {
+    @apply space-y-2;
+}
+
+/* Run name area: text + source link arrows + date/status badges */
+.run-label {
+    @apply flex-1 flex items-center gap-2 flex-wrap;
+}
+
+/* Copy chart as PNG button */
+.chart-copy-btn {
+    @apply text-sm flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-colors;
+}
+
+/* Race mode configuration panel */
+.race-mode-panel {
+    @apply mt-4 p-3 rounded-lg border;
+}
+
+/* Efficiency unit toggle (mi/kWh ↔ Wh/mi) */
+.efficiency-unit-toggle {
+    @apply flex gap-1 p-1 bg-gray-100 rounded-lg;
+}
+
+
+/* ── Runs View ──────────────────────────────────────────────────────────────── */
+
+/* Top header bar of the runs view (title + action buttons) */
+.runs-view-header {
+    @apply flex justify-between items-center mb-6;
+}
+
+/* "Adding data to: X" merge-mode banner */
+.merge-target-banner {
+    @apply mb-4 px-4 py-3 bg-blue-50 border border-blue-200 rounded-lg flex items-center justify-between;
+}
+
+/* Data-type flag toggle chip strip */
+.data-type-flags {
+    @apply flex gap-2 flex-wrap;
+}
+
+/* Sub-section panel within a form (Charging Energy, Range Test Details) */
+.data-subpanel {
+    @apply border rounded-lg bg-gray-50;
+}
+
+/* CSV field mapping label + select row */
+.field-mapping-row {
+    @apply flex items-center gap-4;
+}
+
+/* Range estimation option panel; color classes added inline */
+.estimation-panel {
+    @apply p-4 rounded-lg border flex items-start justify-between gap-4;
+}
+
+/* Join key / merge-mode info panel; color classes added inline */
+.join-key-panel {
+    @apply mt-5 p-4 rounded-lg border;
+}
+
+/* Run card top section (title + action buttons) */
+.run-card-header {
+    @apply flex justify-between items-start;
+}
+
+/* Run metadata block (date, conditions, notes) */
+.run-meta {
+    @apply text-sm text-gray-600 mt-2 space-y-1;
+}
+
+/* Inline badge cluster for run stats (speed, distance, energy, temp) */
+.run-stat-badges {
+    @apply flex flex-wrap gap-1.5 mt-1;
+}
+
+/* Run card action button row */
+.run-actions {
+    @apply flex gap-2 flex-wrap justify-end;
+}
+
+
+/* ── Auth Modal ─────────────────────────────────────────────────────────────── */
+
+/* OAuth provider button (GitHub, Google) */
+.auth-provider-btn {
+    @apply w-full flex items-center justify-center gap-3 font-medium py-3 px-4 rounded-lg transition;
+}
+
+
+/* ── Import Tableau Modal ───────────────────────────────────────────────────── */
+
+/* Per-vehicle accordion panel */
+.import-vehicle-panel {
+    @apply border rounded-lg overflow-hidden transition;
+}
+
+/* Vehicle panel header row */
+.import-vehicle-header {
+    @apply flex items-center gap-3 px-4 py-3 bg-gray-50 border-b;
+}
+
+/* Individual session row within a vehicle panel */
+.import-session-row {
+    @apply px-4 py-2 flex items-center gap-2;
+}
+
+
+/* ── Axis Scale Controls ────────────────────────────────────────────────────── */
+
+/* Min/Max input stack for one axis */
+.axis-scale-group {
+    @apply flex flex-col gap-1.5;
+}
+
+/* Numeric axis-bound input — hides browser spin buttons */
+.axis-input {
+    @apply px-2 py-1 border rounded text-sm w-24;
+    appearance: textfield;
+}
+.axis-input::-webkit-inner-spin-button,
+.axis-input::-webkit-outer-spin-button {
+    appearance: none;
+}
+
+
+/* ── Specs View ─────────────────────────────────────────────────────────────── */
+
+/* Specs comparison table outer wrapper */
+.specs-table-container {
+    @apply rounded-lg shadow overflow-x-auto;
+    background-color: var(--color-card);
+}
+
+/* Specs table cell — both <th> and <td> */
+.specs-table-cell {
+    @apply px-6 py-4;
+}


### PR DESCRIPTION
## Summary
- Added 68 semantic CSS classes to `index.css` using Tailwind's `@apply` directive
- Class names describe UI purpose rather than visual design (e.g. `.vehicle-grid`, `.modal-overlay`, `.run-card-header`)
- Refactored all 11 component files to use the new class names
- Eliminated the `numInputCls` JS string constant in favor of the `.axis-input` CSS class

## Files changed
- `src/index.css` — 68 new semantic classes
- `src/App.jsx`, `src/components/AuthModal.jsx`, `src/components/AxisScaleControls.jsx`, `src/components/ChargingView.jsx`, `src/components/DeleteQueueBar.jsx`, `src/components/ImportTableauModal.jsx`, `src/components/RangeChartView.jsx`, `src/components/RunsView.jsx`, `src/components/SpecsView.jsx`, `src/components/VehiclesView.jsx` — utility clusters replaced with semantic names

## Test plan
- [ ] Vehicles page renders correctly (3-column grid at desktop, 2-col at tablet, 1-col at mobile)
- [ ] Modals open and display correctly (AuthModal, ImportTableauModal)
- [ ] Charts page axis selectors and toggles render correctly
- [ ] Runs view card layout and form inputs render correctly
- [ ] Specs table renders correctly
- [ ] Delete queue bar and notification banners display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)