### PR TITLE
Road Trip: Travel Speed X-axis + Drive Time X-axis

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,8 +86,8 @@ export default function App() {
         totalDistance: 500, speed: 70,
         overhead: 5,              // per-stop overhead minutes (applies to EV and ICE)
         yAxis: 'chargeTime',      // 'distance' | 'chargeTime' | 'byTest'
-        xAxis: 'totalTime',       // 'totalTime' | 'driveTime' | 'speed'
-        speedYAxis: 'totalTime',  // 'totalTime' | 'driveTime' | 'chargeTime' (speed mode only)
+        xAxis: 'totalTime',       // 'totalTime' | 'driveTime' | 'speed' | 'tripDist'
+        sweepYAxis: 'totalTime',  // 'totalTime' | 'driveTime' | 'chargeTime' (sweep modes only)
         towingMode: false,        // override all vehicle efficiencies with a fixed trailer-system value
         towingEfficiency: 1.5,    // mi/kWh for the whole vehicle+trailer system
         towingRefSpeedMph: 70,    // speed at which towingEfficiency was measured
@@ -192,7 +192,7 @@ export default function App() {
             ...(n('rt_oh') != null && { overhead:      n('rt_oh')               }),
             ...(p.get('rt_ya') && { yAxis:              p.get('rt_ya')          }),
             ...(p.get('rt_xa') && { xAxis:              p.get('rt_xa')          }),
-            ...(p.get('rt_sya') && { speedYAxis:        p.get('rt_sya')         }),
+            ...(p.get('rt_sya') && { sweepYAxis:         p.get('rt_sya')         }),
             ...(p.get('rt_tw') === '1' && { towingMode: true                    }),
             ...(n('rt_te') != null && { towingEfficiency:   n('rt_te')          }),
             ...(n('rt_tr') != null && { towingRefSpeedMph:  n('rt_tr')          }),
@@ -302,7 +302,7 @@ export default function App() {
             p.set('rt_oh', rt.overhead);
             p.set('rt_ya',  rt.yAxis);
             p.set('rt_xa',  rt.xAxis);
-            if (rt.speedYAxis !== 'totalTime')    p.set('rt_sya', rt.speedYAxis);
+            if (rt.sweepYAxis !== 'totalTime')     p.set('rt_sya', rt.sweepYAxis);
             if (rt.towingMode)                    p.set('rt_tw', '1');
             if (rt.towingMode) {
                 p.set('rt_te', rt.towingEfficiency);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -85,7 +85,9 @@ export default function App() {
         legDistance: 150, chargeTime: 30,
         totalDistance: 500, speed: 70,
         overhead: 5,              // per-stop overhead minutes (applies to EV and ICE)
-        yAxis: 'chargeTime',      // 'distance' | 'chargeTime'  — default to charge time
+        yAxis: 'chargeTime',      // 'distance' | 'chargeTime' | 'byTest'
+        xAxis: 'totalTime',       // 'totalTime' | 'driveTime' | 'speed'
+        speedYAxis: 'totalTime',  // 'totalTime' | 'driveTime' | 'chargeTime' (speed mode only)
         towingMode: false,        // override all vehicle efficiencies with a fixed trailer-system value
         towingEfficiency: 1.5,    // mi/kWh for the whole vehicle+trailer system
         towingRefSpeedMph: 70,    // speed at which towingEfficiency was measured
@@ -189,6 +191,8 @@ export default function App() {
             ...(n('rt_sp') != null && { speed:         n('rt_sp')               }),
             ...(n('rt_oh') != null && { overhead:      n('rt_oh')               }),
             ...(p.get('rt_ya') && { yAxis:              p.get('rt_ya')          }),
+            ...(p.get('rt_xa') && { xAxis:              p.get('rt_xa')          }),
+            ...(p.get('rt_sya') && { speedYAxis:        p.get('rt_sya')         }),
             ...(p.get('rt_tw') === '1' && { towingMode: true                    }),
             ...(n('rt_te') != null && { towingEfficiency:   n('rt_te')          }),
             ...(n('rt_tr') != null && { towingRefSpeedMph:  n('rt_tr')          }),
@@ -296,7 +300,9 @@ export default function App() {
             p.set('rt_td', rt.totalDistance);
             p.set('rt_sp', rt.speed);
             p.set('rt_oh', rt.overhead);
-            p.set('rt_ya', rt.yAxis);
+            p.set('rt_ya',  rt.yAxis);
+            p.set('rt_xa',  rt.xAxis);
+            if (rt.speedYAxis !== 'totalTime')    p.set('rt_sya', rt.speedYAxis);
             if (rt.towingMode)                    p.set('rt_tw', '1');
             if (rt.towingMode) {
                 p.set('rt_te', rt.towingEfficiency);

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -678,6 +678,7 @@ export default function RoadTripView({
                            : iceTotalMin;
                 return { x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph, y: Math.round(yVal) };
             });
+            const iceSpeedYMin = Math.floor(Math.min(...iceSpeedData.map(d => d.y)) / 60) * 60;
             speedDatasets.unshift({
                 label: 'ICE Reference',
                 data: iceSpeedData,
@@ -708,7 +709,7 @@ export default function RoadTripView({
                             ticks: { stepSize: sweepStepDisplay },
                         },
                         y: {
-                            min: axisScale.yMin != null ? axisScale.yMin * 60 : 0,
+                            min: axisScale.yMin != null ? axisScale.yMin * 60 : iceSpeedYMin,
                             max: axisScale.yMax != null ? axisScale.yMax * 60 : undefined,
                             title: { display: true, text: speedYLabel, font: { size: 13 } },
                             ticks: { stepSize: 30, callback: val => formatTime(val) },
@@ -772,6 +773,7 @@ export default function RoadTripView({
                            : iceTotalMin;
                 return { x: units === 'metric' ? Math.round(legMi * MI_TO_KM) : legMi, y: Math.round(yVal) };
             });
+            const iceDistYMin = Math.floor(Math.min(...iceDistData.map(d => d.y)) / 60) * 60;
             distDatasets.unshift({
                 label: 'ICE Reference',
                 data: iceDistData,
@@ -802,7 +804,7 @@ export default function RoadTripView({
                             ticks: { stepSize: legStepDisplay },
                         },
                         y: {
-                            min: axisScale.yMin != null ? axisScale.yMin * 60 : 0,
+                            min: axisScale.yMin != null ? axisScale.yMin * 60 : iceDistYMin,
                             max: axisScale.yMax != null ? axisScale.yMax * 60 : undefined,
                             title: { display: true, text: sweepLabel, font: { size: 13 } },
                             ticks: { stepSize: 30, callback: val => formatTime(val) },

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -678,7 +678,7 @@ export default function RoadTripView({
                            : iceTotalMin;
                 return { x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph, y: Math.round(yVal) };
             });
-            const iceSpeedYMin = Math.floor(Math.min(...iceSpeedData.map(d => d.y)) / 60) * 60;
+            const iceSpeedYMin = Math.floor((Math.min(...iceSpeedData.map(d => d.y)) - 30) / 60) * 60;
             speedDatasets.unshift({
                 label: 'ICE Reference',
                 data: iceSpeedData,
@@ -773,7 +773,7 @@ export default function RoadTripView({
                            : iceTotalMin;
                 return { x: units === 'metric' ? Math.round(legMi * MI_TO_KM) : legMi, y: Math.round(yVal) };
             });
-            const iceDistYMin = Math.floor(Math.min(...iceDistData.map(d => d.y)) / 60) * 60;
+            const iceDistYMin = Math.floor((Math.min(...iceDistData.map(d => d.y)) - 30) / 60) * 60;
             distDatasets.unshift({
                 label: 'ICE Reference',
                 data: iceDistData,

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -14,6 +14,39 @@ import {
 
 Chart.register(ZoomPlugin);
 
+// ── Speed sweep constants ────────────────────────────────────────────────────
+const SPEED_SWEEP_MIN  = 45;   // mph
+const SPEED_SWEEP_MAX  = 100;  // mph
+const SPEED_SWEEP_STEP = 5;    // mph
+const SPEED_SWEEP_MPH  = Array.from(
+    { length: Math.floor((SPEED_SWEEP_MAX - SPEED_SWEEP_MIN) / SPEED_SWEEP_STEP) + 1 },
+    (_, i) => SPEED_SWEEP_MIN + i * SPEED_SWEEP_STEP,
+); // [45, 50, 55, ..., 100]
+
+/** Y-value for one speed-sweep sim result. */
+function getSpeedModeY(sim, mph, totalDistanceMi, speedYAxis) {
+    const driveMin = (totalDistanceMi / mph) * 60;
+    if (speedYAxis === 'driveTime')  return driveMin;
+    if (speedYAxis === 'chargeTime') return sim.totalTimeMin - driveMin;
+    return sim.totalTimeMin; // 'totalTime'
+}
+
+/** Compute ICE total trip time at a given travel speed (used for speed-sweep ICE line). */
+function calcIceTotalTimeAtSpeed(speedMph, totalDistanceMi, overheadMin) {
+    const ICE_DRIVE_INTERVAL_MIN = 180;
+    let t = 0, d = 0, iter = 0;
+    while (d < totalDistanceMi && iter < 100) {
+        iter++;
+        const rem = totalDistanceMi - d;
+        const driveMi = Math.min((speedMph * ICE_DRIVE_INTERVAL_MIN) / 60, rem);
+        t += (driveMi / speedMph) * 60;
+        d += driveMi;
+        if (d >= totalDistanceMi - 0.01) break;
+        t += overheadMin;
+    }
+    return t;
+}
+
 // ── Efficiency helpers ───────────────────────────────────────────────────────
 
 /**
@@ -498,18 +531,52 @@ export default function RoadTripView({
         });
     }, [validEntries, runDataCache, roadTripConfig]);
 
+    // ── Speed sweep: run simulation at every speed in SPEED_SWEEP_MPH ─────────
+    const speedSweepResults = useMemo(() => {
+        if (roadTripConfig.xAxis !== 'speed') return null;
+        const {
+            startSoc, minSoc, legDistance, chargeTime, totalDistance, mode, overhead,
+            towingMode, towingEfficiency, towingRefSpeedMph,
+        } = roadTripConfig;
+        return validEntries.map(entry => {
+            const chargingData = runDataCache[entry.run.id] ?? [];
+            return SPEED_SWEEP_MPH.map(speedMph => simulateRoadTrip({
+                batteryKwh:        entry.batteryKwh,
+                miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
+                testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
+                chargingData,
+                startSoc, minSoc,
+                legDistanceMi:     legDistance,
+                totalDistanceMi:   totalDistance,
+                speedMph,
+                chargeTimeMinutes: chargeTime,
+                overheadMinutes:   overhead,
+                mode,
+                towingMode,
+            }));
+        });
+    }, [validEntries, runDataCache, roadTripConfig]);
+
     // ── Build & render chart ──────────────────────────────────────────────────
     useEffect(() => {
-        if (!canvasRef.current || !simResults.some(Boolean)) return;
+        if (!canvasRef.current) return;
+        const { totalDistance, yAxis, xAxis, speedYAxis, overhead, speed } = roadTripConfig;
+        const isSpeedMode      = xAxis === 'speed';
+        const isDriveTimeXAxis = xAxis === 'driveTime';
+        const isChargeTimeMode = yAxis === 'chargeTime';
+        const isByTestMode     = yAxis === 'byTest';
+
+        if (isSpeedMode) {
+            if (!speedSweepResults || speedSweepResults.length === 0) return;
+        } else {
+            if (!simResults.some(Boolean)) return;
+        }
 
         if (chartRef.current) {
             chartRef.current.destroy();
             chartRef.current = null;
         }
 
-        const { totalDistance, yAxis, overhead } = roadTripConfig;
-        const isChargeTimeMode = yAxis === 'chargeTime';
-        const isByTestMode     = yAxis === 'byTest';
         const totalDistDisplay = convDistance(totalDistance, units);
 
         // Label logic: include run name when multiple runs from same vehicle
@@ -522,6 +589,100 @@ export default function RoadTripView({
                 ? `${e.vehicle.name} (${e.run.name})`
                 : e.vehicle.name;
 
+        // ── Speed sweep chart ────────────────────────────────────────────────
+        if (isSpeedMode) {
+            const sweepMinDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_MIN * MI_TO_KM) : SPEED_SWEEP_MIN;
+            const sweepMaxDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_MAX * MI_TO_KM) : SPEED_SWEEP_MAX;
+            const sweepStepDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_STEP * MI_TO_KM) : SPEED_SWEEP_STEP;
+            const speedYLabel = { totalTime: 'Total Trip Time', driveTime: 'Driving Time', chargeTime: 'Charge + Stop Time' }[speedYAxis] ?? 'Total Trip Time';
+
+            const speedDatasets = validEntries.map((entry, i) => {
+                const sweepSims = speedSweepResults[i];
+                if (!sweepSims) return null;
+                const data = SPEED_SWEEP_MPH.map((mph, si) => ({
+                    x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph,
+                    y: Math.round(getSpeedModeY(sweepSims[si], mph, totalDistance, speedYAxis)),
+                }));
+                return {
+                    label: entryLabel(entry),
+                    data,
+                    borderColor: entry.color,
+                    backgroundColor: entry.color + '33',
+                    borderWidth: 2.5,
+                    tension: 0.3,
+                    pointRadius: 3,
+                    fill: false,
+                };
+            }).filter(Boolean);
+
+            // ICE reference line
+            const iceSpeedData = SPEED_SWEEP_MPH.map(mph => {
+                const iceTotalMin = calcIceTotalTimeAtSpeed(mph, totalDistance, overhead);
+                const driveMin    = (totalDistance / mph) * 60;
+                const yVal = speedYAxis === 'driveTime'  ? driveMin
+                           : speedYAxis === 'chargeTime' ? iceTotalMin - driveMin
+                           : iceTotalMin;
+                return { x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph, y: Math.round(yVal) };
+            });
+            speedDatasets.unshift({
+                label: 'ICE Reference',
+                data: iceSpeedData,
+                borderColor: '#9ca3af',
+                backgroundColor: 'transparent',
+                borderWidth: 1.5,
+                borderDash: [6, 4],
+                tension: 0.3,
+                pointRadius: 2,
+                fill: false,
+                _isIce: true,
+            });
+
+            chartRef.current = new Chart(canvasRef.current, {
+                type: 'line',
+                data: { datasets: speedDatasets },
+                options: {
+                    animation: false,
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: 'nearest', axis: 'xy', intersect: false },
+                    scales: {
+                        x: {
+                            type: 'linear',
+                            min: axisScale.xMin ?? sweepMinDisplay,
+                            max: axisScale.xMax ?? sweepMaxDisplay,
+                            title: { display: true, text: `Travel Speed (${sl})`, font: { size: 13 } },
+                            ticks: { stepSize: sweepStepDisplay },
+                        },
+                        y: {
+                            min: axisScale.yMin ?? 0,
+                            title: { display: true, text: speedYLabel, font: { size: 13 } },
+                            ticks: { callback: val => formatTime(val) },
+                        },
+                    },
+                    plugins: {
+                        legend: { display: true, position: 'top', labels: { usePointStyle: true, pointStyle: 'line', boxWidth: 40 } },
+                        tooltip: {
+                            callbacks: {
+                                title: items => items[0]?.dataset.label ?? '',
+                                label: ctx => [
+                                    `Speed: ${ctx.parsed.x} ${sl}`,
+                                    `${speedYLabel}: ${formatTime(ctx.parsed.y)}`,
+                                ],
+                            },
+                        },
+                        zoom: {
+                            zoom: {
+                                drag: { enabled: true, backgroundColor: 'rgba(59,130,246,0.08)', borderColor: '#3b82f6', borderWidth: 1 },
+                                mode: 'xy',
+                            },
+                        },
+                    },
+                },
+            });
+            return () => { chartRef.current?.destroy(); chartRef.current = null; };
+        }
+
+        // ── Timeline chart (total time or drive-time X) ──────────────────────
         const datasets = validEntries.map((entry, i) => {
             const sim = simResults[i];
             if (!sim) return null;
@@ -529,8 +690,8 @@ export default function RoadTripView({
             const points = isByTestMode
                 ? segmentsToChartPointsByTest(sim.segments, i)
                 : isChargeTimeMode
-                    ? segmentsToChartPointsChargeTime(sim.segments)
-                    : segmentsToChartPoints(sim.segments, units);
+                    ? segmentsToChartPointsChargeTime(sim.segments, isDriveTimeXAxis)
+                    : segmentsToChartPoints(sim.segments, units, isDriveTimeXAxis);
 
             // Mark charge-start points with larger radius
             const pointRadii = [];
@@ -563,7 +724,7 @@ export default function RoadTripView({
         const icePoints       = [];  // distance / chargeTime mode
         const iceByTestPoints = [];  // byTest mode (SoC lane)
         const iceGasStopSegs  = [];  // gas stop intervals for byTest green boxes
-        let iceTime = 0, iceDist = 0, iceCumStop = 0, iceIter = 0;
+        let iceTime = 0, iceDist = 0, iceCumStop = 0, iceCumDrive = 0, iceIter = 0;
 
         while (iceDist < roadTripConfig.totalDistance && iceIter < 100) {
             iceIter++;
@@ -572,35 +733,43 @@ export default function RoadTripView({
             const driveMi     = Math.min(maxDriveMi, remainingMi);
             const driveMin    = (driveMi / roadTripConfig.speed) * 60;
 
+            // X values: drive time or total time
+            const xDS = isDriveTimeXAxis ? Math.round(iceCumDrive)            : Math.round(iceTime);
+            const xDE = isDriveTimeXAxis ? Math.round(iceCumDrive + driveMin) : Math.round(iceTime + driveMin);
             if (isChargeTimeMode) {
-                icePoints.push({ x: Math.round(iceTime),            y: Math.round(iceCumStop) });
-                icePoints.push({ x: Math.round(iceTime + driveMin), y: Math.round(iceCumStop) });
+                icePoints.push({ x: xDS, y: Math.round(iceCumStop) });
+                icePoints.push({ x: xDE, y: Math.round(iceCumStop) });
             } else {
-                icePoints.push({ x: Math.round(iceTime),            y: convDistance(iceDist,           units) });
-                icePoints.push({ x: Math.round(iceTime + driveMin), y: convDistance(iceDist + driveMi, units) });
+                icePoints.push({ x: xDS, y: convDistance(iceDist,           units) });
+                icePoints.push({ x: xDE, y: convDistance(iceDist + driveMi, units) });
             }
-            // byTest: drive depletes "fuel" from 100% → ICE_MIN_SOC%
+            // byTest always uses total time on X
             iceByTestPoints.push({ x: Math.round(iceTime),            y: iceLane + 1.0            });
             iceByTestPoints.push({ x: Math.round(iceTime + driveMin), y: iceLane + ICE_MIN_SOC / 100 });
 
-            iceTime += driveMin;
-            iceDist += driveMi;
+            iceTime      += driveMin;
+            iceCumDrive  += driveMin;
+            iceDist      += driveMi;
             if (iceDist >= roadTripConfig.totalDistance - 0.01) break;
 
+            // X values for stop: drive time stays flat; only total time advances
+            const xSS = isDriveTimeXAxis ? Math.round(iceCumDrive) : Math.round(iceTime);
+            const xSE = isDriveTimeXAxis ? Math.round(iceCumDrive) : Math.round(iceTime + ICE_STOP_MIN);
             if (isChargeTimeMode) {
-                icePoints.push({ x: Math.round(iceTime),                y: Math.round(iceCumStop) });
-                icePoints.push({ x: Math.round(iceTime + ICE_STOP_MIN), y: Math.round(iceCumStop + ICE_STOP_MIN) });
+                icePoints.push({ x: xSS, y: Math.round(iceCumStop) });
+                icePoints.push({ x: xSE, y: Math.round(iceCumStop + ICE_STOP_MIN) });
             } else {
-                icePoints.push({ x: Math.round(iceTime),                y: convDistance(iceDist, units) });
-                icePoints.push({ x: Math.round(iceTime + ICE_STOP_MIN), y: convDistance(iceDist, units) });
+                icePoints.push({ x: xSS, y: convDistance(iceDist, units) });
+                icePoints.push({ x: xSE, y: convDistance(iceDist, units) });
             }
-            // byTest: gas stop refuels from ICE_MIN_SOC% → 100%
+            // byTest always uses total time on X
             iceGasStopSegs.push({ startTime: iceTime, endTime: iceTime + ICE_STOP_MIN });
             iceByTestPoints.push({ x: Math.round(iceTime),                y: iceLane + ICE_MIN_SOC / 100 });
             iceByTestPoints.push({ x: Math.round(iceTime + ICE_STOP_MIN), y: iceLane + 1.0              });
 
             iceTime    += ICE_STOP_MIN;
             iceCumStop += ICE_STOP_MIN;
+            // iceCumDrive does NOT advance during ICE stops
         }
 
         if (isByTestMode) {
@@ -641,13 +810,29 @@ export default function RoadTripView({
               ), iceCumStop, 30)
             : 0;
 
-        const autoXMax = maxTime * 1.15;
+        // In drive-time X mode, the max X is the total pure driving time
+        const maxDriveTime = isDriveTimeXAxis
+            ? Math.max(...validSims.map(s =>
+                s.segments.filter(seg => seg.type === 'drive')
+                          .reduce((sum, seg) => sum + (seg.endTime - seg.startTime), 0)
+              ), iceCumDrive, 60)
+            : 0;
+
+        const autoXMax = isDriveTimeXAxis ? maxDriveTime * 1.15 : maxTime * 1.15;
         const autoYMax = isChargeTimeMode ? Math.ceil(maxChargeTime * 1.2 / 10) * 10 : totalDistDisplay;
-        // Default X minimum: time of the earliest first charge stop across all vehicles.
-        // This focuses the chart on charging behaviour rather than the initial drive.
-        const firstChargeStart = Math.min(
-            ...validSims.map(s => s.segments.find(seg => seg.type === 'charge')?.startTime ?? Infinity)
-        );
+
+        // Default X minimum: time of the earliest first charge stop.
+        // In drive-time X mode, compute cumulative drive time up to first stop.
+        const firstChargeStart = isDriveTimeXAxis
+            ? Math.min(...validSims.map(s => {
+                let cum = 0;
+                for (const seg of s.segments) {
+                    if (seg.type === 'charge') return cum;
+                    cum += seg.endTime - seg.startTime;
+                }
+                return Infinity;
+            }))
+            : Math.min(...validSims.map(s => s.segments.find(seg => seg.type === 'charge')?.startTime ?? Infinity));
         const autoXMin = isFinite(firstChargeStart) && firstChargeStart > 0 ? firstChargeStart : 0;
 
         chartRef.current = new Chart(canvasRef.current, {
@@ -665,7 +850,7 @@ export default function RoadTripView({
                 scales: {
                     x: {
                         type: 'linear',
-                        title: { display: true, text: 'Elapsed Time', font: { size: 13 } },
+                        title: { display: true, text: isDriveTimeXAxis ? 'Drive Time' : 'Elapsed Time', font: { size: 13 } },
                         min: axisScale.xMin != null ? axisScale.xMin * 60 : autoXMin,
                         max: axisScale.xMax != null ? axisScale.xMax * 60 : autoXMax,
                         ticks: {
@@ -798,16 +983,17 @@ export default function RoadTripView({
             chartRef.current?.destroy();
             chartRef.current = null;
         };
-    }, [simResults, validEntries, units, roadTripConfig.totalDistance, roadTripConfig.yAxis, roadTripConfig.speed, roadTripConfig.overhead, axisScale]);
+    }, [simResults, speedSweepResults, validEntries, units, roadTripConfig.totalDistance, roadTripConfig.yAxis, roadTripConfig.xAxis, roadTripConfig.speedYAxis, roadTripConfig.speed, roadTripConfig.overhead, axisScale]);
 
     // ── Config update helper ─────────────────────────────────────────────────
     const setField = (key, value) => setRoadTripConfig(prev => ({ ...prev, [key]: value }));
 
     // ── Render ───────────────────────────────────────────────────────────────
     const {
-        startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, overhead,
+        startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, speedYAxis, overhead,
         towingMode, towingEfficiency, towingRefSpeedMph,
     } = roadTripConfig;
+    const isSpeedMode = xAxis === 'speed';
 
     // ICE reference total time (for "vs ICE" column)
     const iceRefTimeMin = useMemo(() => {
@@ -860,27 +1046,33 @@ export default function RoadTripView({
                             </div>
                         </div>
                         <div>
-                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">Y Axis</span>
+                            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">X Axis</span>
                             <div className="flex gap-1">
-                                <button
-                                    className={`btn btn-sm ${yAxis === 'distance' ? 'btn-primary' : 'btn-secondary'}`}
-                                    onClick={() => setField('yAxis', 'distance')}
-                                >
-                                    Distance
-                                </button>
-                                <button
-                                    className={`btn btn-sm ${yAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`}
-                                    onClick={() => setField('yAxis', 'chargeTime')}
-                                >
-                                    Charge Time
-                                </button>
-                                <button
-                                    className={`btn btn-sm ${yAxis === 'byTest' ? 'btn-primary' : 'btn-secondary'}`}
-                                    onClick={() => setField('yAxis', 'byTest')}
-                                >
-                                    By Test
-                                </button>
+                                <button className={`btn btn-sm ${xAxis === 'totalTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'totalTime')}>Total Time</button>
+                                <button className={`btn btn-sm ${xAxis === 'driveTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'driveTime')}>Drive Time</button>
+                                <button className={`btn btn-sm ${xAxis === 'speed'     ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'speed')}>Travel Speed</button>
                             </div>
+                        </div>
+                        <div>
+                            {isSpeedMode ? (
+                                <>
+                                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">Y Axis</span>
+                                    <div className="flex gap-1">
+                                        <button className={`btn btn-sm ${speedYAxis === 'totalTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'totalTime')}>Total Time</button>
+                                        <button className={`btn btn-sm ${speedYAxis === 'driveTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'driveTime')}>Drive Time</button>
+                                        <button className={`btn btn-sm ${speedYAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'chargeTime')}>Charge + Stop</button>
+                                    </div>
+                                </>
+                            ) : (
+                                <>
+                                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">Y Axis</span>
+                                    <div className="flex gap-1">
+                                        <button className={`btn btn-sm ${yAxis === 'distance'   ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('yAxis', 'distance')}>Distance</button>
+                                        <button className={`btn btn-sm ${yAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('yAxis', 'chargeTime')}>Charge Time</button>
+                                        <button className={`btn btn-sm ${yAxis === 'byTest'     ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('yAxis', 'byTest')}>By Test</button>
+                                    </div>
+                                </>
+                            )}
                         </div>
                         <div>
                             <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">Mode</span>
@@ -965,15 +1157,17 @@ export default function RoadTripView({
                                     setField('totalDistance', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
                                 }} />
                         </label>
-                        <label className="text-sm">
-                            <span className="font-medium block mb-1 whitespace-nowrap">Speed ({sl})</span>
-                            <input type="number" className="w-full border rounded px-2 py-1"
-                                min={20} value={dispSpeed}
-                                onChange={e => {
-                                    const val = Number(e.target.value);
-                                    setField('speed', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
-                                }} />
-                        </label>
+                        {!isSpeedMode && (
+                            <label className="text-sm">
+                                <span className="font-medium block mb-1 whitespace-nowrap">Speed ({sl})</span>
+                                <input type="number" className="w-full border rounded px-2 py-1"
+                                    min={20} value={dispSpeed}
+                                    onChange={e => {
+                                        const val = Number(e.target.value);
+                                        setField('speed', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
+                                    }} />
+                            </label>
+                        )}
                         <label className="text-sm">
                             <span className="font-medium block mb-1 whitespace-nowrap">Stop Overhead (min)</span>
                             <input type="number" className="w-full border rounded px-2 py-1"
@@ -1068,7 +1262,8 @@ export default function RoadTripView({
                 <div className="card mb-6">
                     <div className="flex items-center justify-between mb-2">
                         <h3 className="text-lg font-bold">
-                            Road Trip{towingMode ? ' (Towing)' : ''} — {Math.round(convDistance(totalDistance, units))} {dl} at {Math.round(convDistance(speed, units))} {sl}
+                            Road Trip{towingMode ? ' (Towing)' : ''} — {Math.round(convDistance(totalDistance, units))} {dl}
+                            {isSpeedMode ? ` · Speed vs. Time` : ` at ${Math.round(convDistance(speed, units))} ${sl}`}
                         </h3>
                         <button
                             onClick={() => chartRef.current?.resetZoom()}
@@ -1078,7 +1273,7 @@ export default function RoadTripView({
                             Reset Zoom
                         </button>
                     </div>
-                    <div style={{ height: `${yAxis === 'byTest' ? Math.max(300, validEntries.length * 120) : Math.max(400, validEntries.length * 40 + 200)}px`, position: 'relative' }}>
+                    <div style={{ height: `${isSpeedMode ? 400 : yAxis === 'byTest' ? Math.max(300, validEntries.length * 120) : Math.max(400, validEntries.length * 40 + 200)}px`, position: 'relative' }}>
                         <canvas ref={canvasRef} />
                     </div>
                     <p className="text-xs text-gray-400 mt-1 text-center">Drag to zoom · Reset Zoom to restore</p>
@@ -1104,7 +1299,7 @@ export default function RoadTripView({
             )}
 
             {/* ── Axis Scale Controls ────────────────────────────────────── */}
-            {!loading && simResults.some(Boolean) && !presentationMode && (
+            {!loading && (simResults.some(Boolean) || speedSweepResults?.length > 0) && !presentationMode && (
                 <div className="card mb-6">
                     <AxisScaleControls
                         xMin={axisScale.xMin} xMax={axisScale.xMax}
@@ -1112,13 +1307,13 @@ export default function RoadTripView({
                         onChange={onAxisChange}
                         showX={true}
                         showY2={false}
-                        xAxisLabel="X-Axis Scale (hrs)"
+                        xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : 'X-Axis Scale (hrs)'}
                     />
                 </div>
             )}
 
             {/* ── Summary Table ─────────────────────────────────────────── */}
-            {!loading && simResults.some(Boolean) && !presentationMode && (
+            {!loading && simResults.some(Boolean) && !presentationMode && !isSpeedMode && (
                 <div className="card">
                     <h3 className="text-lg font-bold mb-3">Results Summary</h3>
                     <div className="overflow-x-auto">

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -708,9 +708,10 @@ export default function RoadTripView({
                             ticks: { stepSize: sweepStepDisplay },
                         },
                         y: {
-                            min: axisScale.yMin ?? 0,
+                            min: axisScale.yMin != null ? axisScale.yMin * 60 : 0,
+                            max: axisScale.yMax != null ? axisScale.yMax * 60 : undefined,
                             title: { display: true, text: speedYLabel, font: { size: 13 } },
-                            ticks: { callback: val => formatTime(val) },
+                            ticks: { stepSize: 30, callback: val => formatTime(val) },
                         },
                     },
                     plugins: {
@@ -801,9 +802,10 @@ export default function RoadTripView({
                             ticks: { stepSize: legStepDisplay },
                         },
                         y: {
-                            min: axisScale.yMin ?? 0,
+                            min: axisScale.yMin != null ? axisScale.yMin * 60 : 0,
+                            max: axisScale.yMax != null ? axisScale.yMax * 60 : undefined,
                             title: { display: true, text: sweepLabel, font: { size: 13 } },
-                            ticks: { callback: val => formatTime(val) },
+                            ticks: { stepSize: 30, callback: val => formatTime(val) },
                         },
                     },
                     plugins: {
@@ -1471,6 +1473,7 @@ export default function RoadTripView({
                         showX={true}
                         showY2={false}
                         xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : isTripDistMode ? `X-Axis Scale (${dl})` : 'X-Axis Scale (hrs)'}
+                        yAxisLabel={isSweepMode ? 'Y-Axis Scale (hrs)' : 'Left Axis Scale'}
                     />
                 </div>
             )}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -25,7 +25,7 @@ const SPEED_SWEEP_MPH  = Array.from(
 
 // ── Leg-distance sweep constants (mi between charging stops) ─────────────────
 const LEG_SWEEP_MIN  = 60;   // miles between charges
-const LEG_SWEEP_MAX  = 200;  // miles between charges
+const LEG_SWEEP_MAX  = 260;  // miles between charges
 const LEG_SWEEP_STEP = 20;   // miles
 const LEG_SWEEP_MI   = Array.from(
     { length: Math.floor((LEG_SWEEP_MAX - LEG_SWEEP_MIN) / LEG_SWEEP_STEP) + 1 },
@@ -1284,7 +1284,7 @@ export default function RoadTripView({
                         <label className="text-sm">
                             <span className="font-medium block mb-1 whitespace-nowrap">Min SoC (%)</span>
                             <input type="number" className="w-full border rounded px-2 py-1"
-                                min={5} max={30} value={minSoc}
+                                min={0} max={30} value={minSoc}
                                 onChange={e => setField('minSoc', Number(e.target.value))} />
                         </label>
                         {mode === 'distance' && !isTripDistMode && (

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -23,14 +23,14 @@ const SPEED_SWEEP_MPH  = Array.from(
     (_, i) => SPEED_SWEEP_MIN + i * SPEED_SWEEP_STEP,
 ); // [45, 50, 55, ..., 100]
 
-// ── Distance sweep constants ─────────────────────────────────────────────────
-const DIST_SWEEP_MIN  = 100;  // miles
-const DIST_SWEEP_MAX  = 1000; // miles
-const DIST_SWEEP_STEP = 50;   // miles
-const DIST_SWEEP_MI   = Array.from(
-    { length: Math.floor((DIST_SWEEP_MAX - DIST_SWEEP_MIN) / DIST_SWEEP_STEP) + 1 },
-    (_, i) => DIST_SWEEP_MIN + i * DIST_SWEEP_STEP,
-); // [100, 150, 200, ..., 1000]
+// ── Leg-distance sweep constants (mi between charging stops) ─────────────────
+const LEG_SWEEP_MIN  = 60;   // miles between charges
+const LEG_SWEEP_MAX  = 200;  // miles between charges
+const LEG_SWEEP_STEP = 20;   // miles
+const LEG_SWEEP_MI   = Array.from(
+    { length: Math.floor((LEG_SWEEP_MAX - LEG_SWEEP_MIN) / LEG_SWEEP_STEP) + 1 },
+    (_, i) => LEG_SWEEP_MIN + i * LEG_SWEEP_STEP,
+); // [60, 80, 100, ..., 200]
 
 // ── Unrealistic simulation check ─────────────────────────────────────────────
 const CHARGE_CEIL_SOC = 95; // % — charging above this marks a sim as unrealistic
@@ -581,23 +581,23 @@ export default function RoadTripView({
         });
     }, [validEntries, runDataCache, roadTripConfig]);
 
-    // ── Distance sweep: run simulation at every distance in DIST_SWEEP_MI ─────
+    // ── Leg-distance sweep: run simulation at every leg distance in LEG_SWEEP_MI ─
     const distSweepResults = useMemo(() => {
         if (roadTripConfig.xAxis !== 'tripDist') return null;
         const {
-            startSoc, minSoc, legDistance, chargeTime, speed, mode, overhead,
+            startSoc, minSoc, chargeTime, totalDistance, speed, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id] ?? [];
-            return DIST_SWEEP_MI.map(distMi => simulateRoadTrip({
+            return LEG_SWEEP_MI.map(legMi => simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
                 startSoc, minSoc,
-                legDistanceMi:     legDistance,
-                totalDistanceMi:   distMi,
+                legDistanceMi:     legMi,
+                totalDistanceMi:   totalDistance,
                 speedMph:          speed,
                 chargeTimeMinutes: chargeTime,
                 overheadMinutes:   overhead,
@@ -739,16 +739,16 @@ export default function RoadTripView({
         // ── Trip distance sweep chart ────────────────────────────────────────
         if (isTripDistMode) {
             const sweepLabel = { totalTime: 'Total Trip Time', driveTime: 'Driving Time', chargeTime: 'Charge + Stop Time' }[sweepYAxis] ?? 'Total Trip Time';
-            const distMinDisplay = units === 'metric' ? Math.round(DIST_SWEEP_MIN * MI_TO_KM) : DIST_SWEEP_MIN;
-            const distMaxDisplay = units === 'metric' ? Math.round(DIST_SWEEP_MAX * MI_TO_KM) : DIST_SWEEP_MAX;
-            const distStepDisplay = units === 'metric' ? Math.round(DIST_SWEEP_STEP * MI_TO_KM) : DIST_SWEEP_STEP;
+            const legMinDisplay  = units === 'metric' ? Math.round(LEG_SWEEP_MIN  * MI_TO_KM) : LEG_SWEEP_MIN;
+            const legMaxDisplay  = units === 'metric' ? Math.round(LEG_SWEEP_MAX  * MI_TO_KM) : LEG_SWEEP_MAX;
+            const legStepDisplay = units === 'metric' ? Math.round(LEG_SWEEP_STEP * MI_TO_KM) : LEG_SWEEP_STEP;
 
             const distDatasets = validEntries.map((entry, i) => {
                 const sweepSims = distSweepResults[i];
                 if (!sweepSims) return null;
-                const data = DIST_SWEEP_MI.map((distMi, di) => ({
-                    x: units === 'metric' ? Math.round(distMi * MI_TO_KM) : distMi,
-                    y: isSimUnrealistic(sweepSims[di]) ? null : Math.round(getSweepY(sweepSims[di], speed, distMi, sweepYAxis)),
+                const data = LEG_SWEEP_MI.map((legMi, di) => ({
+                    x: units === 'metric' ? Math.round(legMi * MI_TO_KM) : legMi,
+                    y: isSimUnrealistic(sweepSims[di]) ? null : Math.round(getSweepY(sweepSims[di], speed, totalDistance, sweepYAxis)),
                 }));
                 return {
                     label: entryLabel(entry),
@@ -762,14 +762,14 @@ export default function RoadTripView({
                 };
             }).filter(Boolean);
 
-            // ICE reference line for distance sweep
-            const iceDistData = DIST_SWEEP_MI.map(distMi => {
-                const iceTotalMin = calcIceTotalTimeAtSpeed(speed, distMi, overhead);
-                const driveMin    = (distMi / speed) * 60;
+            // ICE reference line — ICE stops every 3 hrs regardless of leg distance setting
+            const iceDistData = LEG_SWEEP_MI.map(legMi => {
+                const iceTotalMin = calcIceTotalTimeAtSpeed(speed, totalDistance, overhead);
+                const driveMin    = (totalDistance / speed) * 60;
                 const yVal = sweepYAxis === 'driveTime'  ? driveMin
                            : sweepYAxis === 'chargeTime' ? iceTotalMin - driveMin
                            : iceTotalMin;
-                return { x: units === 'metric' ? Math.round(distMi * MI_TO_KM) : distMi, y: Math.round(yVal) };
+                return { x: units === 'metric' ? Math.round(legMi * MI_TO_KM) : legMi, y: Math.round(yVal) };
             });
             distDatasets.unshift({
                 label: 'ICE Reference',
@@ -795,10 +795,10 @@ export default function RoadTripView({
                     scales: {
                         x: {
                             type: 'linear',
-                            min: axisScale.xMin ?? distMinDisplay,
-                            max: axisScale.xMax ?? distMaxDisplay,
-                            title: { display: true, text: `Trip Distance (${dl})`, font: { size: 13 } },
-                            ticks: { stepSize: distStepDisplay },
+                            min: axisScale.xMin ?? legMinDisplay,
+                            max: axisScale.xMax ?? legMaxDisplay,
+                            title: { display: true, text: `${dl} Between Charges`, font: { size: 13 } },
+                            ticks: { stepSize: legStepDisplay },
                         },
                         y: {
                             min: axisScale.yMin ?? 0,
@@ -812,7 +812,7 @@ export default function RoadTripView({
                             callbacks: {
                                 title: items => items[0]?.dataset.label ?? '',
                                 label: ctx => [
-                                    `Distance: ${ctx.parsed.x} ${dl}`,
+                                    `${dl} between charges: ${ctx.parsed.x} ${dl}`,
                                     `${sweepLabel}: ${formatTime(ctx.parsed.y)}`,
                                 ],
                             },
@@ -1285,7 +1285,7 @@ export default function RoadTripView({
                                 min={5} max={30} value={minSoc}
                                 onChange={e => setField('minSoc', Number(e.target.value))} />
                         </label>
-                        {mode === 'distance' && (
+                        {mode === 'distance' && !isTripDistMode && (
                             <label className="text-sm">
                                 <span className="font-medium block mb-1 whitespace-nowrap">{dl} between charges</span>
                                 <input type="number" className="w-full border rounded px-2 py-1"
@@ -1304,17 +1304,15 @@ export default function RoadTripView({
                                     onChange={e => setField('chargeTime', Number(e.target.value))} />
                             </label>
                         )}
-                        {!isTripDistMode && (
-                            <label className="text-sm">
-                                <span className="font-medium block mb-1 whitespace-nowrap">Total Dist. ({dl})</span>
-                                <input type="number" className="w-full border rounded px-2 py-1"
-                                    min={10} value={dispTotal}
-                                    onChange={e => {
-                                        const val = Number(e.target.value);
-                                        setField('totalDistance', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
-                                    }} />
-                            </label>
-                        )}
+                        <label className="text-sm">
+                            <span className="font-medium block mb-1 whitespace-nowrap">Total Dist. ({dl})</span>
+                            <input type="number" className="w-full border rounded px-2 py-1"
+                                min={10} value={dispTotal}
+                                onChange={e => {
+                                    const val = Number(e.target.value);
+                                    setField('totalDistance', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
+                                }} />
+                        </label>
                         {!isSpeedMode && (
                             <label className="text-sm">
                                 <span className="font-medium block mb-1 whitespace-nowrap">Speed ({sl})</span>
@@ -1422,7 +1420,7 @@ export default function RoadTripView({
                         <h3 className="text-lg font-bold">
                             Road Trip{towingMode ? ' (Towing)' : ''}
                             {isSpeedMode   ? ` · Speed vs. Time`
-                             : isTripDistMode ? ` · Distance vs. Time at ${Math.round(convDistance(speed, units))} ${sl}`
+                             : isTripDistMode ? ` — ${Math.round(convDistance(totalDistance, units))} ${dl} · Leg Distance vs. Time at ${Math.round(convDistance(speed, units))} ${sl}`
                              : ` — ${Math.round(convDistance(totalDistance, units))} ${dl} at ${Math.round(convDistance(speed, units))} ${sl}`}
                         </h3>
                         <button
@@ -1439,7 +1437,7 @@ export default function RoadTripView({
                     <p className="text-xs text-gray-400 mt-1 text-center">Drag to zoom · Reset Zoom to restore</p>
                     {isSweepMode && hasUnrealisticPoints && (
                         <p className="text-xs text-amber-600 mt-1 text-center">
-                            Lines end where a charge stop would exceed {CHARGE_CEIL_SOC}% SoC — unrealistic at that {isSpeedMode ? 'speed' : 'distance'}.
+                            Lines end where a charge stop would exceed {CHARGE_CEIL_SOC}% SoC — unrealistic at that {isSpeedMode ? 'speed' : 'leg distance'}.
                         </p>
                     )}
                     <div className="mt-3 flex gap-2">

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -23,11 +23,35 @@ const SPEED_SWEEP_MPH  = Array.from(
     (_, i) => SPEED_SWEEP_MIN + i * SPEED_SWEEP_STEP,
 ); // [45, 50, 55, ..., 100]
 
-/** Y-value for one speed-sweep sim result. */
-function getSpeedModeY(sim, mph, totalDistanceMi, speedYAxis) {
+// ── Distance sweep constants ─────────────────────────────────────────────────
+const DIST_SWEEP_MIN  = 100;  // miles
+const DIST_SWEEP_MAX  = 1000; // miles
+const DIST_SWEEP_STEP = 50;   // miles
+const DIST_SWEEP_MI   = Array.from(
+    { length: Math.floor((DIST_SWEEP_MAX - DIST_SWEEP_MIN) / DIST_SWEEP_STEP) + 1 },
+    (_, i) => DIST_SWEEP_MIN + i * DIST_SWEEP_STEP,
+); // [100, 150, 200, ..., 1000]
+
+// ── Unrealistic simulation check ─────────────────────────────────────────────
+const CHARGE_CEIL_SOC = 95; // % — charging above this marks a sim as unrealistic
+
+/**
+ * Returns true when a simulation result is considered unrealistic:
+ * any charge stop exceeded CHARGE_CEIL_SOC, or the battery was depleted /
+ * max iterations were hit (i.e. the vehicle couldn't complete the trip).
+ */
+function isSimUnrealistic(sim) {
+    if (!sim) return true;
+    if (sim.segments.some(s => s.type === 'charge' && s.endSoc > CHARGE_CEIL_SOC)) return true;
+    if (sim.warnings.some(w => /depleted|maximum iterations/i.test(w))) return true;
+    return false;
+}
+
+/** Y-value for one sweep sim result (shared by speed and distance sweeps). */
+function getSweepY(sim, mph, totalDistanceMi, sweepYAxis) {
     const driveMin = (totalDistanceMi / mph) * 60;
-    if (speedYAxis === 'driveTime')  return driveMin;
-    if (speedYAxis === 'chargeTime') return sim.totalTimeMin - driveMin;
+    if (sweepYAxis === 'driveTime')  return driveMin;
+    if (sweepYAxis === 'chargeTime') return sim.totalTimeMin - driveMin;
     return sim.totalTimeMin; // 'totalTime'
 }
 
@@ -557,17 +581,47 @@ export default function RoadTripView({
         });
     }, [validEntries, runDataCache, roadTripConfig]);
 
+    // ── Distance sweep: run simulation at every distance in DIST_SWEEP_MI ─────
+    const distSweepResults = useMemo(() => {
+        if (roadTripConfig.xAxis !== 'tripDist') return null;
+        const {
+            startSoc, minSoc, legDistance, chargeTime, speed, mode, overhead,
+            towingMode, towingEfficiency, towingRefSpeedMph,
+        } = roadTripConfig;
+        return validEntries.map(entry => {
+            const chargingData = runDataCache[entry.run.id] ?? [];
+            return DIST_SWEEP_MI.map(distMi => simulateRoadTrip({
+                batteryKwh:        entry.batteryKwh,
+                miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
+                testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
+                chargingData,
+                startSoc, minSoc,
+                legDistanceMi:     legDistance,
+                totalDistanceMi:   distMi,
+                speedMph:          speed,
+                chargeTimeMinutes: chargeTime,
+                overheadMinutes:   overhead,
+                mode,
+                towingMode,
+            }));
+        });
+    }, [validEntries, runDataCache, roadTripConfig]);
+
     // ── Build & render chart ──────────────────────────────────────────────────
     useEffect(() => {
         if (!canvasRef.current) return;
-        const { totalDistance, yAxis, xAxis, speedYAxis, overhead, speed } = roadTripConfig;
+        const { totalDistance, yAxis, xAxis, sweepYAxis, overhead, speed } = roadTripConfig;
         const isSpeedMode      = xAxis === 'speed';
+        const isTripDistMode   = xAxis === 'tripDist';
+        const isSweepMode      = isSpeedMode || isTripDistMode;
         const isDriveTimeXAxis = xAxis === 'driveTime';
         const isChargeTimeMode = yAxis === 'chargeTime';
         const isByTestMode     = yAxis === 'byTest';
 
         if (isSpeedMode) {
             if (!speedSweepResults || speedSweepResults.length === 0) return;
+        } else if (isTripDistMode) {
+            if (!distSweepResults || distSweepResults.length === 0) return;
         } else {
             if (!simResults.some(Boolean)) return;
         }
@@ -594,14 +648,14 @@ export default function RoadTripView({
             const sweepMinDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_MIN * MI_TO_KM) : SPEED_SWEEP_MIN;
             const sweepMaxDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_MAX * MI_TO_KM) : SPEED_SWEEP_MAX;
             const sweepStepDisplay = units === 'metric' ? Math.round(SPEED_SWEEP_STEP * MI_TO_KM) : SPEED_SWEEP_STEP;
-            const speedYLabel = { totalTime: 'Total Trip Time', driveTime: 'Driving Time', chargeTime: 'Charge + Stop Time' }[speedYAxis] ?? 'Total Trip Time';
+            const speedYLabel = { totalTime: 'Total Trip Time', driveTime: 'Driving Time', chargeTime: 'Charge + Stop Time' }[sweepYAxis] ?? 'Total Trip Time';
 
             const speedDatasets = validEntries.map((entry, i) => {
                 const sweepSims = speedSweepResults[i];
                 if (!sweepSims) return null;
                 const data = SPEED_SWEEP_MPH.map((mph, si) => ({
                     x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph,
-                    y: Math.round(getSpeedModeY(sweepSims[si], mph, totalDistance, speedYAxis)),
+                    y: isSimUnrealistic(sweepSims[si]) ? null : Math.round(getSweepY(sweepSims[si], mph, totalDistance, sweepYAxis)),
                 }));
                 return {
                     label: entryLabel(entry),
@@ -619,8 +673,8 @@ export default function RoadTripView({
             const iceSpeedData = SPEED_SWEEP_MPH.map(mph => {
                 const iceTotalMin = calcIceTotalTimeAtSpeed(mph, totalDistance, overhead);
                 const driveMin    = (totalDistance / mph) * 60;
-                const yVal = speedYAxis === 'driveTime'  ? driveMin
-                           : speedYAxis === 'chargeTime' ? iceTotalMin - driveMin
+                const yVal = sweepYAxis === 'driveTime'  ? driveMin
+                           : sweepYAxis === 'chargeTime' ? iceTotalMin - driveMin
                            : iceTotalMin;
                 return { x: units === 'metric' ? Math.round(mph * MI_TO_KM) : mph, y: Math.round(yVal) };
             });
@@ -667,6 +721,99 @@ export default function RoadTripView({
                                 label: ctx => [
                                     `Speed: ${ctx.parsed.x} ${sl}`,
                                     `${speedYLabel}: ${formatTime(ctx.parsed.y)}`,
+                                ],
+                            },
+                        },
+                        zoom: {
+                            zoom: {
+                                drag: { enabled: true, backgroundColor: 'rgba(59,130,246,0.08)', borderColor: '#3b82f6', borderWidth: 1 },
+                                mode: 'xy',
+                            },
+                        },
+                    },
+                },
+            });
+            return () => { chartRef.current?.destroy(); chartRef.current = null; };
+        }
+
+        // ── Trip distance sweep chart ────────────────────────────────────────
+        if (isTripDistMode) {
+            const sweepLabel = { totalTime: 'Total Trip Time', driveTime: 'Driving Time', chargeTime: 'Charge + Stop Time' }[sweepYAxis] ?? 'Total Trip Time';
+            const distMinDisplay = units === 'metric' ? Math.round(DIST_SWEEP_MIN * MI_TO_KM) : DIST_SWEEP_MIN;
+            const distMaxDisplay = units === 'metric' ? Math.round(DIST_SWEEP_MAX * MI_TO_KM) : DIST_SWEEP_MAX;
+            const distStepDisplay = units === 'metric' ? Math.round(DIST_SWEEP_STEP * MI_TO_KM) : DIST_SWEEP_STEP;
+
+            const distDatasets = validEntries.map((entry, i) => {
+                const sweepSims = distSweepResults[i];
+                if (!sweepSims) return null;
+                const data = DIST_SWEEP_MI.map((distMi, di) => ({
+                    x: units === 'metric' ? Math.round(distMi * MI_TO_KM) : distMi,
+                    y: isSimUnrealistic(sweepSims[di]) ? null : Math.round(getSweepY(sweepSims[di], speed, distMi, sweepYAxis)),
+                }));
+                return {
+                    label: entryLabel(entry),
+                    data,
+                    borderColor: entry.color,
+                    backgroundColor: entry.color + '33',
+                    borderWidth: 2.5,
+                    tension: 0.3,
+                    pointRadius: 3,
+                    fill: false,
+                };
+            }).filter(Boolean);
+
+            // ICE reference line for distance sweep
+            const iceDistData = DIST_SWEEP_MI.map(distMi => {
+                const iceTotalMin = calcIceTotalTimeAtSpeed(speed, distMi, overhead);
+                const driveMin    = (distMi / speed) * 60;
+                const yVal = sweepYAxis === 'driveTime'  ? driveMin
+                           : sweepYAxis === 'chargeTime' ? iceTotalMin - driveMin
+                           : iceTotalMin;
+                return { x: units === 'metric' ? Math.round(distMi * MI_TO_KM) : distMi, y: Math.round(yVal) };
+            });
+            distDatasets.unshift({
+                label: 'ICE Reference',
+                data: iceDistData,
+                borderColor: '#9ca3af',
+                backgroundColor: 'transparent',
+                borderWidth: 1.5,
+                borderDash: [6, 4],
+                tension: 0.3,
+                pointRadius: 2,
+                fill: false,
+                _isIce: true,
+            });
+
+            chartRef.current = new Chart(canvasRef.current, {
+                type: 'line',
+                data: { datasets: distDatasets },
+                options: {
+                    animation: false,
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: 'nearest', axis: 'xy', intersect: false },
+                    scales: {
+                        x: {
+                            type: 'linear',
+                            min: axisScale.xMin ?? distMinDisplay,
+                            max: axisScale.xMax ?? distMaxDisplay,
+                            title: { display: true, text: `Trip Distance (${dl})`, font: { size: 13 } },
+                            ticks: { stepSize: distStepDisplay },
+                        },
+                        y: {
+                            min: axisScale.yMin ?? 0,
+                            title: { display: true, text: sweepLabel, font: { size: 13 } },
+                            ticks: { callback: val => formatTime(val) },
+                        },
+                    },
+                    plugins: {
+                        legend: { display: true, position: 'top', labels: { usePointStyle: true, pointStyle: 'line', boxWidth: 40 } },
+                        tooltip: {
+                            callbacks: {
+                                title: items => items[0]?.dataset.label ?? '',
+                                label: ctx => [
+                                    `Distance: ${ctx.parsed.x} ${dl}`,
+                                    `${sweepLabel}: ${formatTime(ctx.parsed.y)}`,
                                 ],
                             },
                         },
@@ -983,17 +1130,25 @@ export default function RoadTripView({
             chartRef.current?.destroy();
             chartRef.current = null;
         };
-    }, [simResults, speedSweepResults, validEntries, units, roadTripConfig.totalDistance, roadTripConfig.yAxis, roadTripConfig.xAxis, roadTripConfig.speedYAxis, roadTripConfig.speed, roadTripConfig.overhead, axisScale]);
+    }, [simResults, speedSweepResults, distSweepResults, validEntries, units, roadTripConfig.totalDistance, roadTripConfig.yAxis, roadTripConfig.xAxis, roadTripConfig.sweepYAxis, roadTripConfig.speed, roadTripConfig.overhead, axisScale]);
 
     // ── Config update helper ─────────────────────────────────────────────────
     const setField = (key, value) => setRoadTripConfig(prev => ({ ...prev, [key]: value }));
 
     // ── Render ───────────────────────────────────────────────────────────────
     const {
-        startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, speedYAxis, overhead,
+        startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, sweepYAxis, overhead,
         towingMode, towingEfficiency, towingRefSpeedMph,
     } = roadTripConfig;
-    const isSpeedMode = xAxis === 'speed';
+    const isSpeedMode    = xAxis === 'speed';
+    const isTripDistMode = xAxis === 'tripDist';
+    const isSweepMode    = isSpeedMode || isTripDistMode;
+
+    // Did any sweep sim get cut off due to unrealistic charging?
+    const activeSweepResults = isSpeedMode ? speedSweepResults : isTripDistMode ? distSweepResults : null;
+    const hasUnrealisticPoints = activeSweepResults?.some(
+        entryResults => entryResults?.some(sim => isSimUnrealistic(sim))
+    ) ?? false;
 
     // ICE reference total time (for "vs ICE" column)
     const iceRefTimeMin = useMemo(() => {
@@ -1051,16 +1206,17 @@ export default function RoadTripView({
                                 <button className={`btn btn-sm ${xAxis === 'totalTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'totalTime')}>Total Time</button>
                                 <button className={`btn btn-sm ${xAxis === 'driveTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'driveTime')}>Drive Time</button>
                                 <button className={`btn btn-sm ${xAxis === 'speed'     ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'speed')}>Travel Speed</button>
+                                <button className={`btn btn-sm ${xAxis === 'tripDist'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'tripDist')}>Trip Distance</button>
                             </div>
                         </div>
                         <div>
-                            {isSpeedMode ? (
+                            {isSweepMode ? (
                                 <>
                                     <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide block mb-1">Y Axis</span>
                                     <div className="flex gap-1">
-                                        <button className={`btn btn-sm ${speedYAxis === 'totalTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'totalTime')}>Total Time</button>
-                                        <button className={`btn btn-sm ${speedYAxis === 'driveTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'driveTime')}>Drive Time</button>
-                                        <button className={`btn btn-sm ${speedYAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('speedYAxis', 'chargeTime')}>Charge + Stop</button>
+                                        <button className={`btn btn-sm ${sweepYAxis === 'totalTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('sweepYAxis', 'totalTime')}>Total Time</button>
+                                        <button className={`btn btn-sm ${sweepYAxis === 'driveTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('sweepYAxis', 'driveTime')}>Drive Time</button>
+                                        <button className={`btn btn-sm ${sweepYAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('sweepYAxis', 'chargeTime')}>Charge + Stop</button>
                                     </div>
                                 </>
                             ) : (
@@ -1148,15 +1304,17 @@ export default function RoadTripView({
                                     onChange={e => setField('chargeTime', Number(e.target.value))} />
                             </label>
                         )}
-                        <label className="text-sm">
-                            <span className="font-medium block mb-1 whitespace-nowrap">Total Dist. ({dl})</span>
-                            <input type="number" className="w-full border rounded px-2 py-1"
-                                min={10} value={dispTotal}
-                                onChange={e => {
-                                    const val = Number(e.target.value);
-                                    setField('totalDistance', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
-                                }} />
-                        </label>
+                        {!isTripDistMode && (
+                            <label className="text-sm">
+                                <span className="font-medium block mb-1 whitespace-nowrap">Total Dist. ({dl})</span>
+                                <input type="number" className="w-full border rounded px-2 py-1"
+                                    min={10} value={dispTotal}
+                                    onChange={e => {
+                                        const val = Number(e.target.value);
+                                        setField('totalDistance', units === 'metric' ? Math.round(val / MI_TO_KM) : val);
+                                    }} />
+                            </label>
+                        )}
                         {!isSpeedMode && (
                             <label className="text-sm">
                                 <span className="font-medium block mb-1 whitespace-nowrap">Speed ({sl})</span>
@@ -1262,8 +1420,10 @@ export default function RoadTripView({
                 <div className="card mb-6">
                     <div className="flex items-center justify-between mb-2">
                         <h3 className="text-lg font-bold">
-                            Road Trip{towingMode ? ' (Towing)' : ''} — {Math.round(convDistance(totalDistance, units))} {dl}
-                            {isSpeedMode ? ` · Speed vs. Time` : ` at ${Math.round(convDistance(speed, units))} ${sl}`}
+                            Road Trip{towingMode ? ' (Towing)' : ''}
+                            {isSpeedMode   ? ` · Speed vs. Time`
+                             : isTripDistMode ? ` · Distance vs. Time at ${Math.round(convDistance(speed, units))} ${sl}`
+                             : ` — ${Math.round(convDistance(totalDistance, units))} ${dl} at ${Math.round(convDistance(speed, units))} ${sl}`}
                         </h3>
                         <button
                             onClick={() => chartRef.current?.resetZoom()}
@@ -1273,10 +1433,15 @@ export default function RoadTripView({
                             Reset Zoom
                         </button>
                     </div>
-                    <div style={{ height: `${isSpeedMode ? 400 : yAxis === 'byTest' ? Math.max(300, validEntries.length * 120) : Math.max(400, validEntries.length * 40 + 200)}px`, position: 'relative' }}>
+                    <div style={{ height: `${isSweepMode ? 400 : yAxis === 'byTest' ? Math.max(300, validEntries.length * 120) : Math.max(400, validEntries.length * 40 + 200)}px`, position: 'relative' }}>
                         <canvas ref={canvasRef} />
                     </div>
                     <p className="text-xs text-gray-400 mt-1 text-center">Drag to zoom · Reset Zoom to restore</p>
+                    {isSweepMode && hasUnrealisticPoints && (
+                        <p className="text-xs text-amber-600 mt-1 text-center">
+                            Lines end where a charge stop would exceed {CHARGE_CEIL_SOC}% SoC — unrealistic at that {isSpeedMode ? 'speed' : 'distance'}.
+                        </p>
+                    )}
                     <div className="mt-3 flex gap-2">
                         <button
                             onClick={() => {
@@ -1299,7 +1464,7 @@ export default function RoadTripView({
             )}
 
             {/* ── Axis Scale Controls ────────────────────────────────────── */}
-            {!loading && (simResults.some(Boolean) || speedSweepResults?.length > 0) && !presentationMode && (
+            {!loading && (simResults.some(Boolean) || speedSweepResults?.length > 0 || distSweepResults?.length > 0) && !presentationMode && (
                 <div className="card mb-6">
                     <AxisScaleControls
                         xMin={axisScale.xMin} xMax={axisScale.xMax}
@@ -1307,13 +1472,13 @@ export default function RoadTripView({
                         onChange={onAxisChange}
                         showX={true}
                         showY2={false}
-                        xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : 'X-Axis Scale (hrs)'}
+                        xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : isTripDistMode ? `X-Axis Scale (${dl})` : 'X-Axis Scale (hrs)'}
                     />
                 </div>
             )}
 
             {/* ── Summary Table ─────────────────────────────────────────── */}
-            {!loading && simResults.some(Boolean) && !presentationMode && !isSpeedMode && (
+            {!loading && simResults.some(Boolean) && !presentationMode && !isSweepMode && (
                 <div className="card">
                     <h3 className="text-lg font-bold mb-3">Results Summary</h3>
                     <div className="overflow-x-auto">

--- a/src/utils/roadTripSimulation.js
+++ b/src/utils/roadTripSimulation.js
@@ -199,12 +199,17 @@ export function simulateRoadTrip({
 /**
  * Convert simulation segments to Chart.js data points (distance mode).
  * Each segment emits its start and end point.
+ * @param {boolean} [driveTimeX] When true, X = cumulative driving time (stops don't advance X).
  */
-export function segmentsToChartPoints(segments, units) {
+export function segmentsToChartPoints(segments, units, driveTimeX = false) {
     const points = [];
+    let cumDrive = 0;
     for (const seg of segments) {
-        points.push({ x: round1(seg.startTime), y: convDistance(seg.startDist, units) });
-        points.push({ x: round1(seg.endTime),   y: convDistance(seg.endDist, units)   });
+        const x1 = driveTimeX ? round1(cumDrive) : round1(seg.startTime);
+        points.push({ x: x1, y: convDistance(seg.startDist, units) });
+        if (seg.type === 'drive') cumDrive += seg.endTime - seg.startTime;
+        const x2 = driveTimeX ? round1(cumDrive) : round1(seg.endTime);
+        points.push({ x: x2, y: convDistance(seg.endDist, units) });
     }
     return points;
 }
@@ -214,16 +219,18 @@ export function segmentsToChartPoints(segments, units) {
  * Y-axis = cumulative minutes spent charging.
  * Drive segments: Y stays flat.
  * Charge segments: Y increases by the segment duration.
+ * @param {boolean} [driveTimeX] When true, X = cumulative driving time (stops don't advance X).
  */
-export function segmentsToChartPointsChargeTime(segments) {
+export function segmentsToChartPointsChargeTime(segments, driveTimeX = false) {
     const points = [];
-    let cumCharge = 0;
+    let cumCharge = 0, cumDrive = 0;
     for (const seg of segments) {
-        points.push({ x: round1(seg.startTime), y: round1(cumCharge) });
-        if (seg.type === 'charge') {
-            cumCharge += seg.endTime - seg.startTime;
-        }
-        points.push({ x: round1(seg.endTime), y: round1(cumCharge) });
+        const x1 = driveTimeX ? round1(cumDrive) : round1(seg.startTime);
+        points.push({ x: x1, y: round1(cumCharge) });
+        if (seg.type === 'charge') cumCharge += seg.endTime - seg.startTime;
+        if (seg.type === 'drive')  cumDrive  += seg.endTime - seg.startTime;
+        const x2 = driveTimeX ? round1(cumDrive) : round1(seg.endTime);
+        points.push({ x: x2, y: round1(cumCharge) });
     }
     return points;
 }


### PR DESCRIPTION
## Summary
- **X-Axis button row** added (Total Time / Drive Time / Travel Speed) — sits above the existing Y-Axis buttons
- **Travel Speed mode**: sweeps 45–100 mph in 5 mph increments and plots trip time vs. speed per vehicle. Y-axis options are Total Time, Drive Time, or Charge + Stop Time. Speed input hidden from settings (it's the X-axis variable). Results summary table hidden. ICE reference line computed at each speed.
- **Drive Time mode**: cumulative driving time on X; charge/stop segments don't advance the axis. Works with all existing Y-axis options (Distance, Charge Time, By Test).
- Speed sweep constants (`SPEED_SWEEP_MIN/MAX/STEP`) are module-level variables for future configurability
- New config fields `xAxis` / `speedYAxis` synced to URL as `rt_xa` / `rt_sya`
- Metric: Travel Speed X values convert to km/h

## Test plan
- [ ] Select 2+ vehicles with charging data → switch to Travel Speed → chart renders one line per run from 45–100 mph
- [ ] ICE grey dashed line appears on Travel Speed chart
- [ ] Switch Y-axis between Total Time / Drive Time / Charge + Stop Time → lines update
- [ ] Toggle metric → X-axis shows km/h
- [ ] Switch to Drive Time X-axis → charge stops are flat on X, drive segments accumulate
- [ ] Speed input hidden in Travel Speed mode, visible in other modes
- [ ] Results table hidden in Travel Speed mode
- [ ] Copy URL → paste in new tab → same xAxis/speedYAxis restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)