### PR TITLE
General UI cleanup

### DIFF
--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -328,6 +328,15 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             }
         });
 
+        // Count active runs per vehicle to decide whether to include run name in label
+        const runsPerVehicle = {};
+        allSelectedRuns.forEach(r => {
+            runsPerVehicle[r.vehicleName] = (runsPerVehicle[r.vehicleName] || 0) + 1;
+        });
+        const runLabel = (run) => runsPerVehicle[run.vehicleName] > 1
+            ? `${run.vehicleName} - ${run.name}`
+            : run.vehicleName;
+
         const datasets = allSelectedRuns.flatMap((run) => {
             const rawData = runDataCache[run.id] ?? run.data ?? [];
             const { vehicleBattery, vehicleRange } = run;
@@ -362,7 +371,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             const showPts = chartConfig.showPoints || false;
 
             const result = [{
-                label:            `${run.vehicleName} - ${run.name}`,
+                label:            runLabel(run),
                 data:             y1Points,
                 backgroundColor:  color,
                 borderColor:      color,
@@ -381,7 +390,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     .filter(p => p.x != null && p.y != null);
                 if (y2Points.length > 0) {
                     result.push({
-                        label:            `${run.vehicleName} - ${run.name} (right)`,
+                        label:            `${runLabel(run)} (right)`,
                         data:             y2Points,
                         backgroundColor:  color,
                         borderColor:      color,
@@ -435,7 +444,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             title(ctx) {
                                 const run = ctx[0]?.dataset?.runMeta;
                                 if (!run) return undefined;
-                                return run.vehicleName ? `${run.vehicleName} — ${run.name}` : run.name;
+                                return runLabel(run);
                             },
                             label(ctx) {
                                 const xl = axisOptions.find(a => a.value === chartConfig.xAxis)?.label ?? 'X';
@@ -484,7 +493,15 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
     // ── PNG export ───────────────────────────────────────────────────────────
     const handleExportImage = async () => {
         if (!chartInstance.current) return;
-        const dataUrl = chartInstance.current.toBase64Image('image/png', 1.0);
+        const src = chartInstance.current.canvas;
+        const offscreen = document.createElement('canvas');
+        offscreen.width = src.width;
+        offscreen.height = src.height;
+        const ctx2 = offscreen.getContext('2d');
+        ctx2.fillStyle = '#ffffff';
+        ctx2.fillRect(0, 0, offscreen.width, offscreen.height);
+        ctx2.drawImage(src, 0, 0);
+        const dataUrl = offscreen.toDataURL('image/png');
         setChartImage(dataUrl);
         // Try writing directly to clipboard (Chrome/Edge; Safari requires user gesture)
         try {

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -427,7 +427,15 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
     // ── Copy chart PNG ────────────────────────────────────────────────────────
     const handleCopyImage = async () => {
         if (!chartInstance.current) return;
-        const dataUrl = chartInstance.current.toBase64Image('image/png', 1.0);
+        const src = chartInstance.current.canvas;
+        const offscreen = document.createElement('canvas');
+        offscreen.width = src.width;
+        offscreen.height = src.height;
+        const ctx2 = offscreen.getContext('2d');
+        ctx2.fillStyle = '#ffffff';
+        ctx2.fillRect(0, 0, offscreen.width, offscreen.height);
+        ctx2.drawImage(src, 0, 0);
+        const dataUrl = offscreen.toDataURL('image/png');
         try {
             const blob = await (await fetch(dataUrl)).blob();
             await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -1767,6 +1767,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 </a>
                                             )}
                                         </h3>
+                                        <RunVoteButtons
+                                            vouch={votes.vouch}
+                                            flag={votes.flag}
+                                            myVote={votes.myVote}
+                                            onVote={(voteType) => toggleRunVote(run.id, voteType)}
+                                        />
                                     </div>
                                     <div className="run-meta">
                                         <p>Date: {run.date}</p>
@@ -1849,12 +1855,6 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     </div>
                                 </div>
                                 <div className="run-actions">
-                                    <RunVoteButtons
-                                        vouch={votes.vouch}
-                                        flag={votes.flag}
-                                        myVote={votes.myVote}
-                                        onVote={(voteType) => toggleRunVote(run.id, voteType)}
-                                    />
                                     <div className="run-actions-row">
                                         {/* Set Default — ghost text, green on hover, pale blue + × when active */}
                                         <button

--- a/src/components/SpecsScatterView.jsx
+++ b/src/components/SpecsScatterView.jsx
@@ -139,9 +139,10 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
                 borderColor:     color,
                 pointRadius:     8,
                 pointHoverRadius: 11,
-                // Store raw values for tooltip
                 _rawX: rawX,
                 _rawY: rawY,
+                _manufacturer: v.manufacturer?.name ?? null,
+                _year: v.year ?? null,
             };
         });
 
@@ -198,7 +199,12 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
                     tooltip: {
                         filter: item => item.dataset.label !== 'Trend',
                         callbacks: {
-                            title: ctx => ctx[0]?.dataset.label || '',
+                            title: ctx => {
+                                const ds = ctx[0]?.dataset;
+                                if (!ds) return '';
+                                const parts = [ds._manufacturer, ds._year, ds.label].filter(Boolean);
+                                return parts.join(' · ');
+                            },
                             label: ctx => {
                                 const ds = ctx.dataset;
                                 return [

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -58,7 +58,7 @@ export default function VehiclesView({
     const [specsViewingVehicle, setSpecsViewingVehicle] = useState(null);
     const VEHICLES_PER_PAGE = 24;
 
-    const { units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink } = useAppContext();
+    const { units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink, user } = useAppContext();
 
     const {
         pendingDeletes, committedDeletes, undoState, secondsLeft,
@@ -248,6 +248,7 @@ export default function VehiclesView({
     // ── Shared sub-components ────────────────────────────────────────────────
 
     const VisibilityPill = ({ vehicle, fullWidth }) => {
+        if (!user) return null;
         const base = `flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full border transition${fullWidth ? ' w-full justify-center' : ''}`;
         const pubCls = 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200';
         const privCls = 'bg-gray-100 text-gray-500 border-gray-300 hover:bg-gray-200';


### PR DESCRIPTION
## Summary

- **Vehicle cards (signed out)**: Hide the Public/Private visibility pill — it's meaningless to anonymous visitors
- **Run cards**: Vote buttons (👍 🚩) moved inline into the title row next to the run name; action buttons (Set Default, Edit, Delete, More) now sit alone in the top-right corner
- **Charging chart legends**: Run name omitted from legend when only one run per vehicle is active; shown only when a vehicle has multiple active runs on the chart
- **Copy Chart as PNG**: Composites the chart onto a white canvas before encoding — fixes transparent backgrounds that don't paste well in other apps
- **Spec Scatter tooltip**: Title now shows `Manufacturer · Year · Vehicle name` on mouseover

## Test plan

- [ ] Sign out and confirm no Public/Private pill appears on vehicle cards
- [ ] Sign in and confirm pill still shows for contributors/admins
- [ ] Open Tests & Data for a vehicle with runs — verify vote buttons appear inline next to run name
- [ ] Load Charging chart with one run per vehicle — legends show vehicle name only; add a second run for the same vehicle — legend now shows `Vehicle - Run name`
- [ ] Copy a chart as PNG and paste into an image editor / messaging app — background should be white
- [ ] Open Compare Specs → Spec Scatter, hover a point — tooltip should show manufacturer, year, and vehicle name

🤖 Generated with [Claude Code](https://claude.com/claude-code)