### PR TITLE
Manufacturers, spec links, spec scatter plot, vehicle performance table

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import RoadTripView from './components/RoadTripView';
 import PopoutView from './components/PopoutView';
 import SpecsView from './components/SpecsView';
 import SpecsChartView from './components/SpecsChartView';
+import SpecsScatterView from './components/SpecsScatterView';
 import AdminView from './components/AdminView';
 
 export default function App() {
@@ -107,7 +108,9 @@ export default function App() {
         y2Max: null,
         showLine:   true,
         showPoints: false,
-        specsField: null,   // selected field key for Spec Chart mode
+        specsField:     null,   // selected field key for Spec Chart mode
+        scatterXField:  null,   // selected X field key for Spec Scatter mode
+        scatterYField:  null,   // selected Y field key for Spec Scatter mode
     });
     const handleChartModeChange = (newMode) => {
         // Push a history entry so "back" can return to the previous chart mode.
@@ -163,7 +166,9 @@ export default function App() {
             y2Max: p.get('y2x') !== null && p.get('y2x') !== '' ? Number(p.get('y2x')) : null,
             showLine:   p.get('line') !== '0', // default to true if not present, false if explicitly set to 0
             showPoints: p.get('pts') === '1', // default to false if not present, true if explicitly set to 1
-            chartMode: p.get('m') || 'charging',
+            chartMode:     p.get('m') || 'charging',
+            scatterXField: p.get('scx') || null,
+            scatterYField: p.get('scy') || null,
         };
 
         // Charge Compare config
@@ -246,8 +251,10 @@ export default function App() {
             yMax:          s.yMax,
             y2Min:         s.y2Min ?? null,
             y2Max:         s.y2Max ?? null,
-            showLine:   s.showLine ?? true, // default to true if not present, false if explicitly set to 0
-            showPoints: s.showPoints ?? false, // default to false if not present, true if explicitly set to 1
+            showLine:      s.showLine ?? true, // default to true if not present, false if explicitly set to 0
+            showPoints:    s.showPoints ?? false, // default to false if not present, true if explicitly set to 1
+            ...(s.scatterXField && { scatterXField: s.scatterXField }),
+            ...(s.scatterYField && { scatterYField: s.scatterYField }),
         }));
         setView('chart');
     }, [loading]);
@@ -308,6 +315,12 @@ export default function App() {
                 p.set('rt_te', rt.towingEfficiency);
                 p.set('rt_tr', rt.towingRefSpeedMph);
             }
+        }
+
+        // Spec Scatter options
+        if (chartMode === 'specscatter') {
+            if (chartConfig.scatterXField) p.set('scx', chartConfig.scatterXField);
+            if (chartConfig.scatterYField) p.set('scy', chartConfig.scatterYField);
         }
 
         history.replaceState({ view: 'chart', chartMode }, '', '?' + p.toString());
@@ -525,7 +538,8 @@ export default function App() {
                                         { key: 'range',     label: 'Range & Efficiency' },
                                         { key: 'compare',   label: 'Charge Compare' },
                                         { key: 'roadtrip',  label: 'Road Trip' },
-                                        { key: 'specs',     label: 'Spec Chart' },
+                                        { key: 'specs',       label: 'Spec Chart' },
+                                        { key: 'specscatter', label: 'Spec Scatter' },
                                     ].map(({ key, label }) => (
                                         <button
                                             key={key}
@@ -698,7 +712,7 @@ export default function App() {
                             onCopyRunToVehicle={(run, targetId) => copyRunToVehicle(currentActiveVehicle.id, run, targetId)}
                         />
                     )}
-                    {view === 'chart' && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'roadtrip' && (
+                    {view === 'chart' && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'specscatter' && chartMode !== 'roadtrip' && (
                         <ChargingView
                             vehicles={vehicles}
                             selectedVehicleIds={selectedVehicles}
@@ -735,6 +749,14 @@ export default function App() {
                             vehicles={selectedVehicles.map(id => vehicles.find(v => v.id === id)).filter(Boolean)}
                             selectedField={chartConfig.specsField}
                             onFieldChange={field => setChartConfig(p => ({ ...p, specsField: field }))}
+                        />
+                    )}
+                    {view === 'chart' && selectedVehicles.length > 0 && chartMode === 'specscatter' && (
+                        <SpecsScatterView
+                            vehicles={selectedVehicles.map(id => vehicles.find(v => v.id === id)).filter(Boolean)}
+                            xField={chartConfig.scatterXField}
+                            yField={chartConfig.scatterYField}
+                            onFieldChange={(x, y) => setChartConfig(p => ({ ...p, scatterXField: x, scatterYField: y }))}
                         />
                     )}
                     {view === 'specs' && (

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -337,10 +337,16 @@ export default function ChargeCompareView({
             if (missing.length === 0) return;
             setLoading(true);
             const updates = {};
+            const allRuns = vehicles.flatMap(v => v.runs || []);
             for (const runId of missing) {
                 try {
                     if (dataService.useSupabase) {
-                        updates[runId] = await dataService.getRunData(runId);
+                        const run = allRuns.find(r => String(r.id) === String(runId));
+                        if (run?._inherited) {
+                            updates[runId] = await dataService.getRunData(run._realRunId, run._scalingFactor ?? 1);
+                        } else {
+                            updates[runId] = await dataService.getRunData(runId);
+                        }
                     } else {
                         for (const v of vehicles) {
                             const run = v.runs?.find(r => r.id === runId);

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -127,10 +127,17 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             if (missingIds.length === 0) return;
             setLoadingData(true);
             const updates = {};
+            // Build a flat lookup of all runs across all selected vehicles
+            const allRuns = vehicles.flatMap(v => v.runs || []);
             for (const runId of missingIds) {
                 try {
                     if (dataService.useSupabase) {
-                        updates[runId] = await dataService.getRunData(runId);
+                        const run = allRuns.find(r => String(r.id) === String(runId));
+                        if (run?._inherited) {
+                            updates[runId] = await dataService.getRunData(run._realRunId, run._scalingFactor ?? 1);
+                        } else {
+                            updates[runId] = await dataService.getRunData(runId);
+                        }
                     } else {
                         // localStorage: find run.data inline
                         for (const v of vehicles) {

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -53,6 +53,14 @@ export default function EditVehicleForm({
     trims, onAddTrim, onRemoveTrim,
     imageUploading, onImageReady,
     onSubmit, onCancel,
+    // Manufacturer
+    manufacturers = [],
+    onAddManufacturer,
+    // Spec links
+    allVehicles = [],
+    onAddSpecLink,
+    onDeleteSpecLink,
+    isContributor = false,
 }) {
     const [imgSrc, setImgSrc] = useState('');
     const [crop, setCrop] = useState();
@@ -65,6 +73,19 @@ export default function EditVehicleForm({
     const [newTrimWheel, setNewTrimWheel] = useState('');
     const [newTrimTire, setNewTrimTire] = useState('');
     const [newTrimEpa, setNewTrimEpa] = useState('');
+
+    // New manufacturer inline creation
+    const [showNewMfg, setShowNewMfg] = useState(false);
+    const [newMfgName, setNewMfgName] = useState('');
+    const [newMfgCountry, setNewMfgCountry] = useState('');
+    const [mfgSaving, setMfgSaving] = useState(false);
+
+    // Spec link "add" form local state
+    const [newLinkSourceId, setNewLinkSourceId] = useState('');
+    const [newLinkSpecType, setNewLinkSpecType] = useState('range_test');
+    const [newLinkScaling, setNewLinkScaling] = useState('');
+    const [newLinkNotes, setNewLinkNotes] = useState('');
+    const [linkSaving, setLinkSaving] = useState(false);
 
     const handleAddTrim = () => {
         if (!newTrimName.trim()) return;
@@ -116,6 +137,71 @@ export default function EditVehicleForm({
         setCompletedCrop(null);
     };
 
+    // ── Manufacturer handlers ─────────────────────────────────────────────────
+
+    const handleManufacturerChange = (e) => {
+        const id = e.target.value ? parseInt(e.target.value, 10) : null;
+        const mfg = manufacturers.find(m => m.id === id);
+        onFormChange({
+            ...formData,
+            manufacturer_id: id || null,
+            make: mfg ? mfg.name : formData.make,
+        });
+    };
+
+    const handleCreateManufacturer = async () => {
+        if (!newMfgName.trim() || !onAddManufacturer) return;
+        setMfgSaving(true);
+        try {
+            const mfg = await onAddManufacturer(newMfgName.trim(), newMfgCountry.trim() || null);
+            if (mfg) {
+                onFormChange({ ...formData, manufacturer_id: mfg.id, make: mfg.name });
+            }
+            setNewMfgName('');
+            setNewMfgCountry('');
+            setShowNewMfg(false);
+        } finally {
+            setMfgSaving(false);
+        }
+    };
+
+    // ── Spec link handlers ────────────────────────────────────────────────────
+
+    const suggestEpaRatio = () => {
+        const src = allVehicles.find(v => v.id === parseInt(newLinkSourceId, 10));
+        const tgt = editingVehicle;
+        if (!src || !tgt) return;
+        const srcRange = parseFloat(src.range);
+        const tgtRange = parseFloat(tgt.range);
+        if (!srcRange || !tgtRange) return;
+        setNewLinkScaling((tgtRange / srcRange).toFixed(3));
+    };
+
+    const handleAddSpecLink = async () => {
+        if (!newLinkSourceId || !onAddSpecLink) return;
+        setLinkSaving(true);
+        try {
+            await onAddSpecLink({
+                targetVehicleId: editingVehicle.id,
+                sourceVehicleId: parseInt(newLinkSourceId, 10),
+                specType: newLinkSpecType,
+                scalingFactor: newLinkScaling ? parseFloat(newLinkScaling) : null,
+                notes: newLinkNotes.trim() || null,
+            });
+            setNewLinkSourceId('');
+            setNewLinkScaling('');
+            setNewLinkNotes('');
+        } finally {
+            setLinkSaving(false);
+        }
+    };
+
+    // Vehicles available as spec link sources (exclude current vehicle and inherited runs)
+    const linkableVehicles = allVehicles.filter(v => v.id !== editingVehicle?.id);
+
+    // Existing spec links on the editing vehicle
+    const existingLinks = editingVehicle?.spec_links || [];
+
     return (
         <>
             <form onSubmit={onSubmit} className="card">
@@ -128,7 +214,66 @@ export default function EditVehicleForm({
                         className="form-input col-span-2"
                         required
                     />
-                    <input placeholder="Make"           value={formData.make}    onChange={(e) => onFormChange({ ...formData, make: e.target.value })}    className="form-input" />
+
+                    {/* Manufacturer select — replaces free-text make input */}
+                    <div className="col-span-2">
+                        {!showNewMfg ? (
+                            <div className="flex gap-2 items-center">
+                                <select
+                                    value={formData.manufacturer_id || ''}
+                                    onChange={handleManufacturerChange}
+                                    className="form-input flex-1"
+                                >
+                                    <option value="">— Manufacturer —</option>
+                                    {manufacturers.map(m => (
+                                        <option key={m.id} value={m.id}>{m.name}</option>
+                                    ))}
+                                </select>
+                                {onAddManufacturer && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowNewMfg(true)}
+                                        className="btn btn-secondary text-sm whitespace-nowrap"
+                                    >
+                                        + New
+                                    </button>
+                                )}
+                            </div>
+                        ) : (
+                            <div className="flex gap-2 items-center">
+                                <input
+                                    autoFocus
+                                    placeholder="Manufacturer name"
+                                    value={newMfgName}
+                                    onChange={e => setNewMfgName(e.target.value)}
+                                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleCreateManufacturer(); } if (e.key === 'Escape') setShowNewMfg(false); }}
+                                    className="form-input flex-1"
+                                />
+                                <input
+                                    placeholder="Country (optional)"
+                                    value={newMfgCountry}
+                                    onChange={e => setNewMfgCountry(e.target.value)}
+                                    className="form-input w-32"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={handleCreateManufacturer}
+                                    disabled={!newMfgName.trim() || mfgSaving}
+                                    className="btn btn-primary text-sm disabled:opacity-40"
+                                >
+                                    {mfgSaving ? 'Saving…' : 'Create'}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setShowNewMfg(false)}
+                                    className="btn btn-secondary text-sm"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        )}
+                    </div>
+
                     <input placeholder="Model"          value={formData.model}   onChange={(e) => onFormChange({ ...formData, model: e.target.value })}   className="form-input" />
                     <input placeholder="Year"           value={formData.year}    onChange={(e) => onFormChange({ ...formData, year: e.target.value })}    className="form-input" />
                     <input placeholder="Battery (kWh)"  value={formData.battery} onChange={(e) => onFormChange({ ...formData, battery: e.target.value })} className="form-input" />
@@ -267,6 +412,115 @@ export default function EditVehicleForm({
                             >
                                 Add
                             </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Inherited Test Data — edit mode + contributors/admins only */}
+                {editingId && isContributor && onAddSpecLink && (
+                    <div className="form-section mt-5">
+                        <label className="block font-medium mb-2">Inherited Test Data</label>
+                        <p className="text-xs text-gray-500 mb-3">
+                            Let this vehicle inherit range tests or charging curves from another vehicle,
+                            with an optional scaling factor applied to range data.
+                        </p>
+
+                        {/* Existing links */}
+                        {existingLinks.length > 0 && (
+                            <div className="spec-link-list mb-3">
+                                {existingLinks.map(link => {
+                                    const src = allVehicles.find(v => v.id === link.source_vehicle_id);
+                                    return (
+                                        <div key={link.id} className="spec-link-row">
+                                            <span className="spec-link-type-badge">
+                                                {link.spec_type === 'range_test' ? 'Range Test' : 'Charging Curve'}
+                                            </span>
+                                            <span className="text-sm text-gray-700 flex-1">
+                                                ← {src?.name || `Vehicle #${link.source_vehicle_id}`}
+                                            </span>
+                                            {link.scaling_factor != null && (
+                                                <span className="text-xs text-gray-500 font-mono">
+                                                    ×{link.scaling_factor}
+                                                </span>
+                                            )}
+                                            {link.notes && (
+                                                <span className="text-xs text-gray-400 italic truncate max-w-32" title={link.notes}>
+                                                    {link.notes}
+                                                </span>
+                                            )}
+                                            <button
+                                                type="button"
+                                                onClick={() => onDeleteSpecLink(link.id)}
+                                                className="text-gray-400 hover:text-red-500 transition text-xs ml-1"
+                                                title="Remove this link"
+                                            >
+                                                Remove
+                                            </button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* Add new link */}
+                        <div className="spec-link-add-form">
+                            <div className="flex gap-2 flex-wrap">
+                                <select
+                                    value={newLinkSourceId}
+                                    onChange={e => setNewLinkSourceId(e.target.value)}
+                                    className="form-input text-sm flex-1 min-w-40"
+                                >
+                                    <option value="">Source vehicle…</option>
+                                    {linkableVehicles
+                                        .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+                                        .map(v => (
+                                            <option key={v.id} value={v.id}>{v.name}</option>
+                                        ))}
+                                </select>
+                                <select
+                                    value={newLinkSpecType}
+                                    onChange={e => setNewLinkSpecType(e.target.value)}
+                                    className="form-input text-sm"
+                                >
+                                    <option value="range_test">Range Test</option>
+                                    <option value="charging_curve">Charging Curve</option>
+                                </select>
+                            </div>
+                            <div className="flex gap-2 mt-2 flex-wrap items-center">
+                                <input
+                                    type="number"
+                                    placeholder="Scaling factor (blank = 1.0)"
+                                    value={newLinkScaling}
+                                    onChange={e => setNewLinkScaling(e.target.value)}
+                                    step="0.001"
+                                    min="0.001"
+                                    className="form-input text-sm flex-1 min-w-40"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={suggestEpaRatio}
+                                    disabled={!newLinkSourceId}
+                                    className="btn btn-secondary text-xs whitespace-nowrap disabled:opacity-40"
+                                    title="Auto-fill scaling from EPA range ratio (target ÷ source)"
+                                >
+                                    Suggest from EPA ratio
+                                </button>
+                                <input
+                                    type="text"
+                                    placeholder="Notes (optional)"
+                                    value={newLinkNotes}
+                                    onChange={e => setNewLinkNotes(e.target.value)}
+                                    className="form-input text-sm flex-1 min-w-40"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={handleAddSpecLink}
+                                    disabled={!newLinkSourceId || linkSaving}
+                                    className="btn btn-primary text-sm disabled:opacity-40"
+                                >
+                                    {linkSaving ? 'Adding…' : 'Add Link'}
+                                </button>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -56,11 +56,6 @@ export default function EditVehicleForm({
     // Manufacturer
     manufacturers = [],
     onAddManufacturer,
-    // Spec links
-    allVehicles = [],
-    onAddSpecLink,
-    onDeleteSpecLink,
-    isContributor = false,
 }) {
     const [imgSrc, setImgSrc] = useState('');
     const [crop, setCrop] = useState();
@@ -79,13 +74,6 @@ export default function EditVehicleForm({
     const [newMfgName, setNewMfgName] = useState('');
     const [newMfgCountry, setNewMfgCountry] = useState('');
     const [mfgSaving, setMfgSaving] = useState(false);
-
-    // Spec link "add" form local state
-    const [newLinkSourceId, setNewLinkSourceId] = useState('');
-    const [newLinkSpecType, setNewLinkSpecType] = useState('range_test');
-    const [newLinkScaling, setNewLinkScaling] = useState('');
-    const [newLinkNotes, setNewLinkNotes] = useState('');
-    const [linkSaving, setLinkSaving] = useState(false);
 
     const handleAddTrim = () => {
         if (!newTrimName.trim()) return;
@@ -165,42 +153,6 @@ export default function EditVehicleForm({
         }
     };
 
-    // ── Spec link handlers ────────────────────────────────────────────────────
-
-    const suggestEpaRatio = () => {
-        const src = allVehicles.find(v => v.id === parseInt(newLinkSourceId, 10));
-        const tgt = editingVehicle;
-        if (!src || !tgt) return;
-        const srcRange = parseFloat(src.range);
-        const tgtRange = parseFloat(tgt.range);
-        if (!srcRange || !tgtRange) return;
-        setNewLinkScaling((tgtRange / srcRange).toFixed(3));
-    };
-
-    const handleAddSpecLink = async () => {
-        if (!newLinkSourceId || !onAddSpecLink) return;
-        setLinkSaving(true);
-        try {
-            await onAddSpecLink({
-                targetVehicleId: editingVehicle.id,
-                sourceVehicleId: parseInt(newLinkSourceId, 10),
-                specType: newLinkSpecType,
-                scalingFactor: newLinkScaling ? parseFloat(newLinkScaling) : null,
-                notes: newLinkNotes.trim() || null,
-            });
-            setNewLinkSourceId('');
-            setNewLinkScaling('');
-            setNewLinkNotes('');
-        } finally {
-            setLinkSaving(false);
-        }
-    };
-
-    // Vehicles available as spec link sources (exclude current vehicle and inherited runs)
-    const linkableVehicles = allVehicles.filter(v => v.id !== editingVehicle?.id);
-
-    // Existing spec links on the editing vehicle
-    const existingLinks = editingVehicle?.spec_links || [];
 
     return (
         <>
@@ -412,115 +364,6 @@ export default function EditVehicleForm({
                             >
                                 Add
                             </button>
-                        </div>
-                    </div>
-                )}
-
-                {/* Inherited Test Data — edit mode + contributors/admins only */}
-                {editingId && isContributor && onAddSpecLink && (
-                    <div className="form-section mt-5">
-                        <label className="block font-medium mb-2">Inherited Test Data</label>
-                        <p className="text-xs text-gray-500 mb-3">
-                            Let this vehicle inherit range tests or charging curves from another vehicle,
-                            with an optional scaling factor applied to range data.
-                        </p>
-
-                        {/* Existing links */}
-                        {existingLinks.length > 0 && (
-                            <div className="spec-link-list mb-3">
-                                {existingLinks.map(link => {
-                                    const src = allVehicles.find(v => v.id === link.source_vehicle_id);
-                                    return (
-                                        <div key={link.id} className="spec-link-row">
-                                            <span className="spec-link-type-badge">
-                                                {link.spec_type === 'range_test' ? 'Range Test' : 'Charging Curve'}
-                                            </span>
-                                            <span className="text-sm text-gray-700 flex-1">
-                                                ← {src?.name || `Vehicle #${link.source_vehicle_id}`}
-                                            </span>
-                                            {link.scaling_factor != null && (
-                                                <span className="text-xs text-gray-500 font-mono">
-                                                    ×{link.scaling_factor}
-                                                </span>
-                                            )}
-                                            {link.notes && (
-                                                <span className="text-xs text-gray-400 italic truncate max-w-32" title={link.notes}>
-                                                    {link.notes}
-                                                </span>
-                                            )}
-                                            <button
-                                                type="button"
-                                                onClick={() => onDeleteSpecLink(link.id)}
-                                                className="text-gray-400 hover:text-red-500 transition text-xs ml-1"
-                                                title="Remove this link"
-                                            >
-                                                Remove
-                                            </button>
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        )}
-
-                        {/* Add new link */}
-                        <div className="spec-link-add-form">
-                            <div className="flex gap-2 flex-wrap">
-                                <select
-                                    value={newLinkSourceId}
-                                    onChange={e => setNewLinkSourceId(e.target.value)}
-                                    className="form-input text-sm flex-1 min-w-40"
-                                >
-                                    <option value="">Source vehicle…</option>
-                                    {linkableVehicles
-                                        .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-                                        .map(v => (
-                                            <option key={v.id} value={v.id}>{v.name}</option>
-                                        ))}
-                                </select>
-                                <select
-                                    value={newLinkSpecType}
-                                    onChange={e => setNewLinkSpecType(e.target.value)}
-                                    className="form-input text-sm"
-                                >
-                                    <option value="range_test">Range Test</option>
-                                    <option value="charging_curve">Charging Curve</option>
-                                </select>
-                            </div>
-                            <div className="flex gap-2 mt-2 flex-wrap items-center">
-                                <input
-                                    type="number"
-                                    placeholder="Scaling factor (blank = 1.0)"
-                                    value={newLinkScaling}
-                                    onChange={e => setNewLinkScaling(e.target.value)}
-                                    step="0.001"
-                                    min="0.001"
-                                    className="form-input text-sm flex-1 min-w-40"
-                                />
-                                <button
-                                    type="button"
-                                    onClick={suggestEpaRatio}
-                                    disabled={!newLinkSourceId}
-                                    className="btn btn-secondary text-xs whitespace-nowrap disabled:opacity-40"
-                                    title="Auto-fill scaling from EPA range ratio (target ÷ source)"
-                                >
-                                    Suggest from EPA ratio
-                                </button>
-                                <input
-                                    type="text"
-                                    placeholder="Notes (optional)"
-                                    value={newLinkNotes}
-                                    onChange={e => setNewLinkNotes(e.target.value)}
-                                    className="form-input text-sm flex-1 min-w-40"
-                                />
-                                <button
-                                    type="button"
-                                    onClick={handleAddSpecLink}
-                                    disabled={!newLinkSourceId || linkSaving}
-                                    className="btn btn-primary text-sm disabled:opacity-40"
-                                >
-                                    {linkSaving ? 'Adding…' : 'Add Link'}
-                                </button>
-                            </div>
                         </div>
                     </div>
                 )}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -499,10 +499,16 @@ export default function RoadTripView({
             if (missing.length === 0) return;
             setLoading(true);
             const updates = {};
+            const allRuns = vehicles.flatMap(v => v.runs || []);
             for (const runId of missing) {
                 try {
                     if (dataService.useSupabase) {
-                        updates[runId] = await dataService.getRunData(runId);
+                        const run = allRuns.find(r => String(r.id) === String(runId));
+                        if (run?._inherited) {
+                            updates[runId] = await dataService.getRunData(run._realRunId, run._scalingFactor ?? 1);
+                        } else {
+                            updates[runId] = await dataService.getRunData(runId);
+                        }
                     } else {
                         for (const v of vehicles) {
                             const run = v.runs?.find(r => r.id === runId);

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -105,7 +105,7 @@ function RunRow({ run, vehicle, isChecked, onToggle, onUpdateRunColor, renderRun
                 onChange={onToggle}
                 className="w-4 h-4 shrink-0"
             />
-            {onUpdateRunColor && (
+            {onUpdateRunColor && !run._inherited && (
                 <>
                     <input
                         type="color"

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -105,7 +105,7 @@ function RunRow({ run, vehicle, isChecked, onToggle, onUpdateRunColor, renderRun
                 onChange={onToggle}
                 className="w-4 h-4 shrink-0"
             />
-            {onUpdateRunColor && !run._inherited && (
+            {onUpdateRunColor && (
                 <>
                     <input
                         type="color"

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -167,14 +167,14 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, onAddTrim, onDeleteTrim, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
     const [showEditSpecs, setShowEditSpecs] = useState(false);
     const [showViewSpecs, setShowViewSpecs] = useState(false);
     const [vehicleFormData, setVehicleFormData] = useState({
-        name: '', make: '', model: '', year: '', battery: '', range: ''
+        name: '', make: '', model: '', year: '', battery: '', range: '', manufacturer_id: null,
     });
     const [vehicleFormTags, setVehicleFormTags] = useState([]);
     const [vehicleNewTagName, setVehicleNewTagName] = useState('');
@@ -188,6 +188,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             year: vehicle.year || '',
             battery: vehicle.battery || '',
             range: vehicle.range || '',
+            manufacturer_id: vehicle.manufacturer?.id ?? null,
         });
         setVehicleFormTags(vehicle.tags || []);
         setVehicleNewTagName('');
@@ -842,9 +843,11 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
 
     // ── Derived state ─────────────────────────────────────────────────────────
 
-    const availableFields = csvData?.meta.fields || [];
-    const displayRuns     = (vehicle.runs || []).filter(r => !committedDeletes.has(r.id));
-    const barVisible      = pendingDeletes.size > 0 || !!undoState;
+    const availableFields  = csvData?.meta.fields || [];
+    const allDisplayRuns   = (vehicle.runs || []).filter(r => !committedDeletes.has(r.id));
+    const displayRuns      = allDisplayRuns.filter(r => !r._inherited);
+    const inheritedRuns    = allDisplayRuns.filter(r => r._inherited);
+    const barVisible       = pendingDeletes.size > 0 || !!undoState;
 
     // ── Render ────────────────────────────────────────────────────────────────
 
@@ -940,7 +943,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                     >
                         {showUpload && uploadMode === 'create' ? 'Cancel' : '+ Add new record'}
                     </button>
-                    {vehicle.runs?.length > 0 && (
+                    {allDisplayRuns.length > 0 && (
                         <button
                             onClick={onViewChart}
                             className="btn btn-primary"
@@ -2021,9 +2024,55 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 })}
             </div>
 
-            {vehicle.runs?.length === 0 && !showUpload && (
+            {displayRuns.length === 0 && !showUpload && inheritedRuns.length === 0 && (
                 <div className="empty-state">
                     <p className="text-lg">No tests yet. Add a record to get started!</p>
+                </div>
+            )}
+
+            {/* ── Inherited Tests ───────────────────────────────────────────── */}
+            {inheritedRuns.length > 0 && (
+                <div className="mt-6">
+                    <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                        Inherited Tests
+                    </h3>
+                    <div className="space-y-2">
+                        {inheritedRuns.map(run => {
+                            const srcName = run._sourceVehicleName || `Vehicle #${run._sourceVehicleId}`;
+                            const sf = run._scalingFactor;
+                            const specLabel = run.has_range ? 'Range Test' : 'Charging Curve';
+                            return (
+                                <div key={run.id} className="card border border-dashed border-gray-300 bg-gray-50 flex items-center gap-3 px-4 py-3">
+                                    <span className="spec-link-type-badge flex-shrink-0">{specLabel}</span>
+                                    <span className="text-sm text-gray-700 flex-1 min-w-0 truncate">
+                                        Inherited from: <span className="font-medium">{srcName}</span>
+                                    </span>
+                                    {sf !== 1 && sf != null && (
+                                        <span className="text-xs font-mono text-gray-500 flex-shrink-0">×{sf}</span>
+                                    )}
+                                    <span className="text-xs bg-amber-100 text-amber-700 border border-amber-300 rounded-full px-2 py-0.5 flex-shrink-0">
+                                        Estimated
+                                    </span>
+                                    <button
+                                        onClick={() => onViewChart && onViewChart()}
+                                        className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700 hover:bg-blue-100 transition flex-shrink-0"
+                                        title="View this run in the chart"
+                                    >
+                                        View Chart →
+                                    </button>
+                                    {isContributor && (
+                                        <button
+                                            onClick={() => deleteSpecLink(run._specLinkId)}
+                                            className="text-xs text-gray-400 hover:text-red-500 transition flex-shrink-0"
+                                            title="Remove this inherited link"
+                                        >
+                                            Remove Link
+                                        </button>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
                 </div>
             )}
 
@@ -2086,6 +2135,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                             onImageReady={handleVehicleImageReady}
                             onSubmit={handleVehicleSubmit}
                             onCancel={closeEditVehicle}
+                            manufacturers={manufacturers}
+                            onAddManufacturer={addManufacturer}
+                            allVehicles={vehicles || []}
+                            onAddSpecLink={addSpecLink}
+                            onDeleteSpecLink={deleteSpecLink}
+                            isContributor={isContributor}
                         />
                     </div>
                 </div>

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -260,6 +260,14 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     const [noHeaders, setNoHeaders]                   = useState(false);
     const [selectedRangeTestRunId, setSelectedRangeTestRunId] = useState(null);
 
+    // ── Inherited test link form state ────────────────────────────────────────
+    const [showAddLink, setShowAddLink]     = useState(false);
+    const [newLinkSpecType, setNewLinkSpecType] = useState('range_test');
+    const [newLinkSourceId, setNewLinkSourceId] = useState('');
+    const [newLinkScaling, setNewLinkScaling]   = useState('');
+    const [newLinkNotes, setNewLinkNotes]       = useState('');
+    const [linkSaving, setLinkSaving]           = useState(false);
+
     // ── Inline data-table state (edit mode) ──────────────────────────────────
     const [editData, setEditData]               = useState(null);   // null=not fetched, []=loaded
     const [editDataLoading, setEditDataLoading] = useState(false);
@@ -2031,48 +2039,177 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             )}
 
             {/* ── Inherited Tests ───────────────────────────────────────────── */}
-            {inheritedRuns.length > 0 && (
+            {(inheritedRuns.length > 0 || (isContributor && canEdit(vehicle))) && (
                 <div className="mt-6">
-                    <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                        Inherited Tests
-                    </h3>
-                    <div className="space-y-2">
-                        {inheritedRuns.map(run => {
-                            const srcName = run._sourceVehicleName || `Vehicle #${run._sourceVehicleId}`;
-                            const sf = run._scalingFactor;
-                            const specLabel = run.has_range ? 'Range Test' : 'Charging Curve';
-                            return (
-                                <div key={run.id} className="card border border-dashed border-gray-300 bg-gray-50 flex items-center gap-3 px-4 py-3">
-                                    <span className="spec-link-type-badge flex-shrink-0">{specLabel}</span>
-                                    <span className="text-sm text-gray-700 flex-1 min-w-0 truncate">
-                                        Inherited from: <span className="font-medium">{srcName}</span>
-                                    </span>
-                                    {sf !== 1 && sf != null && (
-                                        <span className="text-xs font-mono text-gray-500 flex-shrink-0">×{sf}</span>
-                                    )}
-                                    <span className="text-xs bg-amber-100 text-amber-700 border border-amber-300 rounded-full px-2 py-0.5 flex-shrink-0">
-                                        Estimated
-                                    </span>
-                                    <button
-                                        onClick={() => onViewChart && onViewChart()}
-                                        className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700 hover:bg-blue-100 transition flex-shrink-0"
-                                        title="View this run in the chart"
-                                    >
-                                        View Chart →
-                                    </button>
-                                    {isContributor && (
-                                        <button
-                                            onClick={() => deleteSpecLink(run._specLinkId)}
-                                            className="text-xs text-gray-400 hover:text-red-500 transition flex-shrink-0"
-                                            title="Remove this inherited link"
-                                        >
-                                            Remove Link
-                                        </button>
-                                    )}
-                                </div>
-                            );
-                        })}
+                    <div className="flex items-center gap-3 mb-3">
+                        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">
+                            Inherited Tests
+                        </h3>
+                        {isContributor && canEdit(vehicle) && !showAddLink && (
+                            <button
+                                onClick={() => setShowAddLink(true)}
+                                className="text-xs px-2 py-1 rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition"
+                            >
+                                + Add Inherited Link
+                            </button>
+                        )}
                     </div>
+
+                    {/* Existing inherited runs */}
+                    {inheritedRuns.length > 0 && (
+                        <div className="space-y-2 mb-3">
+                            {inheritedRuns.map(run => {
+                                const srcName = run._sourceVehicleName || `Vehicle #${run._sourceVehicleId}`;
+                                const sf = run._scalingFactor;
+                                const specLabel = run.has_range ? 'Range Test' : 'Charging Curve';
+                                return (
+                                    <div key={run.id} className="card border border-dashed border-gray-300 bg-gray-50 flex items-center gap-3 px-4 py-3">
+                                        <span className="spec-link-type-badge flex-shrink-0">{specLabel}</span>
+                                        <span className="text-sm text-gray-700 flex-1 min-w-0 truncate">
+                                            Inherited from: <span className="font-medium">{srcName}</span>
+                                        </span>
+                                        {sf !== 1 && sf != null && (
+                                            <span className="text-xs font-mono text-gray-500 flex-shrink-0">×{sf}</span>
+                                        )}
+                                        <span className="text-xs bg-amber-100 text-amber-700 border border-amber-300 rounded-full px-2 py-0.5 flex-shrink-0">
+                                            Estimated
+                                        </span>
+                                        <button
+                                            onClick={() => onViewChart && onViewChart()}
+                                            className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700 hover:bg-blue-100 transition flex-shrink-0"
+                                        >
+                                            View Chart →
+                                        </button>
+                                        {isContributor && canEdit(vehicle) && (
+                                            <button
+                                                onClick={() => deleteSpecLink(run._specLinkId)}
+                                                className="text-xs text-gray-400 hover:text-red-500 transition flex-shrink-0"
+                                            >
+                                                Remove
+                                            </button>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    {/* Add link form */}
+                    {showAddLink && (() => {
+                        // Only show vehicles that have runs of the selected spec type
+                        const hasRelevantRuns = (v) => newLinkSpecType === 'range_test'
+                            ? v.runs?.some(r => !r._inherited && (r.has_range ?? false))
+                            : v.runs?.some(r => !r._inherited && (r.has_charging ?? true));
+                        // Exclude current vehicle and any already-linked source for this type
+                        const alreadyLinkedIds = new Set(
+                            (vehicle.spec_links || [])
+                                .filter(l => l.spec_type === newLinkSpecType)
+                                .map(l => Number(l.source_vehicle_id))
+                        );
+                        const sourceVehicles = (vehicles || [])
+                            .filter(v => Number(v.id) !== Number(vehicle.id) && hasRelevantRuns(v) && !alreadyLinkedIds.has(Number(v.id)))
+                            .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+                        const suggestEpaRatio = () => {
+                            const src = (vehicles || []).find(v => Number(v.id) === parseInt(newLinkSourceId, 10));
+                            if (!src) return;
+                            const srcRange = parseFloat(src.range);
+                            const tgtRange = parseFloat(vehicle.range);
+                            if (srcRange && tgtRange) setNewLinkScaling((tgtRange / srcRange).toFixed(3));
+                        };
+
+                        const handleAdd = async () => {
+                            if (!newLinkSourceId) return;
+                            setLinkSaving(true);
+                            try {
+                                await addSpecLink({
+                                    targetVehicleId: vehicle.id,
+                                    sourceVehicleId: parseInt(newLinkSourceId, 10),
+                                    specType: newLinkSpecType,
+                                    scalingFactor: newLinkScaling ? parseFloat(newLinkScaling) : null,
+                                    notes: newLinkNotes.trim() || null,
+                                });
+                                setNewLinkSourceId('');
+                                setNewLinkScaling('');
+                                setNewLinkNotes('');
+                                setShowAddLink(false);
+                            } finally {
+                                setLinkSaving(false);
+                            }
+                        };
+
+                        return (
+                            <div className="spec-link-add-form">
+                                <div className="flex gap-2 flex-wrap">
+                                    <select
+                                        value={newLinkSpecType}
+                                        onChange={e => { setNewLinkSpecType(e.target.value); setNewLinkSourceId(''); }}
+                                        className="form-input text-sm"
+                                    >
+                                        <option value="range_test">Range Test</option>
+                                        <option value="charging_curve">Charging Curve</option>
+                                    </select>
+                                    <select
+                                        value={newLinkSourceId}
+                                        onChange={e => setNewLinkSourceId(e.target.value)}
+                                        className="form-input text-sm flex-1 min-w-48"
+                                    >
+                                        <option value="">Source vehicle…</option>
+                                        {sourceVehicles.map(v => (
+                                            <option key={v.id} value={v.id}>{v.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                {sourceVehicles.length === 0 && (
+                                    <p className="text-xs text-gray-400 mt-1">
+                                        No other vehicles have {newLinkSpecType === 'range_test' ? 'range test' : 'charging curve'} data.
+                                    </p>
+                                )}
+                                <div className="flex gap-2 mt-2 flex-wrap items-center">
+                                    <input
+                                        type="number"
+                                        placeholder="Scaling factor (blank = 1.0)"
+                                        value={newLinkScaling}
+                                        onChange={e => setNewLinkScaling(e.target.value)}
+                                        step="0.001"
+                                        min="0.001"
+                                        className="form-input text-sm w-52"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={suggestEpaRatio}
+                                        disabled={!newLinkSourceId}
+                                        className="btn btn-secondary text-xs whitespace-nowrap disabled:opacity-40"
+                                        title="Auto-fill from EPA range ratio (target ÷ source)"
+                                    >
+                                        Suggest from EPA
+                                    </button>
+                                    <input
+                                        type="text"
+                                        placeholder="Notes (optional)"
+                                        value={newLinkNotes}
+                                        onChange={e => setNewLinkNotes(e.target.value)}
+                                        className="form-input text-sm flex-1 min-w-40"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={handleAdd}
+                                        disabled={!newLinkSourceId || linkSaving}
+                                        className="btn btn-primary text-sm disabled:opacity-40"
+                                    >
+                                        {linkSaving ? 'Adding…' : 'Add Link'}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowAddLink(false)}
+                                        className="btn btn-secondary text-sm"
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        );
+                    })()}
                 </div>
             )}
 
@@ -2137,10 +2274,6 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                             onCancel={closeEditVehicle}
                             manufacturers={manufacturers}
                             onAddManufacturer={addManufacturer}
-                            allVehicles={vehicles || []}
-                            onAddSpecLink={addSpecLink}
-                            onDeleteSpecLink={deleteSpecLink}
-                            isContributor={isContributor}
                         />
                     </div>
                 </div>

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -167,7 +167,7 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, onAddTrim, onDeleteTrim, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -267,6 +267,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     const [newLinkScaling, setNewLinkScaling]   = useState('');
     const [newLinkNotes, setNewLinkNotes]       = useState('');
     const [linkSaving, setLinkSaving]           = useState(false);
+    // linkId -> string (local edit value for scaling factor)
+    const [scalingEdits, setScalingEdits]       = useState({});
 
     // ── Inline data-table state (edit mode) ──────────────────────────────────
     const [editData, setEditData]               = useState(null);   // null=not fetched, []=loaded
@@ -2062,14 +2064,43 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                 const srcName = run._sourceVehicleName || `Vehicle #${run._sourceVehicleId}`;
                                 const sf = run._scalingFactor;
                                 const specLabel = run.has_range ? 'Range Test' : 'Charging Curve';
+                                const linkId = run._specLinkId;
+                                const editVal = scalingEdits[linkId] ?? (sf != null ? String(sf) : '');
+                                const saveScaling = async () => {
+                                    const newSf = editVal === '' ? null : parseFloat(editVal);
+                                    const unchanged = newSf === (sf ?? null);
+                                    if (unchanged) return;
+                                    try {
+                                        await updateSpecLink(linkId, { scalingFactor: newSf });
+                                        setScalingEdits(prev => { const n = { ...prev }; delete n[linkId]; return n; });
+                                    } catch (_) { /* error shown by context */ }
+                                };
                                 return (
                                     <div key={run.id} className="card border border-dashed border-gray-300 bg-gray-50 flex items-center gap-3 px-4 py-3">
                                         <span className="spec-link-type-badge flex-shrink-0">{specLabel}</span>
                                         <span className="text-sm text-gray-700 flex-1 min-w-0 truncate">
                                             Inherited from: <span className="font-medium">{srcName}</span>
                                         </span>
-                                        {sf !== 1 && sf != null && (
-                                            <span className="text-xs font-mono text-gray-500 flex-shrink-0">×{sf}</span>
+                                        {isContributor && canEdit(vehicle) ? (
+                                            <label className="flex items-center gap-1 text-xs text-gray-500 flex-shrink-0">
+                                                <span>×</span>
+                                                <input
+                                                    type="number"
+                                                    value={editVal}
+                                                    onChange={e => setScalingEdits(prev => ({ ...prev, [linkId]: e.target.value }))}
+                                                    onBlur={saveScaling}
+                                                    onKeyDown={e => { if (e.key === 'Enter') { e.target.blur(); } }}
+                                                    step="0.001"
+                                                    min="0.001"
+                                                    placeholder="1.0"
+                                                    className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-gray-700"
+                                                    title="Scaling factor (blank = 1.0)"
+                                                />
+                                            </label>
+                                        ) : (
+                                            sf !== 1 && sf != null && (
+                                                <span className="text-xs font-mono text-gray-500 flex-shrink-0">×{sf}</span>
+                                            )
                                         )}
                                         <span className="text-xs bg-amber-100 text-amber-700 border border-amber-300 rounded-full px-2 py-0.5 flex-shrink-0">
                                             Estimated
@@ -2082,7 +2113,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         </button>
                                         {isContributor && canEdit(vehicle) && (
                                             <button
-                                                onClick={() => deleteSpecLink(run._specLinkId)}
+                                                onClick={() => deleteSpecLink(linkId)}
                                                 className="text-xs text-gray-400 hover:text-red-500 transition flex-shrink-0"
                                             >
                                                 Remove

--- a/src/components/SpecsChartView.jsx
+++ b/src/components/SpecsChartView.jsx
@@ -1,84 +1,11 @@
 import { useEffect, useRef, useState, useMemo } from 'react';
 import Chart from 'chart.js/auto';
-import { SPEC_CATEGORIES, formatCustomKey } from '../utils/vehicleSpecSchema';
 import { useAppContext } from '../context/AppContext';
-import { convValue, formatSpecValue, distanceLabel } from '../utils/unitConversions';
-
-// ── Field definitions ─────────────────────────────────────────────────────────
-
-const VEHICLE_FIELDS = [
-    { key: 'vehicle.year',    label: 'Year',          type: 'integer' },
-    { key: 'vehicle.battery', label: 'Battery (kWh)', type: 'number'  },
-    { key: 'vehicle.range',   label: 'EPA Range',     type: 'number', unitGroup: 'distance' },
-];
-
-function buildFieldGroups(vehicles, vehicleFields) {
-    const catCustomKeys = {};
-    for (const v of vehicles) {
-        if (!v.specs) continue;
-        for (const cat of SPEC_CATEGORIES) {
-            const custom = v.specs[cat.key]?._custom || {};
-            if (!catCustomKeys[cat.key]) catCustomKeys[cat.key] = new Set();
-            for (const ck of Object.keys(custom)) catCustomKeys[cat.key].add(ck);
-        }
-    }
-
-    const groups = [{ groupLabel: 'Vehicle', fields: vehicleFields }];
-    for (const cat of SPEC_CATEGORIES) {
-        const customKeys = [...(catCustomKeys[cat.key] || new Set())];
-        const fields = [
-            ...cat.fields.map(f => ({ key: `${cat.key}.${f.key}`, label: f.label, type: f.type, unitGroup: f.unitGroup })),
-            ...customKeys.map(ck => ({ key: `${cat.key}._custom.${ck}`, label: formatCustomKey(ck), type: 'text' })),
-        ];
-        if (fields.length) groups.push({ groupLabel: cat.label, fields });
-    }
-    return groups;
-}
-
-function getFieldDef(fieldKey) {
-    if (fieldKey.startsWith('vehicle.')) {
-        return VEHICLE_FIELDS.find(f => f.key === fieldKey) || { type: 'number' };
-    }
-    const [catKey, sub] = fieldKey.split('.');
-    if (sub === '_custom') return { type: 'text' };
-    const cat = SPEC_CATEGORIES.find(c => c.key === catKey);
-    return cat?.fields.find(f => f.key === sub) || { type: 'text' };
-}
-
-function extractValue(vehicle, fieldKey) {
-    if (fieldKey.startsWith('vehicle.')) return vehicle[fieldKey.split('.')[1]] ?? null;
-    const [catKey, sub, customKey] = fieldKey.split('.');
-    const catData = vehicle.specs?.[catKey];
-    if (!catData) return null;
-    if (sub === '_custom') return catData._custom?.[customKey] ?? null;
-    return catData[sub] ?? null;
-}
-
-function detectMode(vehicles, fieldKey, fieldDef) {
-    if (fieldDef?.type === 'boolean') return 'boolean';
-    const vals = vehicles
-        .map(v => extractValue(v, fieldKey))
-        .filter(v => v !== null && v !== undefined && v !== '');
-    if (!vals.length) return 'numeric';
-    if (vals.every(v => !isNaN(parseFloat(String(v))))) return 'numeric';
-    return 'categorical';
-}
-
-function formatNumericLabel(n) {
-    if (n === null || n === undefined) return '—';
-    return Number.isInteger(n) ? String(n) : parseFloat(n.toFixed(2)).toString();
-}
-
-// ── Color palette ─────────────────────────────────────────────────────────────
-
-const PALETTE = [
-    '#6366f1', '#f59e0b', '#10b981', '#ef4444',
-    '#3b82f6', '#a855f7', '#ec4899', '#14b8a6',
-];
-
-function vehicleColor(vehicle, idx) {
-    return vehicle.color || PALETTE[idx % PALETTE.length];
-}
+import { convValue, formatSpecValue } from '../utils/unitConversions';
+import {
+    makeVehicleFields, buildFieldGroups, getFieldDef, extractValue,
+    detectMode, formatNumericLabel, vehicleColor,
+} from '../utils/specHelpers';
 
 // ── Inside-bar label afterDraw plugin ─────────────────────────────────────────
 
@@ -118,11 +45,7 @@ function makeInsideLabelPlugin(getLabelFn) {
 export default function SpecsChartView({ vehicles, selectedField: controlledField = null, onFieldChange }) {
     const { units } = useAppContext();
 
-    const vehicleFields = useMemo(() => [
-        VEHICLE_FIELDS[0],
-        VEHICLE_FIELDS[1],
-        { ...VEHICLE_FIELDS[2], label: `EPA Range (${distanceLabel(units)})` },
-    ], [units]);
+    const vehicleFields = useMemo(() => makeVehicleFields(units), [units]);
 
     const fieldGroups = useMemo(() => buildFieldGroups(vehicles, vehicleFields), [vehicles, vehicleFields]);
     const allFields   = useMemo(() => fieldGroups.flatMap(g => g.fields), [fieldGroups]);
@@ -154,7 +77,7 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
     useEffect(() => {
         if (!selectedField || !canvasRef.current || !vehicles.length) return;
 
-        const fieldDef  = allFields.find(f => f.key === selectedField) || getFieldDef(selectedField);
+        const fieldDef  = allFields.find(f => f.key === selectedField) || getFieldDef(selectedField, vehicleFields);
         const mode      = detectMode(vehicles, selectedField, fieldDef);
         const rawValues = vehicles.map(v => extractValue(v, selectedField));
         const labels    = vehicles.map(v => v.name);

--- a/src/components/SpecsScatterView.jsx
+++ b/src/components/SpecsScatterView.jsx
@@ -1,0 +1,280 @@
+import { useEffect, useRef, useState, useMemo } from 'react';
+import Chart from 'chart.js/auto';
+import { useAppContext } from '../context/AppContext';
+import { convValue, formatSpecValue } from '../utils/unitConversions';
+import {
+    makeVehicleFields, buildFieldGroups, getFieldDef, extractValue,
+    vehicleColor, formatNumericLabel,
+} from '../utils/specHelpers';
+
+// ── Linear regression ─────────────────────────────────────────────────────────
+
+function linearRegression(points) {
+    const n = points.length;
+    if (n < 2) return null;
+    const sumX  = points.reduce((s, p) => s + p.x, 0);
+    const sumY  = points.reduce((s, p) => s + p.y, 0);
+    const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+    const sumX2 = points.reduce((s, p) => s + p.x * p.x, 0);
+    const denom = n * sumX2 - sumX * sumX;
+    if (denom === 0) return null;
+    const slope     = (n * sumXY - sumX * sumY) / denom;
+    const intercept = (sumY - slope * sumX) / n;
+    return { slope, intercept };
+}
+
+// ── Vehicle name point-label plugin ──────────────────────────────────────────
+
+const pointLabelPlugin = {
+    id: 'pointLabels',
+    afterDatasetsDraw(chart) {
+        const ctx = chart.ctx;
+        // Last dataset is the trend line — skip it
+        const vehicleDatasets = chart.data.datasets.length - 1;
+        for (let di = 0; di < vehicleDatasets; di++) {
+            const pts = chart.getDatasetMeta(di).data;
+            if (!pts.length) continue;
+            const pt = pts[0];
+            ctx.save();
+            ctx.font = '11px system-ui, sans-serif';
+            ctx.fillStyle = '#6b7280';
+            ctx.textBaseline = 'middle';
+            const x = pt.x + 10;
+            const y = pt.y;
+            const maxW = chart.chartArea.right - x - 4;
+            if (maxW > 20) {
+                let text = chart.data.datasets[di].label;
+                while (text.length > 1 && ctx.measureText(text).width > maxW) {
+                    text = text.slice(0, -1);
+                }
+                if (text !== chart.data.datasets[di].label) text += '…';
+                ctx.fillText(text, x, y);
+            }
+            ctx.restore();
+        }
+    },
+};
+
+// ── SpecsScatterView ──────────────────────────────────────────────────────────
+
+export default function SpecsScatterView({ vehicles, xField: xProp, yField: yProp, onFieldChange }) {
+    const { units } = useAppContext();
+
+    const vehicleFields = useMemo(() => makeVehicleFields(units), [units]);
+    const fieldGroups   = useMemo(() => buildFieldGroups(vehicles, vehicleFields), [vehicles, vehicleFields]);
+
+    // Numeric-only field groups (scatter only makes sense for numeric data)
+    const numericGroups = useMemo(() =>
+        fieldGroups
+            .map(g => ({ ...g, fields: g.fields.filter(f => f.type === 'number' || f.type === 'integer') }))
+            .filter(g => g.fields.length > 0),
+        [fieldGroups],
+    );
+    const allNumericFields = useMemo(() => numericGroups.flatMap(g => g.fields), [numericGroups]);
+
+    const [localX, setLocalX] = useState('');
+    const [localY, setLocalY] = useState('');
+    const [copiedUrl, setCopiedUrl] = useState(false);
+
+    const xField = xProp || localX;
+    const yField = yProp || localY;
+
+    const setFields = (x, y) => {
+        setLocalX(x);
+        setLocalY(y);
+        onFieldChange?.(x, y);
+    };
+
+    // Auto-select first two numeric fields that have data
+    useEffect(() => {
+        if (xField && yField) return;
+        const withData = allNumericFields.filter(f =>
+            vehicles.some(v => {
+                const val = extractValue(v, f.key);
+                return val !== null && val !== undefined && val !== '';
+            }),
+        );
+        const newX = xField || withData[0]?.key || '';
+        const newY = yField || withData[1]?.key || withData[0]?.key || '';
+        if (newX !== xField || newY !== yField) setFields(newX, newY);
+    }, [allNumericFields, vehicles]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const canvasRef = useRef(null);
+    const chartRef  = useRef(null);
+
+    useEffect(() => {
+        if (!xField || !yField || !canvasRef.current || !vehicles.length) return;
+
+        const xDef = allNumericFields.find(f => f.key === xField) || getFieldDef(xField, vehicleFields);
+        const yDef = allNumericFields.find(f => f.key === yField) || getFieldDef(yField, vehicleFields);
+
+        const xLabel = allNumericFields.find(f => f.key === xField)?.label || xField;
+        const yLabel = allNumericFields.find(f => f.key === yField)?.label || yField;
+
+        // Convert raw values to display values
+        const toNum = (raw, def) => {
+            if (raw === null || raw === undefined || raw === '') return null;
+            const n = parseFloat(String(raw));
+            if (isNaN(n)) return null;
+            return def.unitGroup ? convValue(n, def.unitGroup, units) : n;
+        };
+
+        const formatVal = (raw, def) => {
+            if (raw === null || raw === undefined || raw === '') return '—';
+            if (def.unitGroup) return formatSpecValue(raw, def.unitGroup, units);
+            return formatNumericLabel(parseFloat(String(raw)));
+        };
+
+        // Build per-vehicle datasets (one point each)
+        const vehicleDatasets = vehicles.map((v, i) => {
+            const rawX = extractValue(v, xField);
+            const rawY = extractValue(v, yField);
+            const numX = toNum(rawX, xDef);
+            const numY = toNum(rawY, yDef);
+            const color = vehicleColor(v, i);
+            return {
+                label:           v.name,
+                data:            numX != null && numY != null ? [{ x: numX, y: numY }] : [],
+                backgroundColor: color,
+                borderColor:     color,
+                pointRadius:     8,
+                pointHoverRadius: 11,
+                // Store raw values for tooltip
+                _rawX: rawX,
+                _rawY: rawY,
+            };
+        });
+
+        // Compute trend line across all vehicles that have both values
+        const scatterPts = vehicleDatasets
+            .filter(ds => ds.data.length > 0)
+            .map(ds => ds.data[0]);
+
+        const reg = linearRegression(scatterPts);
+        let trendData = [];
+        if (reg && scatterPts.length >= 2) {
+            const xVals = scatterPts.map(p => p.x);
+            const xMin  = Math.min(...xVals);
+            const xMax  = Math.max(...xVals);
+            trendData = [
+                { x: xMin, y: reg.slope * xMin + reg.intercept },
+                { x: xMax, y: reg.slope * xMax + reg.intercept },
+            ];
+        }
+
+        const trendDataset = {
+            label:       'Trend',
+            data:        trendData,
+            type:        'line',
+            borderColor: 'rgba(156,163,175,0.6)',
+            borderWidth: 1.5,
+            borderDash:  [5, 4],
+            pointRadius: 0,
+            fill:        false,
+            tension:     0,
+        };
+
+        if (chartRef.current) {
+            chartRef.current.destroy();
+            chartRef.current = null;
+        }
+
+        chartRef.current = new Chart(canvasRef.current, {
+            type: 'scatter',
+            data: { datasets: [...vehicleDatasets, trendDataset] },
+            options: {
+                animation: false,
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        position: 'top',
+                        labels: {
+                            boxWidth: 10,
+                            padding: 10,
+                            filter: item => item.text !== 'Trend',
+                        },
+                    },
+                    tooltip: {
+                        filter: item => item.dataset.label !== 'Trend',
+                        callbacks: {
+                            title: ctx => ctx[0]?.dataset.label || '',
+                            label: ctx => {
+                                const ds = ctx.dataset;
+                                return [
+                                    `${xLabel}: ${formatVal(ds._rawX, xDef)}`,
+                                    `${yLabel}: ${formatVal(ds._rawY, yDef)}`,
+                                ];
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    x: { title: { display: true, text: xLabel, font: { size: 12 } } },
+                    y: { title: { display: true, text: yLabel, font: { size: 12 } } },
+                },
+            },
+            plugins: [pointLabelPlugin],
+        });
+
+        return () => {
+            chartRef.current?.destroy();
+            chartRef.current = null;
+        };
+    }, [xField, yField, vehicles, allNumericFields, vehicleFields, units]);
+
+    return (
+        <div className="specs-chart-card">
+            <div className="specs-chart-controls">
+                <label className="text-sm font-medium text-gray-600">X-Axis:</label>
+                <select
+                    className="specs-chart-field-select"
+                    value={xField}
+                    onChange={e => setFields(e.target.value, yField)}
+                >
+                    {numericGroups.map(group => (
+                        <optgroup key={group.groupLabel} label={group.groupLabel}>
+                            {group.fields.map(f => (
+                                <option key={f.key} value={f.key}>{f.label}</option>
+                            ))}
+                        </optgroup>
+                    ))}
+                </select>
+
+                <label className="text-sm font-medium text-gray-600 ml-3">Y-Axis:</label>
+                <select
+                    className="specs-chart-field-select"
+                    value={yField}
+                    onChange={e => setFields(xField, e.target.value)}
+                >
+                    {numericGroups.map(group => (
+                        <optgroup key={group.groupLabel} label={group.groupLabel}>
+                            {group.fields.map(f => (
+                                <option key={f.key} value={f.key}>{f.label}</option>
+                            ))}
+                        </optgroup>
+                    ))}
+                </select>
+            </div>
+
+            <div style={{ height: `${Math.max(400, vehicles.length * 40)}px`, position: 'relative' }}>
+                <canvas ref={canvasRef} />
+            </div>
+
+            <div className="mt-3 flex gap-2">
+                <button
+                    onClick={() => {
+                        navigator.clipboard.writeText(window.location.href).then(() => {
+                            setCopiedUrl(true);
+                            setTimeout(() => setCopiedUrl(false), 2000);
+                        });
+                    }}
+                    className={`chart-copy-btn ${copiedUrl ? 'bg-green-50 border-green-200 text-green-700' : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'}`}
+                    title="Copy link to this chart view"
+                >
+                    {copiedUrl ? '✓ Copied!' : '🔗 Copy URL'}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -185,9 +185,18 @@ export default function VehiclesView({
 
     // Stage 3: text filter
     const textLower = textFilter.trim().toLowerCase();
-    const textFiltered = !textLower ? mfgFiltered : mfgFiltered.filter(v =>
-        [v.name, v.make, v.model, String(v.year || '')].some(f => (f || '').toLowerCase().includes(textLower))
-    );
+    const textFiltered = !textLower ? mfgFiltered : mfgFiltered.filter(v => {
+        if ([v.name, v.make, v.model].some(f => (f || '').toLowerCase().includes(textLower))) return true;
+        const year = String(v.year || '');
+        if (year.toLowerCase().includes(textLower)) return true;
+        // Range match: "2022-2024" should match a search for "2023"
+        const queryNum = parseInt(textLower, 10);
+        if (!isNaN(queryNum) && /^\d{4}\s*[-–]\s*\d{4}$/.test(year)) {
+            const parts = year.split(/[-–]/).map(s => parseInt(s.trim(), 10));
+            if (parts.length === 2) return queryNum >= parts[0] && queryNum <= parts[1];
+        }
+        return false;
+    });
 
     // Stage 3: sort
     const sortedFilteredVehicles = [...textFiltered].sort((a, b) => {
@@ -336,11 +345,6 @@ export default function VehiclesView({
         // Manufacturer
         manufacturers,
         onAddManufacturer: addManufacturer,
-        // Spec links
-        allVehicles: vehicles,
-        onAddSpecLink: addSpecLink,
-        onDeleteSpecLink: deleteSpecLink,
-        isContributor,
     };
 
     const handleMoveVehicle = (vehicleId, direction) => {

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -39,8 +39,9 @@ export default function VehiclesView({
     const [editingId, setEditingId] = useState(null);
     const [formData, setFormData] = useState({
         name: '', make: '', model: '', year: '',
-        battery: '', range: ''
+        battery: '', range: '', manufacturer_id: null,
     });
+    const [mfgFilter, setMfgFilter] = useState(new Set());
     const [formTags, setFormTags] = useState([]);
     const [newTagName, setNewTagName] = useState('');
     const [tagFilterStates, setTagFilterStates] = useState({}); // { [tagId]: 'or' | 'and' | 'not' }
@@ -57,7 +58,7 @@ export default function VehiclesView({
     const [specsViewingVehicle, setSpecsViewingVehicle] = useState(null);
     const VEHICLES_PER_PAGE = 24;
 
-    const { units } = useAppContext();
+    const { units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink } = useAppContext();
 
     const {
         pendingDeletes, committedDeletes, undoState, secondsLeft,
@@ -81,7 +82,7 @@ export default function VehiclesView({
             onAdd(formData);
         }
         setFormTags([]);
-        setFormData({ name: '', make: '', model: '', year: '', battery: '', range: '' });
+        setFormData({ name: '', make: '', model: '', year: '', battery: '', range: '', manufacturer_id: null });
         setShowForm(false);
     };
 
@@ -94,6 +95,7 @@ export default function VehiclesView({
             year: vehicle.year || '',
             battery: vehicle.battery || '',
             range: vehicle.range || '',
+            manufacturer_id: vehicle.manufacturer?.id ?? null,
         });
         setFormTags(vehicle.tags || []);
         setEditingId(vehicle.id);
@@ -105,7 +107,7 @@ export default function VehiclesView({
         setEditingId(null);
         setFormTags([]);
         setNewTagName('');
-        setFormData({ name: '', make: '', model: '', year: '', battery: '', range: '' });
+        setFormData({ name: '', make: '', model: '', year: '', battery: '', range: '', manufacturer_id: null });
     };
 
     const handleDuplicateVehicle = async (vehicle, e) => {
@@ -176,9 +178,14 @@ export default function VehiclesView({
         return true;
     }).filter(v => !committedDeletes.has(v.id));
 
-    // Stage 2: text filter
+    // Stage 2: manufacturer filter
+    const mfgFiltered = mfgFilter.size === 0 ? tagFiltered : tagFiltered.filter(v =>
+        v.manufacturer?.id != null ? mfgFilter.has(v.manufacturer.id) : false
+    );
+
+    // Stage 3: text filter
     const textLower = textFilter.trim().toLowerCase();
-    const textFiltered = !textLower ? tagFiltered : tagFiltered.filter(v =>
+    const textFiltered = !textLower ? mfgFiltered : mfgFiltered.filter(v =>
         [v.name, v.make, v.model, String(v.year || '')].some(f => (f || '').toLowerCase().includes(textLower))
     );
 
@@ -202,6 +209,12 @@ export default function VehiclesView({
             case 'model_za':    return (b.model || '').localeCompare(a.model || '');
             case 'year_newest': return Number(b.year || 0) - Number(a.year || 0);
             case 'year_oldest': return Number(a.year || 0) - Number(b.year || 0);
+            case 'mfg_az': {
+                const aMfg = a.manufacturer?.name || a.make || '';
+                const bMfg = b.manufacturer?.name || b.make || '';
+                const mfgCmp = aMfg.localeCompare(bMfg);
+                return mfgCmp !== 0 ? mfgCmp : (a.name || '').localeCompare(b.name || '');
+            }
             default: return 0;
         }
     });
@@ -320,6 +333,14 @@ export default function VehiclesView({
         onRemoveTrim: (trimId) => onDeleteTrim(editingId, trimId),
         imageUploading, onImageReady: handleImageReady,
         onSubmit: handleSubmit, onCancel: handleCancel,
+        // Manufacturer
+        manufacturers,
+        onAddManufacturer: addManufacturer,
+        // Spec links
+        allVehicles: vehicles,
+        onAddSpecLink: addSpecLink,
+        onDeleteSpecLink: deleteSpecLink,
+        isContributor,
     };
 
     const handleMoveVehicle = (vehicleId, direction) => {
@@ -389,7 +410,7 @@ export default function VehiclesView({
     };
 
     // Reset to page 1 when filter/sort changes
-    useEffect(() => { setVehiclePage(1); }, [textFilter, tagFilterStates, sortBy]);
+    useEffect(() => { setVehiclePage(1); }, [textFilter, tagFilterStates, sortBy, mfgFilter]);
 
     const showReorderButtons = canEdit({}) && sortBy === 'default'
         && textFilter.trim() === '' && Object.keys(tagFilterStates).length === 0
@@ -456,6 +477,7 @@ export default function VehiclesView({
                     <option value="model_za">Model Z→A</option>
                     <option value="year_newest">Year (Newest)</option>
                     <option value="year_oldest">Year (Oldest)</option>
+                    <option value="mfg_az">Group by Manufacturer</option>
                 </select>
                 {canEdit({}) && sortBy === 'default' && textFilter.trim() === '' && Object.keys(tagFilterStates).length === 0 && (
                     <button
@@ -512,6 +534,38 @@ export default function VehiclesView({
                     </span>
                 </div>
             )}
+            {/* Manufacturer filter bar */}
+            {manufacturers.length > 0 && (
+                <div className="tag-filter-bar">
+                    <span className="text-sm font-medium text-gray-500 flex-shrink-0">Brand:</span>
+                    {manufacturers.map(mfg => {
+                        const active = mfgFilter.has(mfg.id);
+                        return (
+                            <button
+                                key={mfg.id}
+                                onClick={() => setMfgFilter(prev => {
+                                    const next = new Set(prev);
+                                    next.has(mfg.id) ? next.delete(mfg.id) : next.add(mfg.id);
+                                    return next;
+                                })}
+                                className={`tag-filter-btn ${active ? 'tag-filter-or' : 'tag-filter-na'}`}
+                                title={active ? `Remove "${mfg.name}" filter` : `Show only "${mfg.name}" vehicles`}
+                            >
+                                {mfg.name}
+                            </button>
+                        );
+                    })}
+                    {mfgFilter.size > 0 && (
+                        <button
+                            onClick={() => setMfgFilter(new Set())}
+                            className="text-xs text-gray-400 hover:text-gray-600 underline ml-1 flex-shrink-0"
+                        >
+                            Clear
+                        </button>
+                    )}
+                </div>
+            )}
+
             {/* Select All / Clear All Visible */}
             {textFiltered.length > 0 && (
                 <div className="flex justify-end gap-2 mb-4 -mt-3">
@@ -536,13 +590,23 @@ export default function VehiclesView({
             {/* ── CARD VIEW ── */}
             {viewMode === 'card' && (
                 <div className="vehicle-grid">
-                    {pagedVehicles.map(vehicle => {
+                    {pagedVehicles.map((vehicle, pageIdx) => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
                         const isPending  = pendingDeletes.has(vehicle.id);
                         const globalPos  = sortedFilteredVehicles.findIndex(v => v.id === vehicle.id);
                         const totalCount = sortedFilteredVehicles.length;
+                        // Insert a manufacturer group header when group changes
+                        const mfgName = vehicle.manufacturer?.name || vehicle.make || 'Unknown';
+                        const prevVehicle = pagedVehicles[pageIdx - 1];
+                        const prevMfgName = prevVehicle ? (prevVehicle.manufacturer?.name || prevVehicle.make || 'Unknown') : null;
+                        const showMfgHeader = sortBy === 'mfg_az' && mfgName !== prevMfgName;
                         return (
                             <div key={vehicle.id} className="contents">
+                                {showMfgHeader && (
+                                    <div className="col-span-full pt-2 pb-1 border-b border-gray-200 mb-1">
+                                        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">{mfgName}</h3>
+                                    </div>
+                                )}
                                 <div
                                     onClick={() => handleCardClick(vehicle)}
                                     className={`card hover:shadow-lg transition cursor-pointer relative overflow-hidden flex flex-col${isPending ? ' opacity-60' : ''}`}
@@ -643,13 +707,22 @@ export default function VehiclesView({
             {/* ── LIST VIEW ── */}
             {viewMode === 'list' && (
                 <div className="vehicle-list">
-                    {pagedVehicles.map(vehicle => {
+                    {pagedVehicles.map((vehicle, pageIdx) => {
                         const isSelected = selectedVehicles.includes(vehicle.id);
                         const isPending  = pendingDeletes.has(vehicle.id);
                         const globalPos  = sortedFilteredVehicles.findIndex(v => v.id === vehicle.id);
                         const totalCount = sortedFilteredVehicles.length;
+                        const mfgName = vehicle.manufacturer?.name || vehicle.make || 'Unknown';
+                        const prevVehicle = pagedVehicles[pageIdx - 1];
+                        const prevMfgName = prevVehicle ? (prevVehicle.manufacturer?.name || prevVehicle.make || 'Unknown') : null;
+                        const showMfgHeader = sortBy === 'mfg_az' && mfgName !== prevMfgName;
                         return (
                             <div key={vehicle.id}>
+                                {showMfgHeader && (
+                                    <div className="pt-2 pb-1 border-b border-gray-200 mb-1">
+                                        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">{mfgName}</h3>
+                                    </div>
+                                )}
                                 <div
                                     onClick={() => handleCardClick(vehicle)}
                                     className={`card hover:shadow-lg transition cursor-pointer flex items-center gap-4 py-3 px-4 relative overflow-hidden${isPending ? ' opacity-60' : ''}`}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -16,6 +16,7 @@ export function AppProvider({ children }) {
     const [specVouches, setSpecVouches] = useState({});   // { [vehicleId]: { count, myVouch } }
     const [runVotes, setRunVotes] = useState({});          // { [runId]: { vouch, flag, myVote } }
     const [units, setUnits] = useState(() => localStorage.getItem('evbench_units') || 'imperial');
+    const [manufacturers, setManufacturers] = useState([]);
 
     const toggleUnits = () => setUnits(u => {
         const next = u === 'imperial' ? 'metric' : 'imperial';
@@ -41,6 +42,7 @@ export function AppProvider({ children }) {
         const selectedIds = await dataService.getSelectedVehicles();
         const tagsData = dataService.useSupabase ? await dataService.getTags() : [];
         const siteSettings = await dataService.getSiteSettings();
+        const manufacturersData = dataService.useSupabase ? await dataService.getManufacturers() : [];
 
         // Derive custom field name suggestions from all vehicles' specs._custom objects
         const suggestions = {};
@@ -59,6 +61,7 @@ export function AppProvider({ children }) {
         setVehicles(vehiclesData);
         setSelectedVehicles(selectedIds);
         setTags(tagsData);
+        setManufacturers(manufacturersData);
         setHeaderImageUrl(siteSettings.header_image_url || '');
         setLoading(false);
     }
@@ -519,6 +522,68 @@ export function AppProvider({ children }) {
         }
     };
 
+    // ── Manufacturer CRUD ─────────────────────────────────────────────────────
+
+    const addManufacturer = async (name, country = null) => {
+        try {
+            const mfg = await dataService.addManufacturer(name, country);
+            setManufacturers(prev => [...prev, mfg].sort((a, b) => a.name.localeCompare(b.name)));
+            return mfg;
+        } catch (error) {
+            showError('Error adding manufacturer: ' + error.message);
+        }
+    };
+
+    const updateManufacturer = async (id, updates) => {
+        try {
+            await dataService.updateManufacturer(id, updates);
+            setManufacturers(prev =>
+                prev.map(m => m.id === id ? { ...m, ...updates } : m)
+                    .sort((a, b) => a.name.localeCompare(b.name))
+            );
+            // If name changed, keep vehicles' make field in sync
+            if (updates.name) {
+                setVehicles(prev => prev.map(v =>
+                    v.manufacturer?.id === id ? { ...v, manufacturer: { ...v.manufacturer, ...updates }, make: updates.name } : v
+                ));
+            }
+        } catch (error) {
+            showError('Error updating manufacturer: ' + error.message);
+        }
+    };
+
+    const deleteManufacturer = async (id) => {
+        try {
+            await dataService.deleteManufacturer(id);
+            setManufacturers(prev => prev.filter(m => m.id !== id));
+        } catch (error) {
+            showError('Error deleting manufacturer: ' + error.message);
+        }
+    };
+
+    // ── Spec link CRUD ────────────────────────────────────────────────────────
+
+    // Spec links require a full reload because buildInheritedRuns() is a two-pass
+    // operation inside DataService — optimistic state cannot replicate it cheaply.
+    const addSpecLink = async ({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes }) => {
+        try {
+            await dataService.addSpecLink({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes });
+            await initializeApp();
+        } catch (error) {
+            showError('Error adding spec link: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deleteSpecLink = async (linkId) => {
+        try {
+            await dataService.deleteSpecLink(linkId);
+            await initializeApp();
+        } catch (error) {
+            showError('Error removing spec link: ' + error.message);
+        }
+    };
+
     // ── RBAC helpers ──────────────────────────────────────────────────────────
     const isAdmin       = userRole === 'admin';
     const isContributor = userRole === 'admin' || userRole === 'contributor';
@@ -722,6 +787,12 @@ export function AppProvider({ children }) {
         initializeApp,
         units,
         toggleUnits,
+        manufacturers,
+        addManufacturer,
+        updateManufacturer,
+        deleteManufacturer,
+        addSpecLink,
+        deleteSpecLink,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -591,6 +591,16 @@ export function AppProvider({ children }) {
         }
     };
 
+    const updateSpecLink = async (linkId, { scalingFactor }) => {
+        try {
+            await dataService.updateSpecLink(linkId, { scalingFactor });
+            await softRefreshVehicles();
+        } catch (error) {
+            showError('Error updating spec link: ' + error.message);
+            throw error;
+        }
+    };
+
     const deleteSpecLink = async (linkId) => {
         try {
             await dataService.deleteSpecLink(linkId);
@@ -808,6 +818,7 @@ export function AppProvider({ children }) {
         updateManufacturer,
         deleteManufacturer,
         addSpecLink,
+        updateSpecLink,
         deleteSpecLink,
     };
 

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -32,6 +32,13 @@ export function AppProvider({ children }) {
         initializeApp();
     }, []);
 
+    // Refresh only the vehicles list (no loading spinner, no full re-init).
+    // Used after spec-link add/delete so inherited runs rebuild without a page flash.
+    async function softRefreshVehicles() {
+        const vehiclesData = await dataService.getVehicles();
+        setVehicles(vehiclesData);
+    }
+
     async function initializeApp() {
         setLoading(true);
         await dataService.initialize();
@@ -285,6 +292,15 @@ export function AppProvider({ children }) {
 
     const updateRunColor = async (vehicleId, runId, color) => {
         try {
+            // Inherited runs have synthetic string ids — skip the DB write, just update local state
+            if (typeof runId === 'string' && runId.startsWith('inherited_')) {
+                setVehicles(prev => prev.map(v =>
+                    v.id === vehicleId
+                        ? { ...v, runs: v.runs.map(r => r.id === runId ? { ...r, color } : r) }
+                        : v
+                ));
+                return;
+            }
             await dataService.updateRunColor(vehicleId, runId, color);
             setVehicles(prev => prev.map(v =>
                 v.id === vehicleId
@@ -568,7 +584,7 @@ export function AppProvider({ children }) {
     const addSpecLink = async ({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes }) => {
         try {
             await dataService.addSpecLink({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes });
-            await initializeApp();
+            await softRefreshVehicles();
         } catch (error) {
             showError('Error adding spec link: ' + error.message);
             throw error;
@@ -578,7 +594,7 @@ export function AppProvider({ children }) {
     const deleteSpecLink = async (linkId) => {
         try {
             await dataService.deleteSpecLink(linkId);
-            await initializeApp();
+            await softRefreshVehicles();
         } catch (error) {
             showError('Error removing spec link: ' + error.message);
         }

--- a/src/index.css
+++ b/src/index.css
@@ -297,6 +297,20 @@ body {
     @apply flex-1 min-w-0;
 }
 
+/* ── Spec link section (inside EditVehicleForm) ─────────────────────────────── */
+.spec-link-list {
+    @apply border rounded-lg overflow-hidden text-sm;
+}
+.spec-link-row {
+    @apply flex items-center gap-2 px-3 py-2 border-b last:border-b-0 bg-white;
+}
+.spec-link-type-badge {
+    @apply text-xs font-medium px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 whitespace-nowrap;
+}
+.spec-link-add-form {
+    @apply border rounded-lg p-3 bg-gray-50;
+}
+
 /* ── Copy-to-vehicle modal ──────────────────────────────────────────────────── */
 .copy-to-modal-panel {
     @apply bg-white rounded-xl shadow-2xl flex flex-col overflow-hidden;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -49,7 +49,7 @@ function splitPerformance(performance = {}) {
 function buildInheritedRuns(vehicle, allVehicles) {
   const inherited = [];
   for (const link of (vehicle.spec_links || [])) {
-    const src = allVehicles.find(v => v.id === link.source_vehicle_id);
+    const src = allVehicles.find(v => Number(v.id) === Number(link.source_vehicle_id));
     if (!src) continue;
     const relevantRuns = src.runs.filter(r =>
       link.spec_type === 'range_test'     ? r.has_range    :
@@ -190,16 +190,17 @@ class DataService {
   // ── Spec links ────────────────────────────────────────────────────────────
 
   async addSpecLink({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes }) {
+    // Upsert: if a link already exists for (target, spec_type), replace it.
     const { data, error } = await getSupabase()
       .from('spec_links')
-      .insert({
+      .upsert({
         target_vehicle_id: targetVehicleId,
         source_vehicle_id: sourceVehicleId,
         spec_type:         specType,
         scaling_factor:    scalingFactor != null && scalingFactor !== '' ? Number(scalingFactor) : null,
         notes:             notes || null,
         created_by:        this.user?.id ?? null,
-      })
+      }, { onConflict: 'target_vehicle_id,spec_type' })
       .select()
       .single();
     if (error) throw error;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -215,6 +215,14 @@ class DataService {
     return data;
   }
 
+  async updateSpecLink(id, { scalingFactor }) {
+    const { error } = await getSupabase()
+      .from('spec_links')
+      .update({ scaling_factor: scalingFactor != null && scalingFactor !== '' ? Number(scalingFactor) : null })
+      .eq('id', id);
+    if (error) throw error;
+  }
+
   async deleteSpecLink(id) {
     const { error } = await getSupabase().from('spec_links').delete().eq('id', id);
     if (error) throw error;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -25,6 +25,58 @@ function normalisePoint(point, runId, frame) {
   };
 }
 
+// Fields stored in vehicle_performance table instead of specs JSONB.
+// Add a key here when a new column is promoted to the table.
+const PROMOTED_PERF_FIELDS = ['zero_to_60_mph_sec', 'quarter_mile_sec', 'quarter_mile_mph', 'weight_lbs'];
+
+function splitPerformance(performance = {}) {
+  const promoted = {}, remaining = {};
+  for (const [k, v] of Object.entries(performance)) {
+    if (v !== '' && v != null) {
+      (PROMOTED_PERF_FIELDS.includes(k) ? promoted : remaining)[k] = v;
+    }
+  }
+  return { promoted, remaining: Object.keys(remaining).length ? remaining : null };
+}
+
+// ── Spec-link helpers (module-level so they're available before class) ────────
+
+/**
+ * Given a processed vehicle and the full array of already-processed vehicles,
+ * returns synthetic run objects for all runs inherited via spec_links.
+ * Each inherited run gets a synthetic string id to prevent runDataCache collisions.
+ */
+function buildInheritedRuns(vehicle, allVehicles) {
+  const inherited = [];
+  for (const link of (vehicle.spec_links || [])) {
+    const src = allVehicles.find(v => v.id === link.source_vehicle_id);
+    if (!src) continue;
+    const relevantRuns = src.runs.filter(r =>
+      link.spec_type === 'range_test'     ? r.has_range    :
+      link.spec_type === 'charging_curve' ? r.has_charging : false
+    );
+    const sf = link.scaling_factor != null ? Number(link.scaling_factor) : 1;
+    for (const run of relevantRuns) {
+      inherited.push({
+        ...run,
+        // Synthetic id prevents runDataCache collision when both source and
+        // target vehicles are selected simultaneously in charts.
+        id:                   `inherited_${link.id}_${run.id}`,
+        _inherited:            true,
+        _realRunId:            run.id,
+        _scalingFactor:        sf,
+        _specLinkId:           link.id,
+        _sourceVehicleId:      src.id,
+        _sourceVehicleName:    src.name,
+        // Scale the run-level range metric immediately so bar charts are correct
+        // without needing to fetch data points.
+        distance_miles: run.distance_miles != null ? run.distance_miles * sf : null,
+      });
+    }
+  }
+  return inherited;
+}
+
 class DataService {
   constructor() {
     this.user = null;
@@ -59,21 +111,107 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), trims(*)`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), trims(*), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_vehicle_id, spec_type, scaling_factor, notes)`)
       .order('created_at', { ascending: false });
-    return (data || []).map(v => ({
+
+    // Pass 1: process each vehicle's own data
+    const processed = (data || []).map(v => {
+      // Merge promoted performance fields into specs.performance transparently
+      const perf = v.vehicle_performance;
+      if (perf) {
+        const { vehicle_id, updated_at, ...perfFields } = perf;
+        v.specs = {
+          ...(v.specs || {}),
+          performance: { ...(v.specs?.performance || {}), ...perfFields },
+        };
+      }
+      delete v.vehicle_performance;
+
+      // Flatten manufacturer object
+      const manufacturer = v.manufacturers ?? null;
+      delete v.manufacturers;
+
+      return {
+        ...v,
+        manufacturer,                    // { id, name, country } or null
+        spec_links: v.spec_links || [],  // raw link rows (kept for admin UI)
+        tags:  (v.vehicle_tags || []).map(vt => vt.tags).filter(Boolean),
+        trims: (v.trims || []).sort((a, b) => a.id - b.id),
+        runs:  (v.runs || []).map(r => ({
+          ...r,
+          // data_points(count) returns [{ count: N }]; normalise to a plain number
+          dataPointCount: Array.isArray(r.data_points) ? (r.data_points[0]?.count ?? 0) : 0,
+          // Resolve the trim FK so chart components can access trim details directly
+          _trim: (v.trims || []).find(t => t.id === r.trim_id) ?? null,
+        })),
+      };
+    });
+
+    // Pass 2: attach inherited runs (needs all vehicles already processed so
+    // source vehicle runs are available)
+    return processed.map(v => ({
       ...v,
-      tags: (v.vehicle_tags || []).map(vt => vt.tags).filter(Boolean),
-      trims: (v.trims || []).sort((a, b) => a.id - b.id),
-      runs: (v.runs || []).map(r => ({
-        ...r,
-        // data_points(count) returns [{ count: N }]; normalise to a plain number
-        dataPointCount: Array.isArray(r.data_points) ? (r.data_points[0]?.count ?? 0) : 0,
-        // Resolve the trim FK so chart components can access trim details directly
-        _trim: (v.trims || []).find(t => t.id === r.trim_id) ?? null,
-      })),
+      runs: [...v.runs, ...buildInheritedRuns(v, processed)],
     }));
   }
+
+  // ── Manufacturers ─────────────────────────────────────────────────────────
+
+  async getManufacturers() {
+    if (!this.useSupabase) return [];
+    const { data, error } = await getSupabase().from('manufacturers').select('*').order('name');
+    if (error) throw error;
+    return data || [];
+  }
+
+  async addManufacturer(name, country = null) {
+    const { data, error } = await getSupabase()
+      .from('manufacturers')
+      .insert({ name, country: country || null })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  async updateManufacturer(id, { name, country }) {
+    const { error } = await getSupabase()
+      .from('manufacturers')
+      .update({ name, country: country || null })
+      .eq('id', id);
+    if (error) throw error;
+  }
+
+  async deleteManufacturer(id) {
+    const { error } = await getSupabase().from('manufacturers').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // ── Spec links ────────────────────────────────────────────────────────────
+
+  async addSpecLink({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes }) {
+    const { data, error } = await getSupabase()
+      .from('spec_links')
+      .insert({
+        target_vehicle_id: targetVehicleId,
+        source_vehicle_id: sourceVehicleId,
+        spec_type:         specType,
+        scaling_factor:    scalingFactor != null && scalingFactor !== '' ? Number(scalingFactor) : null,
+        notes:             notes || null,
+        created_by:        this.user?.id ?? null,
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deleteSpecLink(id) {
+    const { error } = await getSupabase().from('spec_links').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  // ── Tags ──────────────────────────────────────────────────────────────────
 
   async getTags() {
     if (!this.useSupabase) return [];
@@ -126,6 +264,7 @@ class DataService {
       battery: vehicle.battery ? parseFloat(vehicle.battery) : null,
       range: vehicle.range ? parseFloat(vehicle.range) : null,
       power: vehicle.power ? parseFloat(vehicle.power) : null,
+      manufacturer_id: vehicle.manufacturer_id ? Number(vehicle.manufacturer_id) : null,
       visibility: 'private'
     }).select().single();
     if (error) throw error;
@@ -144,16 +283,32 @@ class DataService {
       name: updates.name, make: updates.make, model: updates.model, year: updates.year,
       battery: updates.battery ? parseFloat(updates.battery) : null,
       range: updates.range ? parseFloat(updates.range) : null,
-      power: updates.power ? parseFloat(updates.power) : null
+      power: updates.power ? parseFloat(updates.power) : null,
+      ...(updates.manufacturer_id !== undefined
+        ? { manufacturer_id: updates.manufacturer_id ? Number(updates.manufacturer_id) : null }
+        : {}),
     }).eq('id', vehicleId);
     if (error) throw error;
   }
 
   async updateVehicleSpecs(vehicleId, specs) {
     if (!this.useSupabase || !this.user) return;
+    const { performance, ...otherSpecs } = specs;
+    const { promoted, remaining } = splitPerformance(performance);
+
+    // Upsert promoted fields to dedicated vehicle_performance table
+    if (Object.keys(promoted).length > 0) {
+      const { error: perfError } = await getSupabase()
+        .from('vehicle_performance')
+        .upsert({ vehicle_id: vehicleId, ...promoted }, { onConflict: 'vehicle_id' });
+      if (perfError) throw perfError;
+    }
+
+    // Save remaining performance fields + all other spec categories to JSONB
+    const finalSpecs = remaining ? { ...otherSpecs, performance: remaining } : otherSpecs;
     const { error } = await getSupabase()
       .from('vehicles')
-      .update({ specs })
+      .update({ specs: finalSpecs })
       .eq('id', vehicleId);
     if (error) throw error;
   }
@@ -417,20 +572,28 @@ class DataService {
     localStorage.setItem('selectedVehicles', JSON.stringify(vehicleIds));
   }
 
-  async getRunData(runId) {
+  async getRunData(runId, scalingFactor = 1) {
+    // Inherited runs carry synthetic string ids like "inherited_<linkId>_<realRunId>".
+    // Strip the prefix to get the real DB run id.
+    const actualId = typeof runId === 'string' && runId.startsWith('inherited_')
+      ? parseInt(runId.split('_').pop(), 10)
+      : runId;
     const { data, error } = await getSupabase()
       .from('data_points')
       .select('*')
-      .eq('run_id', runId)
+      .eq('run_id', actualId)
       .order('frame', { ascending: true });
     if (error) throw error;
     return (data || []).map(p => ({
-      frame: p.frame,
-      timestamp: p.timestamp,
-      soc: p.soc,
-      chargeRate: p.charge_rate,
-      time: p.time_value,
-      range: p.range_value,
+      frame:       p.frame,
+      timestamp:   p.timestamp,
+      soc:         p.soc,
+      chargeRate:  p.charge_rate,
+      time:        p.time_value,
+      // Scale range_value for inherited runs so charts reflect the target vehicle
+      range:       p.range_value != null && scalingFactor !== 1
+        ? p.range_value * scalingFactor
+        : p.range_value,
       temperature: p.temperature,
     }));
   }

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -68,6 +68,8 @@ function buildInheritedRuns(vehicle, allVehicles) {
         _specLinkId:           link.id,
         _sourceVehicleId:      src.id,
         _sourceVehicleName:    src.name,
+        // Distinct default so inherited runs are visually differentiated.
+        color:          run.color ?? '#9ca3af',
         // Scale the run-level range metric immediately so bar charts are correct
         // without needing to fetch data points.
         distance_miles: run.distance_miles != null ? run.distance_miles * sf : null,
@@ -190,17 +192,23 @@ class DataService {
   // ── Spec links ────────────────────────────────────────────────────────────
 
   async addSpecLink({ targetVehicleId, sourceVehicleId, specType, scalingFactor, notes }) {
-    // Upsert: if a link already exists for (target, spec_type), replace it.
+    // Delete any existing link for (target, spec_type) first — avoids needing
+    // an UPDATE RLS policy; only INSERT + DELETE policies are required.
+    await getSupabase()
+      .from('spec_links')
+      .delete()
+      .eq('target_vehicle_id', targetVehicleId)
+      .eq('spec_type', specType);
     const { data, error } = await getSupabase()
       .from('spec_links')
-      .upsert({
+      .insert({
         target_vehicle_id: targetVehicleId,
         source_vehicle_id: sourceVehicleId,
         spec_type:         specType,
         scaling_factor:    scalingFactor != null && scalingFactor !== '' ? Number(scalingFactor) : null,
         notes:             notes || null,
         created_by:        this.user?.id ?? null,
-      }, { onConflict: 'target_vehicle_id,spec_type' })
+      })
       .select()
       .single();
     if (error) throw error;

--- a/src/utils/specHelpers.js
+++ b/src/utils/specHelpers.js
@@ -1,0 +1,90 @@
+import { SPEC_CATEGORIES, formatCustomKey } from './vehicleSpecSchema';
+import { distanceLabel } from './unitConversions';
+
+// ── Built-in vehicle-level fields ─────────────────────────────────────────────
+
+export function makeVehicleFields(units) {
+    return [
+        { key: 'vehicle.year',    label: 'Year',                              type: 'integer' },
+        { key: 'vehicle.battery', label: 'Battery (kWh)',                     type: 'number'  },
+        { key: 'vehicle.range',   label: `EPA Range (${distanceLabel(units)})`, type: 'number', unitGroup: 'distance' },
+    ];
+}
+
+// ── Color palette ─────────────────────────────────────────────────────────────
+
+export const PALETTE = [
+    '#6366f1', '#f59e0b', '#10b981', '#ef4444',
+    '#3b82f6', '#a855f7', '#ec4899', '#14b8a6',
+];
+
+export function vehicleColor(vehicle, idx) {
+    return vehicle.color || PALETTE[idx % PALETTE.length];
+}
+
+// ── Field group builder (drives all optgroup dropdowns) ───────────────────────
+
+export function buildFieldGroups(vehicles, vehicleFields) {
+    const catCustomKeys = {};
+    for (const v of vehicles) {
+        if (!v.specs) continue;
+        for (const cat of SPEC_CATEGORIES) {
+            const custom = v.specs[cat.key]?._custom || {};
+            if (!catCustomKeys[cat.key]) catCustomKeys[cat.key] = new Set();
+            for (const ck of Object.keys(custom)) catCustomKeys[cat.key].add(ck);
+        }
+    }
+
+    const groups = [{ groupLabel: 'Vehicle', fields: vehicleFields }];
+    for (const cat of SPEC_CATEGORIES) {
+        const customKeys = [...(catCustomKeys[cat.key] || new Set())];
+        const fields = [
+            ...cat.fields.map(f => ({ key: `${cat.key}.${f.key}`, label: f.label, type: f.type, unitGroup: f.unitGroup })),
+            ...customKeys.map(ck => ({ key: `${cat.key}._custom.${ck}`, label: formatCustomKey(ck), type: 'text' })),
+        ];
+        if (fields.length) groups.push({ groupLabel: cat.label, fields });
+    }
+    return groups;
+}
+
+// ── Field definition lookup ───────────────────────────────────────────────────
+
+export function getFieldDef(fieldKey, vehicleFields) {
+    if (fieldKey.startsWith('vehicle.')) {
+        return (vehicleFields || []).find(f => f.key === fieldKey) || { type: 'number' };
+    }
+    const [catKey, sub] = fieldKey.split('.');
+    if (sub === '_custom') return { type: 'text' };
+    const cat = SPEC_CATEGORIES.find(c => c.key === catKey);
+    return cat?.fields.find(f => f.key === sub) || { type: 'text' };
+}
+
+// ── Value extraction from a vehicle object ────────────────────────────────────
+
+export function extractValue(vehicle, fieldKey) {
+    if (fieldKey.startsWith('vehicle.')) return vehicle[fieldKey.split('.')[1]] ?? null;
+    const [catKey, sub, customKey] = fieldKey.split('.');
+    const catData = vehicle.specs?.[catKey];
+    if (!catData) return null;
+    if (sub === '_custom') return catData._custom?.[customKey] ?? null;
+    return catData[sub] ?? null;
+}
+
+// ── Numeric / categorical / boolean mode detection ────────────────────────────
+
+export function detectMode(vehicles, fieldKey, fieldDef) {
+    if (fieldDef?.type === 'boolean') return 'boolean';
+    const vals = vehicles
+        .map(v => extractValue(v, fieldKey))
+        .filter(v => v !== null && v !== undefined && v !== '');
+    if (!vals.length) return 'numeric';
+    if (vals.every(v => !isNaN(parseFloat(String(v))))) return 'numeric';
+    return 'categorical';
+}
+
+// ── Numeric label formatting ──────────────────────────────────────────────────
+
+export function formatNumericLabel(n) {
+    if (n === null || n === undefined) return '—';
+    return Number.isInteger(n) ? String(n) : parseFloat(n.toFixed(2)).toString();
+}

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -4,6 +4,7 @@ export const IN_TO_MM   = 25.4;
 export const LBS_TO_KG  = 0.453592;
 export const CUFT_TO_L  = 28.3168;
 export const LBFT_TO_NM = 1.35582;
+export const FT_TO_M    = 0.3048;
 
 // ── Formatted strings (value + unit label) ────────────────────────────────
 
@@ -66,6 +67,7 @@ export function convValue(value, unitGroup, sys) {
         case 'dimension': return Math.round(value * IN_TO_MM);
         case 'torque':    return r1(value * LBFT_TO_NM);
         case 'power':     return r1(value * 0.7457);
+        case 'feet':      return r1(value * FT_TO_M);
         default:          return value;
     }
 }
@@ -82,6 +84,7 @@ export function formatSpecValue(value, unitGroup, sys) {
         case 'dimension': return fmtDimension(value, sys);
         case 'torque':    return fmtTorque(value, sys);
         case 'power':     return fmtPower(value, sys);
+        case 'feet':      return sys === 'metric' ? `${r1(value * FT_TO_M)} m` : `${value} ft`;
         default:          return String(value);
     }
 }

--- a/src/utils/vehicleSpecSchema.js
+++ b/src/utils/vehicleSpecSchema.js
@@ -41,9 +41,17 @@ export const SPEC_CATEGORIES = [
         key: 'performance',
         label: 'Performance',
         fields: [
-            { key: 'zero_to_60_mph_sec', label: '0–60 mph (sec)',       type: 'number' },
-            { key: 'top_speed_mph',      label: 'Top Speed (mph)',       type: 'number', unitGroup: 'speed' },
-            { key: 'quarter_mile',       label: 'Quarter Mile',          type: 'text' },
+            { key: 'zero_to_60_mph_sec', label: '0–60 mph (sec)',              type: 'number' },
+            { key: 'quarter_mile_sec',   label: '¼ Mile (sec)',                type: 'number' },
+            { key: 'quarter_mile_mph',   label: '¼ Mile Trap Speed',           type: 'number', unitGroup: 'speed' },
+            { key: 'top_speed_mph',      label: 'Top Speed',                   type: 'number', unitGroup: 'speed' },
+            { key: 'weight_lbs',         label: 'Curb Weight',                 type: 'number', unitGroup: 'weight' },
+            { key: 'braking_60_0_ft',    label: 'Braking 60–0',               type: 'number', unitGroup: 'feet' },
+            { key: 'braking_70_0_ft',    label: 'Braking 70–0',               type: 'number', unitGroup: 'feet' },
+            { key: 'lateral_g',          label: 'Lateral Grip (g)',            type: 'number' },
+            { key: 'figure_8_sec',       label: 'Figure 8 (sec)',              type: 'number' },
+            { key: 'slalom_mph',         label: 'Slalom Speed',                type: 'number', unitGroup: 'speed' },
+            { key: 'elk_test_mph',       label: 'Elk Test Speed (Moose Test)', type: 'number', unitGroup: 'speed' },
         ],
     },
     {
@@ -71,7 +79,6 @@ export const SPEC_CATEGORIES = [
         key: 'dimensions',
         label: 'Exterior Dimensions',
         fields: [
-            { key: 'weight_lbs',          label: 'Weight (lbs)',            type: 'number', unitGroup: 'weight' },
             { key: 'length_in',           label: 'Length (in)',             type: 'number', unitGroup: 'dimension' },
             { key: 'width_in',            label: 'Width (in)',              type: 'number', unitGroup: 'dimension' },
             { key: 'height_in',           label: 'Height (in)',             type: 'number', unitGroup: 'dimension' },

--- a/supabase/migrations/009_vehicle_performance.sql
+++ b/supabase/migrations/009_vehicle_performance.sql
@@ -1,0 +1,49 @@
+CREATE TABLE vehicle_performance (
+    vehicle_id         bigint PRIMARY KEY REFERENCES vehicles(id) ON DELETE CASCADE,
+    zero_to_60_mph_sec numeric,
+    quarter_mile_sec   numeric,
+    quarter_mile_mph   numeric,
+    weight_lbs         numeric,
+    updated_at         timestamptz DEFAULT now()
+);
+
+ALTER TABLE vehicle_performance ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read vehicle_performance"
+    ON vehicle_performance FOR SELECT USING (true);
+
+CREATE POLICY "Contributors can insert vehicle_performance"
+    ON vehicle_performance FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Contributors can update vehicle_performance"
+    ON vehicle_performance FOR UPDATE
+    USING (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Admins can delete vehicle_performance"
+    ON vehicle_performance FOR DELETE
+    USING (current_user_role() = 'admin');
+
+-- Migrate existing data from JSONB
+INSERT INTO vehicle_performance (vehicle_id, zero_to_60_mph_sec, weight_lbs)
+SELECT
+    id,
+    (specs->'performance'->>'zero_to_60_mph_sec')::numeric,
+    (specs->'dimensions'->>'weight_lbs')::numeric
+FROM vehicles
+WHERE specs IS NOT NULL
+  AND (
+    specs->'performance'->>'zero_to_60_mph_sec' IS NOT NULL OR
+    specs->'dimensions'->>'weight_lbs' IS NOT NULL
+  )
+ON CONFLICT DO NOTHING;
+
+-- Clear migrated fields from JSONB
+UPDATE vehicles SET specs = specs #- '{performance,zero_to_60_mph_sec}'
+    WHERE specs->'performance' ? 'zero_to_60_mph_sec';
+UPDATE vehicles SET specs = specs #- '{performance,top_speed_mph}'
+    WHERE specs->'performance' ? 'top_speed_mph';
+UPDATE vehicles SET specs = specs #- '{performance,quarter_mile}'
+    WHERE specs->'performance' ? 'quarter_mile';
+UPDATE vehicles SET specs = specs #- '{dimensions,weight_lbs}'
+    WHERE specs->'dimensions' ? 'weight_lbs';

--- a/supabase/migrations/010_manufacturers.sql
+++ b/supabase/migrations/010_manufacturers.sql
@@ -1,0 +1,48 @@
+-- Migration 010: Manufacturers as first-class entities
+--
+-- Creates a `manufacturers` table and adds a manufacturer_id FK to vehicles.
+-- The existing `make` text column is kept for backwards compatibility
+-- (search, sort, display still use it) and is kept in sync with
+-- manufacturer.name by the application layer.
+
+CREATE TABLE manufacturers (
+    id         bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name       text NOT NULL UNIQUE,
+    country    text,
+    logo_url   text,
+    created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE manufacturers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read manufacturers"
+    ON manufacturers FOR SELECT USING (true);
+
+CREATE POLICY "Contributors can insert manufacturers"
+    ON manufacturers FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Contributors can update manufacturers"
+    ON manufacturers FOR UPDATE
+    USING (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Admins can delete manufacturers"
+    ON manufacturers FOR DELETE
+    USING (current_user_role() = 'admin');
+
+-- Add FK column to vehicles (nullable so migration is non-destructive)
+ALTER TABLE vehicles
+    ADD COLUMN manufacturer_id bigint REFERENCES manufacturers(id) ON DELETE SET NULL;
+
+-- Backfill: create one manufacturer row per distinct make string, then wire up the FK
+INSERT INTO manufacturers (name)
+    SELECT DISTINCT make
+    FROM vehicles
+    WHERE make IS NOT NULL AND make != ''
+    ON CONFLICT DO NOTHING;
+
+UPDATE vehicles v
+    SET manufacturer_id = (
+        SELECT id FROM manufacturers m WHERE m.name = v.make
+    )
+    WHERE make IS NOT NULL AND make != '';

--- a/supabase/migrations/011_spec_links.sql
+++ b/supabase/migrations/011_spec_links.sql
@@ -1,0 +1,41 @@
+-- Migration 011: Spec links — run inheritance between vehicles
+--
+-- A spec_link lets a target vehicle inherit range tests or charging curves
+-- from a source vehicle, with an optional uniform scaling factor applied to
+-- range data (run-level distance_miles + individual range_value data points).
+-- Intended use: share a tested vehicle's data with closely related trims/years.
+--
+-- Resolution order (application layer):
+--   1. Target vehicle has its own runs of the given spec_type → use those
+--   2. No own runs + link exists → inherit source runs, mark is_estimated = true
+--   3. Link has scaling_factor → multiply range_value & distance_miles by factor
+--   4. Link is manually removed when real data arrives for the target
+
+CREATE TABLE spec_links (
+    id                bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source_vehicle_id bigint NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    target_vehicle_id bigint NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    spec_type         text   NOT NULL CHECK (spec_type IN ('range_test', 'charging_curve')),
+    scaling_factor    numeric        CHECK (scaling_factor > 0),  -- NULL means 1.0 (no scaling)
+    notes             text,
+    created_by        uuid   REFERENCES auth.users(id),
+    created_at        timestamptz DEFAULT now(),
+
+    -- A target vehicle can only inherit a given spec type from one source at a time
+    UNIQUE (target_vehicle_id, spec_type),
+    -- Prevent self-referential links
+    CHECK  (source_vehicle_id != target_vehicle_id)
+);
+
+ALTER TABLE spec_links ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read spec_links"
+    ON spec_links FOR SELECT USING (true);
+
+CREATE POLICY "Contributors can insert spec_links"
+    ON spec_links FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Contributors can delete spec_links"
+    ON spec_links FOR DELETE
+    USING (current_user_role() IN ('admin', 'contributor'));

--- a/supabase/migrations/012_spec_links_update_policy.sql
+++ b/supabase/migrations/012_spec_links_update_policy.sql
@@ -1,0 +1,11 @@
+-- Migration 012: Allow contributors to update spec_links
+--
+-- Required to support inline editing of scaling_factor without a remove + re-add.
+-- The earlier addSpecLink workaround (delete-then-insert) is kept in place so that
+-- re-adding a removed link still works without this policy — but the UPDATE path
+-- is now the preferred route for scaling_factor edits.
+
+CREATE POLICY "Contributors can update spec_links"
+    ON spec_links FOR UPDATE
+    USING      (current_user_role() IN ('admin', 'contributor'))
+    WITH CHECK (current_user_role() IN ('admin', 'contributor'));


### PR DESCRIPTION
## Summary

- **Manufacturers as first-class entities** — `manufacturers` table with FK on `vehicles`. `make` text column kept for backwards compat. VehiclesView gets manufacturer filter pills and "Group by Manufacturer" sort. EditVehicleForm replaces the make text input with a manufacturer select + inline create flow.

- **Spec links (run inheritance)** — `spec_links` table lets a target vehicle inherit range tests or charging curves from a source with an optional scaling factor. Inherited runs appear with synthetic ids (no cache collisions). Scaling applied to `distance_miles` for bar charts, and to `range_value` data points in `getRunData()` for line charts. RunsView shows an "Inherited Tests" section with estimated badge and Remove Link button. EditVehicleForm shows existing links with an add-link form and EPA ratio auto-suggest button.

- **Spec scatter plot** — new "Spec Scatter" chart mode. X/Y dropdowns (numeric fields only), one point per vehicle, faint trend line, per-point name labels. Field selections persist in URL via `scx`/`scy` params.

- **Vehicle performance table** — `vehicle_performance` DB table for indexed metrics (`zero_to_60_mph_sec`, `quarter_mile_sec`, `quarter_mile_mph`, `weight_lbs`). New JSONB-only fields: braking, lateral g, figure 8, slalom, elk test. \`feet\` unit group added.

## Migrations to apply (in order)

Run these in the Supabase SQL editor before deploying:
1. \`supabase/migrations/009_vehicle_performance.sql\`
2. \`supabase/migrations/010_manufacturers.sql\`
3. \`supabase/migrations/011_spec_links.sql\`

## Test plan

- [ ] Apply migrations 009 → 010 → 011 in Supabase SQL editor
- [ ] VehiclesView: manufacturer filter pills appear; selecting a brand hides other vehicles; "Group by Manufacturer" shows brand headers in card grid
- [ ] EditVehicleForm: manufacturer dropdown pre-selected for existing vehicles; "+ New" creates inline; saving updates both \`manufacturer_id\` and \`make\`
- [ ] Add a spec link (source vehicle + Range Test + 0.89 scaling); target vehicle shows "Inherited Tests" section with estimated badge and ×0.89 label
- [ ] Range & Efficiency chart: inherited run bar shows scaled distance
- [ ] Charging chart: selecting the inherited run plots scaled \`range_value\` data points
- [ ] Remove Link button removes the inherited run from all views
- [ ] Charts tab: "Spec Scatter" mode renders, dropdowns update chart live, URL round-trips with \`scx\`/\`scy\`
- [ ] Performance section: 0–60, ¼ mile, weight persist from \`vehicle_performance\` table; braking/g-force/slalom fields save to JSONB

🤖 Generated with [Claude Code](https://claude.com/claude-code)