### PR TITLE
feat: box zoom on Charging chart; Copy PNG on Road Trip / Spec views

### DIFF
--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import Chart from 'chart.js/auto';
+import ZoomPlugin from 'chartjs-plugin-zoom';
 Chart.defaults.font.size = 13;
+Chart.register(ZoomPlugin);
 import { dataService } from '../services/DataService';
 import RunSelector from './RunSelector';
 import RangeChartView from './RangeChartView';
@@ -455,7 +457,13 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                 return runTooltipLines(ctx.dataset?.runMeta, [], units);
                             },
                         },
-                    }
+                    },
+                    zoom: {
+                        zoom: {
+                            drag: { enabled: true, backgroundColor: 'rgba(59,130,246,0.08)', borderColor: '#3b82f6', borderWidth: 1 },
+                            mode: 'xy',
+                        },
+                    },
                 },
                 scales: {
                     x: {
@@ -678,7 +686,14 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 </div>
 
                 {/* Export / share buttons */}
-                <div className="mt-3 flex items-center gap-3">
+                <div className="mt-3 flex items-center gap-3 flex-wrap">
+                    <button
+                        onClick={() => chartInstance.current?.resetZoom()}
+                        className="chart-copy-btn bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100"
+                        title="Reset zoom to full view"
+                    >
+                        🔍 Reset Zoom
+                    </button>
                     <button
                         onClick={() => {
                             navigator.clipboard.writeText(window.location.href).then(() => {
@@ -715,6 +730,8 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                         </button>
                     )}
                 </div>
+
+                <p className="text-xs text-gray-400 mt-1">Drag to box-zoom · Reset Zoom to restore</p>
 
                 {/* Inline image preview — right-click/long-press to copy or save */}
                 {chartImage && (

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -390,6 +390,8 @@ export default function RoadTripView({
     });
     const [axisScale, setAxisScale] = useState({ xMin: null, xMax: null, yMin: null, yMax: null });
     const [copiedUrl, setCopiedUrl] = useState(false);
+    const [imageCopied, setImageCopied] = useState(false);
+    const [chartImage, setChartImage]   = useState(null);
     const [sortCol, setSortCol] = useState(null);   // column key or null
     const [sortDir, setSortDir] = useState('asc');  // 'asc' | 'desc'
     const onAxisChange = (key, val) => setAxisScale(prev => ({ ...prev, [key]: val }));
@@ -1146,6 +1148,27 @@ export default function RoadTripView({
     // ── Config update helper ─────────────────────────────────────────────────
     const setField = (key, value) => setRoadTripConfig(prev => ({ ...prev, [key]: value }));
 
+    // ── PNG export ────────────────────────────────────────────────────────────
+    const handleCopyImage = async () => {
+        if (!chartRef.current) return;
+        const src = chartRef.current.canvas;
+        const offscreen = document.createElement('canvas');
+        offscreen.width  = src.width;
+        offscreen.height = src.height;
+        const ctx2 = offscreen.getContext('2d');
+        ctx2.fillStyle = '#ffffff';
+        ctx2.fillRect(0, 0, offscreen.width, offscreen.height);
+        ctx2.drawImage(src, 0, 0);
+        const dataUrl = offscreen.toDataURL('image/png');
+        setChartImage(dataUrl);
+        try {
+            const blob = await (await fetch(dataUrl)).blob();
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+            setImageCopied(true);
+            setTimeout(() => setImageCopied(false), 2500);
+        } catch { /* Clipboard API not supported — image shown inline */ }
+    };
+
     // ── Render ───────────────────────────────────────────────────────────────
     const {
         startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, sweepYAxis, overhead,
@@ -1468,7 +1491,25 @@ export default function RoadTripView({
                         >
                             {copiedUrl ? '✓ Copied!' : '🔗 Copy URL'}
                         </button>
+                        <button
+                            onClick={handleCopyImage}
+                            className={`chart-copy-btn ${imageCopied ? 'bg-green-50 border-green-200 text-green-700' : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'}`}
+                            title="Copy chart as PNG"
+                        >
+                            {imageCopied ? '✓ Copied to clipboard!' : '📋 Copy Chart as PNG'}
+                        </button>
+                        {chartImage && (
+                            <button onClick={() => setChartImage(null)} className="text-xs text-gray-400 hover:text-gray-600 transition-colors">
+                                ✕ Dismiss preview
+                            </button>
+                        )}
                     </div>
+                    {chartImage && (
+                        <div className="mt-3">
+                            <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
+                            <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1450,31 +1450,28 @@ export default function RoadTripView({
 
             {!loading && validEntries.length > 0 && (
                 <div className="card mb-6">
-                    <div className="flex items-center justify-between mb-2">
-                        <h3 className="text-lg font-bold">
-                            Road Trip{towingMode ? ' (Towing)' : ''}
-                            {isSpeedMode   ? ` · Speed vs. Time`
-                             : isTripDistMode ? ` — ${Math.round(convDistance(totalDistance, units))} ${dl} · Leg Distance vs. Time at ${Math.round(convDistance(speed, units))} ${sl}`
-                             : ` — ${Math.round(convDistance(totalDistance, units))} ${dl} at ${Math.round(convDistance(speed, units))} ${sl}`}
-                        </h3>
-                        <button
-                            onClick={() => chartRef.current?.resetZoom()}
-                            className="text-xs text-gray-400 hover:text-gray-700 border border-gray-200 rounded px-2 py-1 transition-colors"
-                            title="Reset zoom to full view"
-                        >
-                            Reset Zoom
-                        </button>
-                    </div>
+                    <h3 className="text-lg font-bold mb-2">
+                        Road Trip{towingMode ? ' (Towing)' : ''}
+                        {isSpeedMode   ? ` · Speed vs. Time`
+                         : isTripDistMode ? ` — ${Math.round(convDistance(totalDistance, units))} ${dl} · Leg Distance vs. Time at ${Math.round(convDistance(speed, units))} ${sl}`
+                         : ` — ${Math.round(convDistance(totalDistance, units))} ${dl} at ${Math.round(convDistance(speed, units))} ${sl}`}
+                    </h3>
                     <div style={{ height: `${isSweepMode ? 400 : yAxis === 'byTest' ? Math.max(300, validEntries.length * 120) : Math.max(400, validEntries.length * 40 + 200)}px`, position: 'relative' }}>
                         <canvas ref={canvasRef} />
                     </div>
-                    <p className="text-xs text-gray-400 mt-1 text-center">Drag to zoom · Reset Zoom to restore</p>
                     {isSweepMode && hasUnrealisticPoints && (
                         <p className="text-xs text-amber-600 mt-1 text-center">
                             Lines end where a charge stop would exceed {CHARGE_CEIL_SOC}% SoC — unrealistic at that {isSpeedMode ? 'speed' : 'leg distance'}.
                         </p>
                     )}
-                    <div className="mt-3 flex gap-2">
+                    <div className="mt-3 flex gap-2 flex-wrap items-center">
+                        <button
+                            onClick={() => chartRef.current?.resetZoom()}
+                            className="chart-copy-btn bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100"
+                            title="Reset zoom to full view"
+                        >
+                            🔍 Reset Zoom
+                        </button>
                         <button
                             onClick={() => {
                                 const p = new URLSearchParams(window.location.search);
@@ -1504,6 +1501,7 @@ export default function RoadTripView({
                             </button>
                         )}
                     </div>
+                    <p className="text-xs text-gray-400 mt-1">Drag to box-zoom · Reset Zoom to restore</p>
                     {chartImage && (
                         <div className="mt-3">
                             <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>

--- a/src/components/SpecsChartView.jsx
+++ b/src/components/SpecsChartView.jsx
@@ -50,8 +50,10 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
     const fieldGroups = useMemo(() => buildFieldGroups(vehicles, vehicleFields), [vehicles, vehicleFields]);
     const allFields   = useMemo(() => fieldGroups.flatMap(g => g.fields), [fieldGroups]);
 
-    const [localField,  setLocalField]  = useState('');
-    const [copiedUrl,   setCopiedUrl]   = useState(false);
+    const [localField,   setLocalField]   = useState('');
+    const [copiedUrl,    setCopiedUrl]    = useState(false);
+    const [imageCopied,  setImageCopied]  = useState(false);
+    const [chartImage,   setChartImage]   = useState(null);
     const selectedField = controlledField || localField;
 
     const setSelectedField = (field) => {
@@ -183,6 +185,26 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
         };
     }, [selectedField, vehicles, allFields, units]);
 
+    const handleCopyImage = async () => {
+        if (!chartRef.current) return;
+        const src = chartRef.current.canvas;
+        const offscreen = document.createElement('canvas');
+        offscreen.width  = src.width;
+        offscreen.height = src.height;
+        const ctx2 = offscreen.getContext('2d');
+        ctx2.fillStyle = '#ffffff';
+        ctx2.fillRect(0, 0, offscreen.width, offscreen.height);
+        ctx2.drawImage(src, 0, 0);
+        const dataUrl = offscreen.toDataURL('image/png');
+        setChartImage(dataUrl);
+        try {
+            const blob = await (await fetch(dataUrl)).blob();
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+            setImageCopied(true);
+            setTimeout(() => setImageCopied(false), 2500);
+        } catch { /* Clipboard API not supported — image shown inline */ }
+    };
+
     return (
         <div className="specs-chart-card">
             <div className="specs-chart-controls">
@@ -205,7 +227,7 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
             <div style={{ height: `${Math.max(220, vehicles.length * 52)}px`, position: 'relative' }}>
                 <canvas ref={canvasRef} />
             </div>
-            <div className="mt-3 flex gap-2">
+            <div className="mt-3 flex gap-2 flex-wrap">
                 <button
                     onClick={() => {
                         navigator.clipboard.writeText(window.location.href).then(() => {
@@ -218,7 +240,25 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
                 >
                     {copiedUrl ? '✓ Copied!' : '🔗 Copy URL'}
                 </button>
+                <button
+                    onClick={handleCopyImage}
+                    className={`chart-copy-btn ${imageCopied ? 'bg-green-50 border-green-200 text-green-700' : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'}`}
+                    title="Copy chart as PNG"
+                >
+                    {imageCopied ? '✓ Copied to clipboard!' : '📋 Copy Chart as PNG'}
+                </button>
+                {chartImage && (
+                    <button onClick={() => setChartImage(null)} className="text-xs text-gray-400 hover:text-gray-600 transition-colors">
+                        ✕ Dismiss preview
+                    </button>
+                )}
             </div>
+            {chartImage && (
+                <div className="mt-3">
+                    <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
+                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/SpecsScatterView.jsx
+++ b/src/components/SpecsScatterView.jsx
@@ -74,7 +74,9 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
 
     const [localX, setLocalX] = useState('');
     const [localY, setLocalY] = useState('');
-    const [copiedUrl, setCopiedUrl] = useState(false);
+    const [copiedUrl,   setCopiedUrl]   = useState(false);
+    const [imageCopied, setImageCopied] = useState(false);
+    const [chartImage,  setChartImage]  = useState(null);
 
     const xField = xProp || localX;
     const yField = yProp || localY;
@@ -229,6 +231,26 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
         };
     }, [xField, yField, vehicles, allNumericFields, vehicleFields, units]);
 
+    const handleCopyImage = async () => {
+        if (!chartRef.current) return;
+        const src = chartRef.current.canvas;
+        const offscreen = document.createElement('canvas');
+        offscreen.width  = src.width;
+        offscreen.height = src.height;
+        const ctx2 = offscreen.getContext('2d');
+        ctx2.fillStyle = '#ffffff';
+        ctx2.fillRect(0, 0, offscreen.width, offscreen.height);
+        ctx2.drawImage(src, 0, 0);
+        const dataUrl = offscreen.toDataURL('image/png');
+        setChartImage(dataUrl);
+        try {
+            const blob = await (await fetch(dataUrl)).blob();
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+            setImageCopied(true);
+            setTimeout(() => setImageCopied(false), 2500);
+        } catch { /* Clipboard API not supported — image shown inline */ }
+    };
+
     return (
         <div className="specs-chart-card">
             <div className="specs-chart-controls">
@@ -267,7 +289,7 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
                 <canvas ref={canvasRef} />
             </div>
 
-            <div className="mt-3 flex gap-2">
+            <div className="mt-3 flex gap-2 flex-wrap">
                 <button
                     onClick={() => {
                         navigator.clipboard.writeText(window.location.href).then(() => {
@@ -280,7 +302,25 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
                 >
                     {copiedUrl ? '✓ Copied!' : '🔗 Copy URL'}
                 </button>
+                <button
+                    onClick={handleCopyImage}
+                    className={`chart-copy-btn ${imageCopied ? 'bg-green-50 border-green-200 text-green-700' : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'}`}
+                    title="Copy chart as PNG"
+                >
+                    {imageCopied ? '✓ Copied to clipboard!' : '📋 Copy Chart as PNG'}
+                </button>
+                {chartImage && (
+                    <button onClick={() => setChartImage(null)} className="text-xs text-gray-400 hover:text-gray-600 transition-colors">
+                        ✕ Dismiss preview
+                    </button>
+                )}
             </div>
+            {chartImage && (
+                <div className="mt-3">
+                    <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
+                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary

- **Charging chart** — drag to draw a selection box and zoom into any region (uses the already-installed `chartjs-plugin-zoom`). A **Reset Zoom** button appears in the button row. Hint text below the chart reads "Drag to box-zoom · Reset Zoom to restore."

- **Road Trip chart** — adds **Copy Chart as PNG** button (same style and behaviour as the existing button on Charging/Range charts).

- **Spec Chart** (bar) — adds **Copy Chart as PNG** button.

- **Spec Scatter** — adds **Copy Chart as PNG** button.

All three PNG exports: composite a white background before encoding, attempt clipboard write, and fall back to an inline image preview (right-click / long-press to save) on browsers that don't support `ClipboardItem`.

## Test plan
- [ ] `npm run build` passes clean (✅ verified)
- [ ] Charging chart: drag a box → chart zooms in; Reset Zoom restores full view
- [ ] Charging chart: Copy Chart as PNG still works as before
- [ ] Road Trip chart: Copy Chart as PNG copies / shows inline image with white background
- [ ] Spec Chart: Copy Chart as PNG copies / shows inline image
- [ ] Spec Scatter: Copy Chart as PNG copies / shows inline image

🤖 Generated with [Claude Code](https://claude.com/claude-code)