### PR TITLE
Persist Vehicles tab state + searchable inheritance parent combobox

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,18 @@ export default function App() {
 
     const [activeVehicle, setActiveVehicle] = useState(null);
     const [view, setView] = useState('vehicles');
+
+    // Persist Vehicles tab UI state across tab switches so filters/sort/page
+    // are restored when the user returns.
+    const [vehiclesViewState, setVehiclesViewState] = useState(() => ({
+        textFilter: '',
+        tagFilterStates: {},
+        mfgFilterStates: {},
+        modelFilter: new Set(),
+        sortBy: 'default',
+        viewMode: 'card',
+        vehiclePage: 1,
+    }));
     const [dragOverIdx, setDragOverIdx] = useState(null); // pill drop-indicator position
     const [chartMode, setChartMode] = useState('charging'); // 'charging' | 'range' | 'compare'
     const [compareConfig, setCompareConfig] = useState({ xMinutes: 15, mMiles: 150, startSoc: 10 });
@@ -636,6 +648,8 @@ export default function App() {
                             specCustomFieldSuggestions={specCustomFieldSuggestions}
                             pendingEditVehicle={pendingEditVehicle}
                             onClearPendingEdit={() => setPendingEditVehicle(null)}
+                            savedState={vehiclesViewState}
+                            onSaveState={setVehiclesViewState}
                         />
                     )}
                     {view === 'runs' && currentActiveVehicle && (

--- a/src/components/EditSpecsForm.jsx
+++ b/src/components/EditSpecsForm.jsx
@@ -202,6 +202,8 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
     const [inheritFromId, setInheritFromId] = useState(
         vehicle.spec_source_vehicle_id ? String(vehicle.spec_source_vehicle_id) : ''
     );
+    const [parentSearch, setParentSearch] = useState('');
+    const [showParentDropdown, setShowParentDropdown] = useState(false);
 
     // Load vouch count for display in footer
     useEffect(() => { loadSpecVouches(vehicle.id); }, [vehicle.id]);
@@ -218,10 +220,36 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
         ? resolveEffectiveSpecs(sourceVehicle, vehicles, new Set([vehicle.id]))
         : {};
 
-    // Other vehicles available as inheritance sources (excluding self)
+    // Build the set of descendant IDs so we can exclude them from the parent picker
+    // (selecting a descendant as parent would create a circular inheritance chain).
+    const getDescendantIds = (rootId, allVehicles, visited = new Set()) => {
+        const ids = new Set();
+        for (const v of allVehicles) {
+            if (v.spec_source_vehicle_id === rootId && !visited.has(v.id)) {
+                ids.add(v.id);
+                const childVisited = new Set([...visited, v.id]);
+                for (const d of getDescendantIds(v.id, allVehicles, childVisited)) ids.add(d);
+            }
+        }
+        return ids;
+    };
+    const descendantIds = getDescendantIds(vehicle.id, vehicles || []);
+
+    // Other vehicles available as inheritance sources (excluding self and descendants)
     const otherVehicles = (vehicles || [])
-        .filter(v => v.id !== vehicle.id)
+        .filter(v => v.id !== vehicle.id && !descendantIds.has(v.id))
         .sort((a, b) => vehicleLabel(a).localeCompare(vehicleLabel(b)));
+
+    // Filtered list for combobox
+    const parentSearchLower = parentSearch.toLowerCase();
+    const filteredParents = parentSearch
+        ? otherVehicles.filter(v => vehicleLabel(v).toLowerCase().includes(parentSearchLower))
+        : otherVehicles;
+
+    // Label for the currently-selected parent (shown in the closed combobox)
+    const selectedParentLabel = inheritFromId
+        ? vehicleLabel(otherVehicles.find(v => String(v.id) === inheritFromId) || {})
+        : '';
 
     const toggleCategory = (key) => {
         setOpenCategories(prev => {
@@ -329,21 +357,72 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                 {/* Scrollable body */}
                 <div className="modal-body flex-1 overflow-y-auto">
 
-                    {/* ── Inherit from selector ── */}
-                    <div className="flex items-center gap-3 mb-4 pb-4 border-b">
-                        <label className="text-sm font-medium text-gray-600 whitespace-nowrap">Inherit from:</label>
-                        <select
-                            value={inheritFromId}
-                            onChange={e => setInheritFromId(e.target.value)}
-                            className="form-input text-sm flex-1"
-                        >
-                            <option value="">— None —</option>
-                            {otherVehicles.map(v => (
-                                <option key={v.id} value={String(v.id)}>{vehicleLabel(v)}</option>
-                            ))}
-                        </select>
+                    {/* ── Inherit from selector (combobox) ── */}
+                    <div className="mb-4 pb-4 border-b">
+                        <div className="flex items-center gap-3">
+                            <label className="text-sm font-medium text-gray-600 whitespace-nowrap">Inherit from:</label>
+                            <div className="relative flex-1">
+                                {showParentDropdown ? (
+                                    <input
+                                        autoFocus
+                                        type="text"
+                                        value={parentSearch}
+                                        onChange={e => setParentSearch(e.target.value)}
+                                        onBlur={() => setTimeout(() => setShowParentDropdown(false), 150)}
+                                        placeholder="Type to filter vehicles…"
+                                        className="form-input text-sm w-full"
+                                    />
+                                ) : (
+                                    <button
+                                        type="button"
+                                        onClick={() => { setParentSearch(''); setShowParentDropdown(true); }}
+                                        className="form-input text-sm w-full text-left truncate"
+                                    >
+                                        {selectedParentLabel || <span className="text-gray-400">— None —</span>}
+                                    </button>
+                                )}
+                                {showParentDropdown && (
+                                    <ul className="absolute z-50 mt-1 w-full max-h-52 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
+                                        <li
+                                            className="px-3 py-2 text-sm cursor-pointer text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700"
+                                            onMouseDown={() => {
+                                                setInheritFromId('');
+                                                setShowParentDropdown(false);
+                                                setParentSearch('');
+                                            }}
+                                        >
+                                            — None —
+                                        </li>
+                                        {filteredParents.map(v => (
+                                            <li
+                                                key={v.id}
+                                                className={`px-3 py-2 text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900 ${String(v.id) === inheritFromId ? 'font-semibold text-indigo-600 dark:text-indigo-300' : ''}`}
+                                                onMouseDown={() => {
+                                                    setInheritFromId(String(v.id));
+                                                    setShowParentDropdown(false);
+                                                    setParentSearch('');
+                                                }}
+                                            >
+                                                {vehicleLabel(v)}
+                                            </li>
+                                        ))}
+                                        {filteredParents.length === 0 && (
+                                            <li className="px-3 py-2 text-sm text-gray-400 italic">No matches</li>
+                                        )}
+                                    </ul>
+                                )}
+                            </div>
+                            {inheritFromId && (
+                                <button
+                                    type="button"
+                                    onClick={() => setInheritFromId('')}
+                                    className="text-gray-400 hover:text-gray-600 text-lg leading-none flex-shrink-0"
+                                    title="Clear inheritance"
+                                >×</button>
+                            )}
+                        </div>
                         {sourceVehicle && (
-                            <p className="text-xs text-indigo-500 whitespace-nowrap">
+                            <p className="text-xs text-indigo-500 mt-1.5">
                                 Fields you leave blank will show <span className="font-medium">↑ inherited</span> hints.
                             </p>
                         )}

--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -15,6 +15,55 @@ export default function SpecsView({ selectedVehicleIds }) {
     const pendingFlagsRef = useRef(pendingFlags);
     useEffect(() => { pendingFlagsRef.current = pendingFlags; }, [pendingFlags]);
 
+    // ── Sticky mirror scrollbar ───────────────────────────────────────────────
+    // The real scroll container is deep inside the page; its native scrollbar
+    // only appears at the very bottom of the content. The mirror scrollbar sticks
+    // to the bottom of the viewport and overlays the table so it is always reachable.
+    const tableContainerRef = useRef(null);
+    const mirrorRef = useRef(null);
+    const isSyncing = useRef(false);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const [mirrorInnerWidth, setMirrorInnerWidth] = useState(0);
+
+    useEffect(() => {
+        const container = tableContainerRef.current;
+        if (!container) return;
+        const update = () => {
+            setIsOverflowing(container.scrollWidth > container.clientWidth + 1);
+            setMirrorInnerWidth(container.scrollWidth);
+        };
+        update();
+        const ro = new ResizeObserver(update);
+        ro.observe(container);
+        const table = container.querySelector('table');
+        if (table) ro.observe(table);
+        return () => ro.disconnect();
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        const container = tableContainerRef.current;
+        const mirror = mirrorRef.current;
+        if (!container || !mirror) return;
+        const onContainerScroll = () => {
+            if (isSyncing.current) return;
+            isSyncing.current = true;
+            mirror.scrollLeft = container.scrollLeft;
+            isSyncing.current = false;
+        };
+        const onMirrorScroll = () => {
+            if (isSyncing.current) return;
+            isSyncing.current = true;
+            container.scrollLeft = mirror.scrollLeft;
+            isSyncing.current = false;
+        };
+        container.addEventListener('scroll', onContainerScroll, { passive: true });
+        mirror.addEventListener('scroll', onMirrorScroll, { passive: true });
+        return () => {
+            container.removeEventListener('scroll', onContainerScroll);
+            mirror.removeEventListener('scroll', onMirrorScroll);
+        };
+    }, []);
+
     // Commit all pending flags on tab leave (component unmount).
     useEffect(() => {
         return () => {
@@ -180,7 +229,7 @@ export default function SpecsView({ selectedVehicleIds }) {
                     </p>
                 </div>
             ) : (
-                <div className="specs-table-container">
+                <div className="specs-table-container" ref={tableContainerRef}>
                     <table className="w-full">
                         <thead className="bg-gray-50 dark:bg-blue-950 dark:text-slate-100">
                             <tr>
@@ -234,6 +283,23 @@ export default function SpecsView({ selectedVehicleIds }) {
                     </table>
                 </div>
             )}
+
+            {/* Sticky mirror scrollbar — always reachable at the bottom of the viewport.
+                Uses negative margin-top to float over the table rather than push it down. */}
+            <div
+                ref={mirrorRef}
+                className="sticky bottom-0 z-20 overflow-x-scroll overflow-y-hidden"
+                style={{
+                    height: 16,
+                    marginTop: -16,
+                    visibility: isOverflowing ? 'visible' : 'hidden',
+                    background: 'var(--color-card)',
+                    boxShadow: '0 -2px 6px rgba(0,0,0,0.10)',
+                    borderRadius: '0 0 8px 8px',
+                }}
+            >
+                <div style={{ width: mirrorInnerWidth, height: 1 }} />
+            </div>
         </div>
     );
 }

--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -288,10 +288,10 @@ export default function SpecsView({ selectedVehicleIds }) {
                 Uses negative margin-top to float over the table rather than push it down. */}
             <div
                 ref={mirrorRef}
-                className="sticky bottom-0 z-20 overflow-x-scroll overflow-y-hidden"
+                className="sticky bottom-2.5 z-20 overflow-x-scroll overflow-y-hidden"
                 style={{
-                    height: 16,
-                    marginTop: -16,
+                    height: 24,
+                    marginTop: -24,
                     visibility: isOverflowing ? 'visible' : 'hidden',
                     background: 'var(--color-card)',
                     boxShadow: '0 -2px 6px rgba(0,0,0,0.10)',

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -451,8 +451,13 @@ export default function VehiclesView({
         setPendingOrder(null);
     };
 
-    // Reset to page 1 when filter/sort changes
-    useEffect(() => { setVehiclePage(1); }, [textFilter, tagFilterStates, sortBy, mfgFilterStates]);
+    // Reset to page 1 when filter/sort changes — but NOT on the initial mount,
+    // otherwise the effect would immediately overwrite the restored vehiclePage.
+    const didMount = useRef(false);
+    useEffect(() => {
+        if (!didMount.current) { didMount.current = true; return; }
+        setVehiclePage(1);
+    }, [textFilter, tagFilterStates, sortBy, mfgFilterStates]);
 
     const showReorderButtons = canEdit({}) && sortBy === 'default'
         && textFilter.trim() === '' && Object.keys(tagFilterStates).length === 0

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { fmtDistance } from '../utils/unitConversions';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
@@ -33,6 +33,7 @@ export default function VehiclesView({
     onReorderVehicles, onDuplicateVehicle,
     onUpdateVehicleSpecs, specCustomFieldSuggestions,
     pendingEditVehicle, onClearPendingEdit,
+    savedState, onSaveState,
 }) {
     const [showForm, setShowForm] = useState(false);
     const [editingId, setEditingId] = useState(null);
@@ -40,23 +41,38 @@ export default function VehiclesView({
         name: '', make: '', model: '', trim: '', year: '',
         battery: '', range: '', manufacturer_id: null,
     });
-    const [mfgFilterStates, setMfgFilterStates] = useState({}); // { [mfgId]: 'or' | 'not' }
-    const [modelFilter, setModelFilter] = useState(new Set());
+    const [mfgFilterStates, setMfgFilterStates] = useState(savedState?.mfgFilterStates ?? {}); // { [mfgId]: 'or' | 'not' }
+    const [modelFilter, setModelFilter] = useState(savedState?.modelFilter ?? new Set());
     const [formTags, setFormTags] = useState([]);
     const [newTagName, setNewTagName] = useState('');
-    const [tagFilterStates, setTagFilterStates] = useState({}); // { [tagId]: 'or' | 'and' | 'not' }
+    const [tagFilterStates, setTagFilterStates] = useState(savedState?.tagFilterStates ?? {}); // { [tagId]: 'or' | 'and' | 'not' }
     const [imageUploading, setImageUploading] = useState(false);
-    const [viewMode, setViewMode] = useState('card'); // 'card' | 'list'
-    const [sortBy, setSortBy] = useState('default');
-    const [textFilter, setTextFilter] = useState('');
+    const [viewMode, setViewMode] = useState(savedState?.viewMode ?? 'card'); // 'card' | 'list'
+    const [sortBy, setSortBy] = useState(savedState?.sortBy ?? 'default');
+    const [textFilter, setTextFilter] = useState(savedState?.textFilter ?? '');
     const [editingOrder, setEditingOrder] = useState(false);
     const [pendingOrder, setPendingOrder] = useState(null);   // [{id, sort_order}] or null
     const [savingOrder, setSavingOrder]   = useState(false);
     const [duplicatingId, setDuplicatingId] = useState(null);
-    const [vehiclePage, setVehiclePage] = useState(1);
+    const [vehiclePage, setVehiclePage] = useState(savedState?.vehiclePage ?? 1);
     const [specsEditingVehicle, setSpecsEditingVehicle] = useState(null);
     const [specsViewingVehicle, setSpecsViewingVehicle] = useState(null);
     const VEHICLES_PER_PAGE = 24;
+
+    // Keep a ref always pointing at latest filter/sort/page so the unmount
+    // cleanup can save it without stale-closure issues.
+    const persistableState = useRef({});
+    useEffect(() => {
+        persistableState.current = {
+            textFilter, tagFilterStates, mfgFilterStates, modelFilter,
+            sortBy, viewMode, vehiclePage,
+        };
+    }, [textFilter, tagFilterStates, mfgFilterStates, modelFilter, sortBy, viewMode, vehiclePage]);
+
+    // Save state back to App when this tab is left (unmount).
+    useEffect(() => {
+        return () => { onSaveState?.(persistableState.current); };
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentional: fire only on unmount
 
     const { units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink, user } = useAppContext();
 


### PR DESCRIPTION
## Summary

- **Vehicles tab state persistence** — filters (text, tag, brand, model), sort order, view mode (card/list), and page number are now preserved when switching to another tab and returning. State is lifted to `App.jsx` as `vehiclesViewState` and restored via `savedState` prop; saved back on unmount via a ref to avoid stale-closure issues.
- **Searchable inheritance parent picker** — replaces the plain `<select>` dropdown in Edit Specs with a live-filter combobox. Click to open, type to narrow (e.g. "6" matches "EV6" or "Ioniq 6"), click a row to select. Closes with the chosen vehicle name displayed. A clear × button appears when a parent is selected. Descendants of the current vehicle are excluded from candidates to prevent circular inheritance chains.

## Test plan

- [ ] Set filters / sort / view mode / page in the Vehicles tab, navigate to Charts, return — state is fully restored
- [ ] Switching multiple times doesn't accumulate stale state
- [ ] Open Edit Specs, click "Inherit from" — dropdown appears with all vehicles except self and descendants
- [ ] Type partial name (e.g. "6") — list narrows in real time
- [ ] Select a vehicle — dropdown closes, button shows the selected name
- [ ] Click × — clears the selection
- [ ] Blur without selecting — dropdown closes without changing selection
- [ ] Vehicles that are descendants of the current vehicle do not appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)