### PR TITLE
Add quad-state tag filter and Select All Visible button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -454,7 +454,7 @@ export default function App() {
                                     })}
                                     <button
                                         onClick={clearAllSelections}
-                                        className="btn btn-warning text-xs"
+                                        className="btn btn-warning btn-sm"
                                     >
                                         Clear all
                                     </button>

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -500,14 +500,14 @@ export default function VehiclesView({
                 <div className="flex justify-end gap-2 mb-4 -mt-3">
                     <button
                         onClick={() => onSelectAllVisible(textFiltered.map(v => v.id))}
-                        className="btn btn-primary text-sm"
+                        className="btn btn-primary btn-sm"
                         title="Add all currently visible vehicles to the comparison selection"
                     >
                         Select All Visible ({textFiltered.length})
                     </button>
                     <button
                         onClick={() => onClearAllVisible(textFiltered.map(v => v.id))}
-                        className="btn btn-secondary text-sm"
+                        className="btn btn-secondary btn-sm"
                         title="Remove all currently visible vehicles from the comparison selection"
                     >
                         Clear All Visible

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,12 @@
     text-align: center;
 }
 
+/* Small button modifier — matches vehicle card action button sizing */
+.btn.btn-sm {
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+}
+
 /*
  * BUTTON SEMANTIC GUIDE
  * ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Tag filter buttons now cycle through four states on each click:
  N/A (grey) → OR (green) → AND (blue) → NOT (red) → N/A

Filter semantics:
- OR: show vehicles that have at least one green-tagged tag
- AND: show vehicles that have all blue-tagged tags
- NOT: hide vehicles that have any red-tagged tag (overrides all)
- States combine: NOT is checked first, then AND, then OR

Each button shows a context-sensitive native tooltip describing the current state and what the next click will do. A small legend (● OR  ● AND  ● NOT) sits right-aligned in the filter bar with a tooltip explaining the color semantics.

"Select All Visible (N)" button appears below the filter bar and adds all currently filtered vehicles (across all pages) to the comparison selection as a union with any existing selection.