### PR TITLE
feat: recursive spec inheritance across full ancestor chain

### DIFF
--- a/src/components/EditSpecsForm.jsx
+++ b/src/components/EditSpecsForm.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { SPEC_CATEGORIES, normalizeCustomKey, formatCustomKey } from '../utils/vehicleSpecSchema';
 import { SpecVouchButton, SpecFieldFlagButton } from './VoteButtons';
-import { vehicleLabel } from '../utils/specHelpers';
+import { vehicleLabel, resolveEffectiveSpecs } from '../utils/specHelpers';
 
 /**
  * Modal form for editing all spec categories of a vehicle.
@@ -211,9 +211,12 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
     const liveVehicle = vehicles.find(v => v.id === vehicle.id) || vehicle;
     const flaggedSpecs = liveVehicle.flagged_specs || [];
 
-    // Source vehicle specs for inheritance hints
+    // Source vehicle specs for inheritance hints — resolve the full ancestor chain
+    // so hints show the value that would actually be inherited (not just direct parent's own fields).
     const sourceVehicle  = inheritFromId ? vehicles.find(v => String(v.id) === inheritFromId) : null;
-    const inheritedSpecs = sourceVehicle?.specs ?? {};
+    const inheritedSpecs = sourceVehicle
+        ? resolveEffectiveSpecs(sourceVehicle, vehicles, new Set([vehicle.id]))
+        : {};
 
     // Other vehicles available as inheritance sources (excluding self)
     const otherVehicles = (vehicles || [])

--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -3,7 +3,7 @@ import { useAppContext } from '../context/AppContext';
 import { SPEC_CATEGORIES, formatCustomKey } from '../utils/vehicleSpecSchema';
 import { formatSpecValue, fmtDistance, distanceLabel } from '../utils/unitConversions';
 import { SpecFieldFlagButton } from './VoteButtons';
-import { mergeInheritedSpecs, vehicleLabel } from '../utils/specHelpers';
+import { mergeInheritedSpecs, resolveEffectiveSpecs, vehicleLabel } from '../utils/specHelpers';
 
 export default function SpecsView({ selectedVehicleIds }) {
     // Read vehicles directly from context so optimistic updates (e.g. admin unflag)
@@ -40,12 +40,13 @@ export default function SpecsView({ selectedVehicleIds }) {
         ? selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean)
         : vehicles;
 
-    // Resolve effective specs (own overrides + inherited fallback) for each vehicle.
+    // Resolve effective specs (own overrides + full ancestor chain) for each vehicle.
     const resolvedVehicles = displayVehicles.map(v => {
         const source = v.spec_source_vehicle_id
             ? vehicles.find(sv => sv.id === v.spec_source_vehicle_id)
             : null;
-        const { merged, inheritedKeys } = mergeInheritedSpecs(v.specs, source?.specs);
+        const ancestorSpecs = source ? resolveEffectiveSpecs(source, vehicles, new Set([v.id])) : null;
+        const { merged, inheritedKeys } = mergeInheritedSpecs(v.specs, ancestorSpecs);
         return {
             ...v,
             effectiveSpecs: merged,

--- a/src/components/ViewSpecsModal.jsx
+++ b/src/components/ViewSpecsModal.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useAppContext } from '../context/AppContext';
 import VehicleSpecsDisplay from './VehicleSpecsDisplay';
 import { SpecVouchButton } from './VoteButtons';
-import { mergeInheritedSpecs, vehicleLabel } from '../utils/specHelpers';
+import { mergeInheritedSpecs, resolveEffectiveSpecs, vehicleLabel } from '../utils/specHelpers';
 
 /**
  * Read-only modal showing a vehicle's specs.
@@ -25,9 +25,12 @@ export default function ViewSpecsModal({ vehicle, onClose }) {
     const sourceVehicle = liveVehicle.spec_source_vehicle_id
         ? vehicles.find(v => v.id === liveVehicle.spec_source_vehicle_id)
         : null;
+    const ancestorSpecs = sourceVehicle
+        ? resolveEffectiveSpecs(sourceVehicle, vehicles, new Set([liveVehicle.id]))
+        : null;
     const { merged: effectiveSpecs, inheritedKeys } = mergeInheritedSpecs(
         liveVehicle.specs,
-        sourceVehicle?.specs
+        ancestorSpecs
     );
     const sourceVehicleName = sourceVehicle ? vehicleLabel(sourceVehicle) : null;
 

--- a/src/utils/specHelpers.js
+++ b/src/utils/specHelpers.js
@@ -11,6 +11,34 @@ export function vehicleLabel(v) {
 // ── Spec inheritance merge ────────────────────────────────────────────────────
 
 /**
+ * Walk the full ancestor chain for a vehicle and return its fully-resolved
+ * effective specs — own fields merged over all ancestors — so that grandchild
+ * vehicles see values that were only set on a grandparent.
+ *
+ * _visited: Set of vehicle IDs already seen this walk; stops infinite loops
+ * caused by circular spec_source_vehicle_id references.
+ *
+ * Returns a plain specs object (same shape as vehicle.specs).
+ */
+export function resolveEffectiveSpecs(vehicle, vehicles, _visited = new Set()) {
+    if (!vehicle) return {};
+
+    const parent = vehicle.spec_source_vehicle_id
+        ? vehicles.find(v => v.id === vehicle.spec_source_vehicle_id)
+        : null;
+
+    if (!parent || _visited.has(parent.id)) {
+        // No parent, or cycle detected — own specs are the effective specs.
+        return vehicle.specs ?? {};
+    }
+
+    const visited = new Set([..._visited, vehicle.id]);
+    const parentEffective = resolveEffectiveSpecs(parent, vehicles, visited);
+    const { merged } = mergeInheritedSpecs(vehicle.specs, parentEffective);
+    return merged;
+}
+
+/**
  * Merge own (override) specs with source (inherited) specs.
  * Returns:
  *   merged       — the effective spec object to display


### PR DESCRIPTION
## Summary

- Adds `resolveEffectiveSpecs(vehicle, vehicles, visited)` to `specHelpers.js` — walks the full `spec_source_vehicle_id` chain recursively, merging each level's own overrides on top of the resolved parent, so grandchild vehicles see values set only on a grandparent.
- Cycle guard via a `visited` Set prevents infinite loops if circular references ever exist in data.
- Updates all three call sites: Compare Specs table, read-only spec modal, and edit form inheritance hints.
- The "inherits from X" label still shows the **direct** parent name — only the resolved *value* changes.

**Example fixed:** Ioniq 5 base → LR AWD → 5N. "Transmission Speeds: 1" set on base now flows through to 5N (was `undefined` before).

## Test plan
- [ ] A → B → C chain: field set only on A appears correctly on C with inherited indicator
- [ ] B overriding A's field: C sees B's value, not A's
- [ ] Single-level inheritance still works as before
- [ ] Edit form hint on C shows the chain-resolved value (not undefined)
- [ ] No regressions on vehicles with no inheritance parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)