### PR TITLE
fix: Compare Specs column order; manufacturer join on add/update

### DIFF
--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -35,8 +35,9 @@ export default function SpecsView({ selectedVehicleIds }) {
         });
     };
 
+    // Map over selectedVehicleIds (not vehicles) to preserve pill order.
     const displayVehicles = selectedVehicleIds.length > 0
-        ? vehicles.filter(v => selectedVehicleIds.includes(v.id))
+        ? selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean)
         : vehicles;
 
     // Resolve effective specs (own overrides + inherited fallback) for each vehicle.

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -102,6 +102,12 @@ export function AppProvider({ children }) {
     const addVehicle = async (vehicle) => {
         try {
             const newVehicle = await dataService.addVehicle(vehicle);
+            // API response has manufacturer_id but not the joined manufacturer object —
+            // attach it from the already-loaded list so the card renders correctly.
+            if (newVehicle.manufacturer_id && !newVehicle.manufacturer) {
+                const mfg = manufacturers.find(m => m.id === newVehicle.manufacturer_id);
+                if (mfg) newVehicle.manufacturer = mfg;
+            }
             setVehicles(prev => [...prev, newVehicle]);
         } catch (error) {
             showError('Error adding vehicle: ' + error.message);
@@ -111,7 +117,16 @@ export function AppProvider({ children }) {
     const updateVehicle = async (vehicleId, updates) => {
         try {
             await dataService.updateVehicle(vehicleId, updates);
-            setVehicles(prev => prev.map(v => v.id === vehicleId ? { ...v, ...updates } : v));
+            setVehicles(prev => prev.map(v => {
+                if (v.id !== vehicleId) return v;
+                const updated = { ...v, ...updates };
+                // Re-attach manufacturer object when manufacturer_id changes so the
+                // card and filters reflect the new brand without a full page refresh.
+                if ('manufacturer_id' in updates) {
+                    updated.manufacturer = manufacturers.find(m => m.id === updates.manufacturer_id) ?? null;
+                }
+                return updated;
+            }));
         } catch (error) {
             showError('Error updating vehicle: ' + error.message);
         }


### PR DESCRIPTION
## Summary
- **Compare Specs ordering** — columns now follow the selected-vehicle pill order. Was using `vehicles.filter()` (database order); switched to `selectedVehicleIds.map()` so the order matches exactly.
- **Manufacturer stale-state bug** — adding or editing a vehicle's brand now reflects immediately without a page reload. The API response only returns `manufacturer_id`, not the joined `manufacturer` object. Both `addVehicle` and `updateVehicle` in AppContext now look up the matching manufacturer from the already-loaded list and attach it before updating state.

## Test plan
- [ ] Add a new vehicle with a manufacturer — card should show the correct brand immediately
- [ ] Edit a vehicle's manufacturer — card, brand filter, and edit form should all update without refreshing
- [ ] Select vehicles in a specific order, open Compare Specs — columns should match the pill strip order

🤖 Generated with [Claude Code](https://claude.com/claude-code)