### PR TITLE
Add EPA road-load curves chart tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import PopoutView from './components/PopoutView';
 import SpecsView from './components/SpecsView';
 import SpecsChartView from './components/SpecsChartView';
 import SpecsScatterView from './components/SpecsScatterView';
+import EpaCurvesView from './components/EpaCurvesView';
 import AdminView from './components/AdminView';
 
 export default function App() {
@@ -86,8 +87,9 @@ export default function App() {
         vehiclePage: 1,
     }));
     const [dragOverIdx, setDragOverIdx] = useState(null); // pill drop-indicator position
-    const [chartMode, setChartMode] = useState('charging'); // 'charging' | 'range' | 'compare'
+    const [chartMode, setChartMode] = useState('charging'); // 'charging' | 'range' | 'compare' | 'epacurves' | …
     const [compareConfig, setCompareConfig] = useState({ xMinutes: 15, mMiles: 150, startSoc: 10 });
+    const [epaConfig, setEpaConfig] = useState({ yAxis: 'kwh100mi', xMin: null, xMax: null, yMin: null, yMax: null });
     const [roadTripConfig, setRoadTripConfig] = useState({
         mode: 'distance', startSoc: 90, minSoc: 10,
         legDistance: 150, chargeTime: 30,
@@ -135,8 +137,8 @@ export default function App() {
     const themeTitle = theme === 'dark' ? 'Dark mode (click for system)' : theme === 'light' ? 'Light mode (click for dark)' : 'System theme (click for light)';
 
     const { isPopout, sendState } = useChartSync({
-        chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig,
-        setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig,
+        chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig,
+        setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig,
     });
 
     // Navigate to a new top-level view and push a browser history entry so the
@@ -211,6 +213,10 @@ export default function App() {
             ...(n('rt_tr') != null && { towingRefSpeedMph:  n('rt_tr')          }),
         };
         if (Object.keys(rtOverride).length > 0) setRoadTripConfig(prev => ({ ...prev, ...rtOverride }));
+
+        // EPA Curves config
+        const epaYa = p.get('epa_ya');
+        if (epaYa) setEpaConfig(prev => ({ ...prev, yAxis: epaYa }));
     }, []);
 
     // ── Handle browser back/forward ─────────────────────────────────────────
@@ -331,13 +337,18 @@ export default function App() {
             if (chartConfig.scatterYField) p.set('scy', chartConfig.scatterYField);
         }
 
+        // EPA Curves options
+        if (chartMode === 'epacurves') {
+            if (epaConfig.yAxis && epaConfig.yAxis !== 'kwh100mi') p.set('epa_ya', epaConfig.yAxis);
+        }
+
         history.replaceState({ view: 'chart', chartMode }, '', '?' + p.toString());
-    }, [view, chartConfig, selectedVehicles, chartMode, vehicles, compareConfig, roadTripConfig]);
+    }, [view, chartConfig, selectedVehicles, chartMode, vehicles, compareConfig, roadTripConfig, epaConfig]);
 
     // ── Broadcast chart state to any open pop-out windows ───────────────────
     useEffect(() => {
         sendState();
-    }, [chartMode, chartConfig, selectedVehicles, compareConfig, sendState]);
+    }, [chartMode, chartConfig, selectedVehicles, compareConfig, epaConfig, sendState]);
 
     // Keep activeVehicle in sync with vehicles state
     const currentActiveVehicle = activeVehicle
@@ -365,6 +376,7 @@ export default function App() {
                 setChartConfig={setChartConfig}
                 compareConfig={compareConfig}
                 roadTripConfig={roadTripConfig}
+                epaConfig={epaConfig}
                 onUpdateRunColor={updateRunColor}
             />
         );
@@ -514,6 +526,7 @@ export default function App() {
                                         { key: 'roadtrip',  label: 'Road Trip' },
                                         { key: 'specs',       label: 'Spec Chart' },
                                         { key: 'specscatter', label: 'Spec Scatter' },
+                                        { key: 'epacurves',   label: 'EPA Curves' },
                                     ].map(({ key, label }) => (
                                         <button
                                             key={key}
@@ -729,6 +742,14 @@ export default function App() {
                             xField={chartConfig.scatterXField}
                             yField={chartConfig.scatterYField}
                             onFieldChange={(x, y) => setChartConfig(p => ({ ...p, scatterXField: x, scatterYField: y }))}
+                        />
+                    )}
+                    {view === 'chart' && chartMode === 'epacurves' && (
+                        <EpaCurvesView
+                            vehicles={vehicles}
+                            selectedVehicleIds={selectedVehicles}
+                            epaConfig={epaConfig}
+                            setEpaConfig={setEpaConfig}
                         />
                     )}
                     {view === 'specs' && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -697,7 +697,7 @@ export default function App() {
                             onCopyRunToVehicle={(run, targetId) => copyRunToVehicle(currentActiveVehicle.id, run, targetId)}
                         />
                     )}
-                    {view === 'chart' && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'specscatter' && chartMode !== 'roadtrip' && (
+                    {view === 'chart' && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'specscatter' && chartMode !== 'roadtrip' && chartMode !== 'epacurves' && (
                         <ChargingView
                             vehicles={vehicles}
                             selectedVehicleIds={selectedVehicles}

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import ImportTableauModal from './ImportTableauModal';
 import EpaImportModal from './EpaImportModal';
+import EpaDataCard from './EpaDataCard';
 
 const ROLES = ['user', 'contributor', 'admin'];
 
@@ -12,7 +13,11 @@ const roleBadgeStyle = {
 };
 
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
-    const { exportData, importData, importTableauSessions, importEpaTestGroups, vehicles } = useAppContext();
+    const {
+        exportData, importData, importTableauSessions,
+        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup,
+        vehicles,
+    } = useAppContext();
     const [users, setUsers]           = useState([]);
     const [loading, setLoading]       = useState(true);
     const [saving, setSaving]         = useState(null);
@@ -181,6 +186,11 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                     <li><em>Unauthenticated</em> — read-only access to public content</li>
                 </ul>
             </div>
+
+            <EpaDataCard
+                getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
+                deleteEpaTestGroup={deleteEpaTestGroup}
+            />
         </div>
     );
 }

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -15,7 +15,7 @@ const roleBadgeStyle = {
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
     const {
         exportData, importData, importTableauSessions,
-        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup,
+        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod,
         vehicles,
     } = useAppContext();
     const [users, setUsers]           = useState([]);
@@ -190,6 +190,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
             <EpaDataCard
                 getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
                 deleteEpaTestGroup={deleteEpaTestGroup}
+                updateEpaLabelMethod={updateEpaLabelMethod}
             />
         </div>
     );

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -15,7 +15,7 @@ const roleBadgeStyle = {
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
     const {
         exportData, importData, importTableauSessions,
-        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod,
+        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod, updateEpaTestGroup,
         vehicles,
     } = useAppContext();
     const [users, setUsers]           = useState([]);
@@ -191,6 +191,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                 getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
                 deleteEpaTestGroup={deleteEpaTestGroup}
                 updateEpaLabelMethod={updateEpaLabelMethod}
+                updateEpaTestGroup={updateEpaTestGroup}
             />
         </div>
     );

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import ImportTableauModal from './ImportTableauModal';
+import EpaImportModal from './EpaImportModal';
 
 const ROLES = ['user', 'contributor', 'admin'];
 
@@ -11,13 +12,14 @@ const roleBadgeStyle = {
 };
 
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
-    const { exportData, importData, importTableauSessions, vehicles } = useAppContext();
+    const { exportData, importData, importTableauSessions, importEpaTestGroups, vehicles } = useAppContext();
     const [users, setUsers]           = useState([]);
     const [loading, setLoading]       = useState(true);
     const [saving, setSaving]         = useState(null);
     const [error, setError]           = useState(null);
     const [showImportMenu, setShowImportMenu] = useState(false);
     const [showTableauModal, setShowTableauModal] = useState(false);
+    const [showEpaModal, setShowEpaModal]         = useState(false);
     const jsonImportRef = useRef();
 
     useEffect(() => {
@@ -58,6 +60,13 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                     onClose={() => setShowTableauModal(false)}
                 />
             )}
+            {showEpaModal && (
+                <EpaImportModal
+                    vehicles={vehicles}
+                    onImport={importEpaTestGroups}
+                    onClose={() => setShowEpaModal(false)}
+                />
+            )}
             <div className="flex justify-between items-center mb-6">
                 <div>
                     <h2 className="page-title">Admin Panel</h2>
@@ -83,6 +92,10 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                                     <button className="dropdown-item w-full text-left"
                                         onClick={() => { setShowImportMenu(false); setShowTableauModal(true); }}>
                                         📊 Tableau CSV
+                                    </button>
+                                    <button className="dropdown-item w-full text-left"
+                                        onClick={() => { setShowImportMenu(false); setShowEpaModal(true); }}>
+                                        ⚡ EPA Test Car Data
                                     </button>
                                 </div>
                             </>

--- a/src/components/AxisScaleControls.jsx
+++ b/src/components/AxisScaleControls.jsx
@@ -1,6 +1,6 @@
 /**
  * Shared Y/X axis min-max scale controls.
- * Used by ChargingView (charging) and RangeChartView (range & efficiency).
+ * Used below charts in ChargingView, RangeChartView, RoadTripView, EpaCurvesView.
  *
  * Props:
  *   xMin, xMax, yMin, yMax        – current values (null = auto)
@@ -13,15 +13,28 @@
  *   xAxisLabel                     – label for the X-axis section (default "X-Axis Scale").
  *                                    Pass e.g. "X-Axis Scale (hrs)" to hint at expected units.
  *   yAxisLabel                     – label for the left Y-axis section (default "Left Axis Scale").
+ *
+ * Card wrapping (design pattern):
+ *   By default this component renders itself inside a `card mb-6` container so that
+ *   chart views don't need to remember to add one. Pass `card={false}` when the
+ *   parent already manages a shared card (e.g. ChargingView bundles axis controls
+ *   together with race-mode and line-toggle panels in one card).
  */
 
-export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max, onChange, showX = true, showY2 = false, xAxisLabel = 'X-Axis Scale', yAxisLabel = 'Left Axis Scale' }) {
+export default function AxisScaleControls({
+    xMin, xMax, yMin, yMax, y2Min, y2Max,
+    onChange,
+    showX = true, showY2 = false,
+    xAxisLabel = 'X-Axis Scale',
+    yAxisLabel = 'Left Axis Scale',
+    card = true,
+}) {
     const colCount = 1 + (showX ? 1 : 0) + (showY2 ? 1 : 0);
     const gridClass = colCount === 3 ? 'grid-cols-3'
                     : colCount === 2 ? 'grid-cols-2'
                     : 'grid-cols-1 max-w-xs';
 
-    return (
+    const content = (
         <div className={`grid gap-8 ${gridClass}`}>
 
             {/* ── Y-Axis Scale ─────────────────────────────────────────────── */}
@@ -138,4 +151,6 @@ export default function AxisScaleControls({ xMin, xMax, yMin, yMax, y2Min, y2Max
             )}
         </div>
     );
+
+    return card ? <div className="card mb-6">{content}</div> : content;
 }

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -752,6 +752,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     y2Min={chartConfig.y2Min} y2Max={chartConfig.y2Max}
                     onChange={(key, val) => setChartConfig(prev => ({ ...prev, [key]: val }))}
                     showY2={!!chartConfig.y2Axis}
+                    card={false}
                 />
 
                 {/* ── Race mode panel — only visible when X = Time ── */}

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -179,9 +179,12 @@ export default function EditVehicleForm({
         epaDebounceRef.current = setTimeout(async () => {
             setEpaSearching(true);
             try {
-                const year = formData.year ? parseInt(formData.year, 10) : null;
-                const rows = await searchEpaTestGroups?.(q.trim(), year);
+                // No year filter — EPA model years often differ from the vehicle's model year;
+                // the year is visible in dropdown results for manual verification.
+                const rows = await searchEpaTestGroups?.(q.trim());
                 setEpaResults(rows || []);
+            } catch {
+                setEpaResults([]);
             } finally {
                 setEpaSearching(false);
             }

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -4,6 +4,8 @@
 import { useState, useRef, useCallback } from 'react';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
+import InfoIcon from './InfoIcon';
+import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 
 const ASPECT = 16 / 9;
 const MAX_W = 1600;
@@ -43,6 +45,20 @@ function getCroppedBlob(imgEl, completedCrop) {
     });
 }
 
+// Confidence badge — same style as EpaCurvesView
+const CONFIDENCE_COLORS = {
+    verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
+    likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
+    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+};
+function ConfidenceBadge({ confidence }) {
+    return (
+        <span className={`text-xs px-1.5 py-0.5 rounded border font-medium ${CONFIDENCE_COLORS[confidence] ?? CONFIDENCE_COLORS.inferred}`}>
+            {confidence}
+        </span>
+    );
+}
+
 export default function EditVehicleForm({
     formData, onFormChange,
     editingId,
@@ -55,6 +71,11 @@ export default function EditVehicleForm({
     // Manufacturer
     manufacturers = [],
     onAddManufacturer,
+    // EPA linking (edit mode only, contributor+)
+    searchEpaTestGroups,
+    onLinkEpaTestGroup,
+    onUpdateEpaMapping,
+    onUnlinkEpaTestGroup,
 }) {
     const [imgSrc, setImgSrc] = useState('');
     const [crop, setCrop] = useState();
@@ -67,6 +88,15 @@ export default function EditVehicleForm({
     const [newMfgName, setNewMfgName] = useState('');
     const [newMfgCountry, setNewMfgCountry] = useState('');
     const [mfgSaving, setMfgSaving] = useState(false);
+
+    // ── EPA linking state ─────────────────────────────────────────────────────
+    const [epaQuery, setEpaQuery]           = useState('');
+    const [epaResults, setEpaResults]       = useState([]);
+    const [epaSearching, setEpaSearching]   = useState(false);
+    const [showEpaDropdown, setShowEpaDropdown] = useState(false);
+    const [epaLinking, setEpaLinking]       = useState(false);  // in-flight link
+    const [epaUnlinking, setEpaUnlinking]   = useState(null);   // mappingId being unlinked
+    const epaDebounceRef = useRef(null);
 
     const handleFileSelect = (e) => {
         const file = e.target.files[0];
@@ -137,6 +167,56 @@ export default function EditVehicleForm({
         }
     };
 
+
+    // ── EPA linking handlers ──────────────────────────────────────────────────
+
+    const handleEpaQueryChange = (e) => {
+        const q = e.target.value;
+        setEpaQuery(q);
+        setShowEpaDropdown(true);
+        if (epaDebounceRef.current) clearTimeout(epaDebounceRef.current);
+        if (!q.trim()) { setEpaResults([]); return; }
+        epaDebounceRef.current = setTimeout(async () => {
+            setEpaSearching(true);
+            try {
+                const year = formData.year ? parseInt(formData.year, 10) : null;
+                const rows = await searchEpaTestGroups?.(q.trim(), year);
+                setEpaResults(rows || []);
+            } finally {
+                setEpaSearching(false);
+            }
+        }, 300);
+    };
+
+    const handleEpaSelect = async (group) => {
+        setShowEpaDropdown(false);
+        setEpaQuery('');
+        setEpaResults([]);
+        if (!editingId || !onLinkEpaTestGroup) return;
+        setEpaLinking(true);
+        try {
+            await onLinkEpaTestGroup(editingId, group.test_group_id, 'inferred', null);
+        } finally {
+            setEpaLinking(false);
+        }
+    };
+
+    const handleEpaUnlink = async (mappingId) => {
+        if (!onUnlinkEpaTestGroup) return;
+        setEpaUnlinking(mappingId);
+        try {
+            await onUnlinkEpaTestGroup(mappingId);
+        } finally {
+            setEpaUnlinking(null);
+        }
+    };
+
+    const handleConfidenceChange = async (mappingId, confidence) => {
+        await onUpdateEpaMapping?.(mappingId, { confidence });
+    };
+
+    // Current EPA mappings come from editingVehicle (refreshed by parent on success)
+    const currentEpaMappings = editingVehicle?.epa_mappings ?? [];
 
     return (
         <>
@@ -301,6 +381,103 @@ export default function EditVehicleForm({
                             />
                         </label>
                         <p className="text-xs text-gray-400 mt-1">16:9 crop · max 1600×900 · saved as JPEG</p>
+                    </div>
+                )}
+
+                {/* EPA Test Group linking — edit mode only */}
+                {editingId && searchEpaTestGroups && (
+                    <div className="form-section mt-5">
+                        <label className="block font-medium mb-2">
+                            EPA Test Group
+                            <InfoIcon
+                                text={EPA_EXPLAINERS.roadLoad}
+                                position="right"
+                                className="ml-1"
+                            />
+                        </label>
+
+                        {/* Current mappings list */}
+                        {currentEpaMappings.length === 0 ? (
+                            <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">No EPA test group linked yet.</p>
+                        ) : (
+                            <div className="flex flex-col gap-2 mb-3">
+                                {currentEpaMappings.map(m => {
+                                    const g = m.epaGroup;
+                                    if (!g) return null;
+                                    return (
+                                        <div key={m.id} className="flex items-center gap-2 flex-wrap rounded border border-gray-200 dark:border-slate-600 p-2 text-sm">
+                                            <span className="flex-1 min-w-0">
+                                                <span className="font-medium">{g.epa_carline_name}</span>
+                                                <span className="text-gray-500 dark:text-slate-400 ml-1">({g.model_year})</span>
+                                                {m.notes && (
+                                                    <span className="text-gray-500 dark:text-slate-400 ml-1">· {m.notes}</span>
+                                                )}
+                                            </span>
+                                            <select
+                                                value={m.confidence}
+                                                onChange={e => handleConfidenceChange(m.id, e.target.value)}
+                                                className="form-input text-xs py-0.5 w-28"
+                                            >
+                                                <option value="verified">Verified</option>
+                                                <option value="likely">Likely</option>
+                                                <option value="inferred">Inferred</option>
+                                            </select>
+                                            <ConfidenceBadge confidence={m.confidence} />
+                                            <button
+                                                type="button"
+                                                disabled={epaUnlinking === m.id}
+                                                onClick={() => handleEpaUnlink(m.id)}
+                                                className="btn btn-secondary text-xs py-0.5 px-2 disabled:opacity-40"
+                                            >
+                                                {epaUnlinking === m.id ? 'Unlinking…' : 'Unlink'}
+                                            </button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* Search combobox for adding a new mapping */}
+                        <div className="relative">
+                            <input
+                                type="text"
+                                placeholder="Search EPA test groups by make or carline…"
+                                value={epaQuery}
+                                onChange={handleEpaQueryChange}
+                                onFocus={() => epaQuery && setShowEpaDropdown(true)}
+                                onBlur={() => setTimeout(() => setShowEpaDropdown(false), 150)}
+                                className="form-input text-sm w-full"
+                                disabled={epaLinking}
+                            />
+                            {epaLinking && (
+                                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500 dark:text-slate-400">Linking…</span>
+                            )}
+                            {showEpaDropdown && (epaResults.length > 0 || epaSearching) && (
+                                <ul className="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
+                                    {epaSearching && (
+                                        <li className="px-3 py-2 text-sm text-gray-400 italic">Searching…</li>
+                                    )}
+                                    {!epaSearching && epaResults.map(g => (
+                                        <li
+                                            key={g.test_group_id}
+                                            className="px-3 py-2 text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900"
+                                            onMouseDown={e => { e.preventDefault(); handleEpaSelect(g); }}
+                                        >
+                                            <span className="font-medium">{g.make} · {g.epa_carline_name}</span>
+                                            <span className="text-gray-400 ml-2">
+                                                {g.model_year}{g.drive ? ` · ${g.drive}` : ''} · {g.test_group_id}
+                                            </span>
+                                        </li>
+                                    ))}
+                                    {!epaSearching && epaResults.length === 0 && epaQuery.trim() && (
+                                        <li className="px-3 py-2 text-sm text-gray-400 italic">No results</li>
+                                    )}
+                                </ul>
+                            )}
+                        </div>
+                        <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                            Results are pre-filtered by vehicle year when available.
+                        </p>
                     </div>
                 )}
 

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -1,0 +1,484 @@
+import { useEffect, useRef, useMemo, useState } from 'react';
+import Chart from 'chart.js/auto';
+import { useTheme } from '../hooks/useTheme';
+import { useAppContext } from '../context/AppContext';
+import { convSpeed, speedLabel, distanceLabel } from '../utils/unitConversions';
+import { vehicleColor, vehicleLabel } from '../utils/specHelpers';
+import { PALETTE } from '../utils/specHelpers';
+import {
+    buildEpaCurve, resolveUseableKwh,
+    HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH,
+} from '../utils/epaPhysics';
+import InfoIcon from './InfoIcon';
+import { EPA_EXPLAINERS } from '../utils/epaExplainers';
+
+// ── Reference line / highway band plugin ─────────────────────────────────────
+
+/**
+ * Draws the highway speed band and two reference speed lines after Chart.js
+ * renders its datasets. Follows the same afterDraw pattern as barGroupPlugin
+ * and makeBarPlugin in other chart views.
+ */
+function makeReferencePlugin(hwfetMph, us06Mph, bandMph, units, isDark) {
+    return {
+        id: 'epaReferenceLines',
+        afterDraw(chart) {
+            const { ctx, chartArea: area, scales } = chart;
+            if (!area || !scales.x) return;
+
+            const x = v => scales.x.getPixelForValue(convSpeed(v, units));
+            const textColor  = isDark ? 'rgba(226,232,240,0.6)' : 'rgba(107,114,128,0.8)';
+            const bandColor  = isDark ? 'rgba(59,130,246,0.07)' : 'rgba(59,130,246,0.06)';
+            const lineHwfet  = isDark ? 'rgba(99,102,241,0.45)'  : 'rgba(99,102,241,0.55)';
+            const lineUs06   = isDark ? 'rgba(168,85,247,0.40)'  : 'rgba(168,85,247,0.50)';
+
+            ctx.save();
+
+            // 65–75 mph highway band
+            const xBand0 = x(bandMph[0]);
+            const xBand1 = x(bandMph[1]);
+            ctx.fillStyle = bandColor;
+            ctx.fillRect(xBand0, area.top, xBand1 - xBand0, area.bottom - area.top);
+
+            // Helper: draw one dashed vertical line with a rotated label at the top
+            const drawLine = (mph, color, label) => {
+                const px = x(mph);
+                if (px < area.left || px > area.right) return;
+                ctx.beginPath();
+                ctx.strokeStyle = color;
+                ctx.lineWidth = 1;
+                ctx.setLineDash([4, 4]);
+                ctx.moveTo(px, area.top);
+                ctx.lineTo(px, area.bottom);
+                ctx.stroke();
+                ctx.setLineDash([]);
+                // Rotated label
+                ctx.save();
+                ctx.translate(px - 3, area.top + 4);
+                ctx.rotate(-Math.PI / 2);
+                ctx.font = '10px system-ui, sans-serif';
+                ctx.fillStyle = textColor;
+                ctx.textAlign = 'left';
+                ctx.fillText(label, 0, 0);
+                ctx.restore();
+            };
+
+            drawLine(hwfetMph, lineHwfet, `HWFET avg (${convSpeed(hwfetMph, units)} ${speedLabel(units)})`);
+            drawLine(us06Mph,  lineUs06,  `US06 avg (${convSpeed(us06Mph, units)} ${speedLabel(units)})`);
+
+            // Band label
+            ctx.font = '9px system-ui, sans-serif';
+            ctx.fillStyle = textColor;
+            ctx.textAlign = 'center';
+            const bandMid = (xBand0 + xBand1) / 2;
+            ctx.fillText('Hwy', bandMid, area.top + 10);
+
+            ctx.restore();
+        },
+    };
+}
+
+// ── Y-axis mode config ────────────────────────────────────────────────────────
+
+const Y_MODES = [
+    { key: 'kwh100mi', label: 'kWh/100mi' },
+    { key: 'mi_kwh',   label: 'mi/kWh'    },
+    { key: 'mpge',     label: 'MPGe'       },
+    { key: 'range_mi', label: 'Range (mi)' },
+];
+
+function getYValue(point, yAxis) {
+    switch (yAxis) {
+        case 'kwh100mi': return point.kwh100mi;
+        case 'mi_kwh':   return point.miPerKwh;
+        case 'mpge':     return point.mpge;
+        case 'range_mi': return point.rangeMi;
+        default:         return point.kwh100mi;
+    }
+}
+
+function yAxisLabel(yAxis, units) {
+    if (yAxis === 'range_mi') return `Range (${distanceLabel(units)})`;
+    if (units === 'metric') {
+        if (yAxis === 'kwh100mi') return 'kWh/100km';
+        if (yAxis === 'mi_kwh')   return 'km/kWh';
+    }
+    if (yAxis === 'kwh100mi') return 'kWh/100mi';
+    if (yAxis === 'mi_kwh')   return 'mi/kWh';
+    if (yAxis === 'mpge')     return 'MPGe';
+    return '';
+}
+
+/** Convert a Y value from imperial to metric for display. */
+function convertYValue(val, yAxis, units) {
+    if (val == null) return null;
+    if (units !== 'metric') return val;
+    if (yAxis === 'kwh100mi') return val / 1.60934;  // kWh/100mi → kWh/100km
+    if (yAxis === 'mi_kwh')   return val * 1.60934;  // mi/kWh → km/kWh
+    if (yAxis === 'range_mi') return val * 1.60934;  // mi → km
+    return val; // MPGe stays as-is
+}
+
+// ── Confidence badge ──────────────────────────────────────────────────────────
+
+const CONFIDENCE_COLORS = {
+    verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
+    likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
+    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+};
+
+function ConfidenceBadge({ confidence }) {
+    return (
+        <span className={`text-xs px-1.5 py-0.5 rounded border font-medium ${CONFIDENCE_COLORS[confidence] || CONFIDENCE_COLORS.inferred}`}>
+            {confidence}
+        </span>
+    );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+/**
+ * EpaCurvesView — "EPA Curves" chart sub-tab.
+ *
+ * Renders theoretical steady-state efficiency vs speed curves derived from
+ * EPA road-load coefficients for each selected vehicle that has an EPA test
+ * group linked. Vehicles without a mapping are listed in an empty-state callout.
+ *
+ * Props:
+ *   vehicles           {Array}    — full vehicles array from context (with epa_mappings)
+ *   selectedVehicleIds {Array}    — currently selected vehicle IDs
+ *   epaConfig          {object}   — { yAxis, xMin, xMax, yMin, yMax }
+ *   setEpaConfig       {function}
+ *   presentationMode   {boolean}  — strips controls for popout window
+ */
+export default function EpaCurvesView({
+    vehicles,
+    selectedVehicleIds,
+    epaConfig,
+    setEpaConfig,
+    presentationMode = false,
+}) {
+    const { units } = useAppContext();
+    const { isDark } = useTheme();
+    const canvasRef = useRef(null);
+    const chartRef  = useRef(null);
+    const [imageCopied, setImageCopied] = useState(false);
+
+    const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
+
+    // Resolve selected vehicles that have EPA data vs those that don't
+    const selectedVehicles = useMemo(() => {
+        return selectedVehicleIds
+            .map(id => vehicles.find(v => v.id === id))
+            .filter(Boolean);
+    }, [vehicles, selectedVehicleIds]);
+
+    const vehiclesWithEpa    = selectedVehicles.filter(v => v.epa_mappings?.length > 0);
+    const vehiclesWithoutEpa = selectedVehicles.filter(v => !v.epa_mappings?.length);
+
+    // Build curve datasets: one per vehicle-mapping combination
+    const datasets = useMemo(() => {
+        const result = [];
+        vehiclesWithEpa.forEach((vehicle, vi) => {
+            vehicle.epa_mappings.forEach((mapping, mi) => {
+                const { epaGroup, confidence } = mapping;
+                if (!epaGroup) return;
+                const useableKwh = resolveUseableKwh(epaGroup, vehicle);
+                const curve      = buildEpaCurve(epaGroup, useableKwh);
+                if (!curve.length) return;
+
+                const baseColor = vehicle.color || PALETTE[vi % PALETTE.length];
+                // Use a slightly lighter alpha for additional mappings on the same vehicle
+                const color = mi === 0 ? baseColor : baseColor + 'bb';
+                const label = vehiclesWithEpa.length > 1 || mi > 0
+                    ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaGroup.epa_carline_name})` : ''}`
+                    : vehicleLabel(vehicle);
+
+                result.push({
+                    label,
+                    data: curve.map(pt => ({
+                        x: convSpeed(pt.mph, units),
+                        y: convertYValue(getYValue(pt, yAxis), yAxis, units),
+                    })).filter(pt => pt.y != null),
+                    borderColor: color,
+                    backgroundColor: color + '22',
+                    borderWidth: 2,
+                    borderDash: [6, 4],            // dashed = theoretical (vs solid empirical runs)
+                    pointRadius: 0,
+                    pointHoverRadius: 4,
+                    tension: 0.3,
+                    // Store metadata for tooltip
+                    _vehicleId:   vehicle.id,
+                    _mappingId:   mapping.id,
+                    _confidence:  confidence,
+                    _epaGroup:    epaGroup,
+                    _useableKwh:  useableKwh,
+                    _curve:       curve,            // full curve for tooltip lookup
+                });
+            });
+        });
+        return result;
+    }, [vehiclesWithEpa, yAxis, units]);
+
+    // Build / rebuild chart whenever deps change
+    useEffect(() => {
+        if (!canvasRef.current) return;
+        if (chartRef.current) {
+            chartRef.current.destroy();
+            chartRef.current = null;
+        }
+        if (!datasets.length) return;
+
+        const tickColor   = isDark ? 'rgb(226,232,240)'         : 'rgb(107,114,128)';
+        const gridColor   = isDark ? 'rgba(100,116,139,0.35)'   : 'rgba(229,231,235,0.8)';
+        const legendColor = isDark ? 'rgb(241,245,249)'         : 'rgb(55,65,81)';
+
+        const refPlugin = makeReferencePlugin(
+            HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH, units, isDark
+        );
+
+        chartRef.current = new Chart(canvasRef.current, {
+            type: 'line',
+            plugins: [refPlugin],
+            data: { datasets },
+            options: {
+                animation: false,
+                responsive: true,
+                maintainAspectRatio: false,
+                parsing: false,
+                scales: {
+                    x: {
+                        type: 'linear',
+                        title: { display: true, text: `Speed (${speedLabel(units)})`, color: tickColor },
+                        min: xMin ?? convSpeed(5,   units),
+                        max: xMax ?? convSpeed(120, units),
+                        ticks: { color: tickColor },
+                        grid:  { color: gridColor },
+                    },
+                    y: {
+                        title: { display: true, text: yAxisLabel(yAxis, units), color: tickColor },
+                        min:   yMin ?? undefined,
+                        max:   yMax ?? undefined,
+                        ticks: { color: tickColor },
+                        grid:  { color: gridColor },
+                    },
+                },
+                plugins: {
+                    legend: {
+                        display:  datasets.length > 1,
+                        labels: { color: legendColor, usePointStyle: true, pointStyleWidth: 16 },
+                    },
+                    tooltip: {
+                        callbacks: {
+                            title(items) {
+                                const item = items[0];
+                                const spd = item.parsed.x;
+                                return `${spd.toFixed(1)} ${speedLabel(units)}`;
+                            },
+                            label(item) {
+                                const ds = item.dataset;
+                                const curve   = ds._curve;
+                                const speedMph = units === 'metric'
+                                    ? item.parsed.x / 1.60934
+                                    : item.parsed.x;
+                                // Find nearest curve point
+                                const pt = curve.reduce((best, p) =>
+                                    Math.abs(p.mph - speedMph) < Math.abs(best.mph - speedMph) ? p : best
+                                , curve[0]);
+                                if (!pt) return ds.label;
+                                const lines = [
+                                    `${ds.label}`,
+                                    `  kWh/100mi:  ${pt.kwh100mi?.toFixed(1)}`,
+                                    `  mi/kWh:     ${pt.miPerKwh?.toFixed(2)}`,
+                                    `  MPGe:       ${pt.mpge?.toFixed(1)}`,
+                                ];
+                                if (pt.rangeMi != null) {
+                                    lines.push(`  Range:      ${units === 'metric' ? (pt.rangeMi * 1.60934).toFixed(0) : pt.rangeMi.toFixed(0)} ${distanceLabel(units)}`);
+                                }
+                                lines.push(`  Confidence: ${ds._confidence}`);
+                                return lines;
+                            },
+                            afterBody(items) {
+                                const ds = items[0]?.dataset;
+                                const eg = ds?._epaGroup;
+                                if (!eg) return [];
+                                return [
+                                    '',
+                                    `EPA carline: ${eg.epa_carline_name} (${eg.model_year})`,
+                                    `Test group:  ${eg.test_group_id}`,
+                                    ds._useableKwh
+                                        ? `Useable kWh: ${Number(ds._useableKwh).toFixed(1)}`
+                                        : 'Useable kWh: N/A',
+                                ];
+                            },
+                        },
+                        mode: 'index',
+                        intersect: false,
+                    },
+                },
+            },
+        });
+
+        return () => {
+            chartRef.current?.destroy();
+            chartRef.current = null;
+        };
+    }, [datasets, yAxis, units, isDark, xMin, xMax, yMin, yMax]);
+
+    // ── PNG copy ──────────────────────────────────────────────────────────────
+    const handleCopyPng = async () => {
+        if (!chartRef.current) return;
+        const canvas = chartRef.current.canvas;
+        const bg = isDark ? 'rgb(8,12,28)' : '#ffffff';
+        const tmp = document.createElement('canvas');
+        tmp.width  = canvas.width;
+        tmp.height = canvas.height;
+        const ctx2 = tmp.getContext('2d');
+        ctx2.fillStyle = bg;
+        ctx2.fillRect(0, 0, tmp.width, tmp.height);
+        ctx2.drawImage(canvas, 0, 0);
+        try {
+            const blob = await new Promise(res => tmp.toBlob(res, 'image/png'));
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+            setImageCopied(true);
+            setTimeout(() => setImageCopied(false), 2000);
+        } catch {
+            // Fallback: open in new tab
+            window.open(tmp.toDataURL('image/png'));
+        }
+    };
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    // Empty state: no vehicles selected
+    if (selectedVehicleIds.length === 0) {
+        return (
+            <div>
+                <h2 className="page-title mb-6">EPA Efficiency Curves</h2>
+                <div className="empty-state">
+                    <p className="text-lg">No vehicles selected. Select vehicles from the Vehicles tab to view their EPA curves.</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            {!presentationMode && (
+                <div className="flex items-center gap-3 mb-4">
+                    <h2 className="page-title mb-0">
+                        EPA Efficiency Curves
+                        <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="below" />
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={handleCopyPng}
+                        disabled={!datasets.length}
+                        className={`chart-copy-btn ml-auto ${imageCopied ? 'chart-copy-btn-active' : ''}`}
+                    >
+                        {imageCopied ? '✓ Copied!' : '📋 Copy PNG'}
+                    </button>
+                </div>
+            )}
+
+            {/* Y-axis mode toggle */}
+            {!presentationMode && (
+                <div className="chart-toggles mb-4">
+                    <span className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>Y axis:</span>
+                    <div className="chart-type-buttons">
+                        {Y_MODES.map(m => (
+                            <button
+                                key={m.key}
+                                type="button"
+                                className={`btn btn-sm ${yAxis === m.key ? 'btn-primary' : 'btn-secondary'}`}
+                                onClick={() => setEpaConfig(p => ({ ...p, yAxis: m.key }))}
+                            >
+                                {m.label}
+                            </button>
+                        ))}
+                    </div>
+                    <div className="flex items-center gap-1.5 ml-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                        <span className="inline-block w-8 border-t-2 border-dashed border-indigo-400" />
+                        <span>Theoretical (EPA road load)</span>
+                        <InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} />
+                    </div>
+                </div>
+            )}
+
+            {/* Chart canvas */}
+            {datasets.length > 0 ? (
+                <div className="specs-chart-card">
+                    <div style={{ height: presentationMode ? 'calc(100vh - 120px)' : 480 }}>
+                        <canvas ref={canvasRef} />
+                    </div>
+                    {!presentationMode && (
+                        <div className="mt-3 flex flex-wrap gap-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                            <span>
+                                <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
+                            </span>
+                            <span>
+                                <span className="font-medium" style={{ color: 'rgb(99,102,241)' }}>Purple dashes</span> — HWFET avg (48.3 mph) · the basis for EPA highway label
+                                <InfoIcon text={EPA_EXPLAINERS.hwfetCycle} />
+                            </span>
+                            <span>
+                                <span className="font-medium" style={{ color: 'rgb(168,85,247)' }}>Violet dashes</span> — US06 avg (48.4 mph) · aggressive cycle with transients to 80+ mph
+                                <InfoIcon text={EPA_EXPLAINERS.us06Cycle} />
+                            </span>
+                        </div>
+                    )}
+                </div>
+            ) : (
+                <div className="empty-state">
+                    <p>No EPA test group data available for the selected vehicles.</p>
+                    <p className="text-sm mt-2" style={{ color: 'var(--color-text-muted)' }}>
+                        Link an EPA test group via Edit Vehicle to enable this chart.
+                    </p>
+                </div>
+            )}
+
+            {/* Vehicles without EPA data */}
+            {vehiclesWithoutEpa.length > 0 && !presentationMode && (
+                <div className="mt-4 p-3 rounded-lg text-sm" style={{ background: 'var(--color-surface-muted)', color: 'var(--color-text-secondary)' }}>
+                    <span className="font-medium">No EPA data:</span>{' '}
+                    {vehiclesWithoutEpa.map(v => vehicleLabel(v)).join(', ')}
+                    {' '}— link an EPA test group via Edit Vehicle.
+                </div>
+            )}
+
+            {/* Per-vehicle metadata summary */}
+            {vehiclesWithEpa.length > 0 && !presentationMode && (
+                <div className="mt-4 space-y-2">
+                    {vehiclesWithEpa.map(vehicle =>
+                        vehicle.epa_mappings.map(mapping => {
+                            const { epaGroup, confidence } = mapping;
+                            if (!epaGroup) return null;
+                            return (
+                                <div
+                                    key={mapping.id}
+                                    className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2 rounded-lg text-xs"
+                                    style={{ background: 'var(--color-card)', border: '1px solid var(--color-border)' }}
+                                >
+                                    <span className="font-medium">{vehicleLabel(vehicle)}</span>
+                                    <span style={{ color: 'var(--color-text-muted)' }}>{epaGroup.epa_carline_name} · {epaGroup.model_year} · {epaGroup.test_group_id}</span>
+                                    <ConfidenceBadge confidence={confidence} />
+                                    {epaGroup.label_combined_mpge && (
+                                        <span style={{ color: 'var(--color-text-secondary)' }}>
+                                            Label: {epaGroup.label_combined_mpge} MPGe combined
+                                            {epaGroup.label_method && <InfoIcon text={EPA_EXPLAINERS.labelMethod} />}
+                                        </span>
+                                    )}
+                                    {epaGroup.hwfet_unadj_kwh_100mi && (
+                                        <span style={{ color: 'var(--color-text-muted)' }}>
+                                            HWFET unadj: {epaGroup.hwfet_unadj_kwh_100mi} kWh/100mi
+                                            <InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} />
+                                        </span>
+                                    )}
+                                </div>
+                            );
+                        })
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -8,7 +8,7 @@ import { PALETTE } from '../utils/specHelpers';
 import {
     buildEpaCurve, resolveUseableKwh, resolveUseableKwhSource,
     resolveCoeffs, calibrateEfficiency,
-    HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH,
+    HWFET_AVG_MPH, HIGHWAY_BAND_MPH,
 } from '../utils/epaPhysics';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
@@ -21,7 +21,7 @@ import { EPA_EXPLAINERS } from '../utils/epaExplainers';
  * renders its datasets. Follows the same afterDraw pattern as barGroupPlugin
  * and makeBarPlugin in other chart views.
  */
-function makeReferencePlugin(hwfetMph, us06Mph, bandMph, units, isDark) {
+function makeReferencePlugin(bandMph, units, isDark) {
     return {
         id: 'epaReferenceLines',
         afterDraw(chart) {
@@ -29,10 +29,8 @@ function makeReferencePlugin(hwfetMph, us06Mph, bandMph, units, isDark) {
             if (!area || !scales.x) return;
 
             const x = v => scales.x.getPixelForValue(convSpeed(v, units));
-            const textColor  = isDark ? 'rgba(226,232,240,0.6)' : 'rgba(107,114,128,0.8)';
-            const bandColor  = isDark ? 'rgba(59,130,246,0.07)' : 'rgba(59,130,246,0.06)';
-            const lineHwfet  = isDark ? 'rgba(99,102,241,0.45)'  : 'rgba(99,102,241,0.55)';
-            const lineUs06   = isDark ? 'rgba(168,85,247,0.40)'  : 'rgba(168,85,247,0.50)';
+            const textColor = isDark ? 'rgba(226,232,240,0.6)' : 'rgba(107,114,128,0.8)';
+            const bandColor = isDark ? 'rgba(59,130,246,0.07)' : 'rgba(59,130,246,0.06)';
 
             ctx.save();
 
@@ -42,38 +40,11 @@ function makeReferencePlugin(hwfetMph, us06Mph, bandMph, units, isDark) {
             ctx.fillStyle = bandColor;
             ctx.fillRect(xBand0, area.top, xBand1 - xBand0, area.bottom - area.top);
 
-            // Helper: draw one dashed vertical line with a rotated label at the top
-            const drawLine = (mph, color, label) => {
-                const px = x(mph);
-                if (px < area.left || px > area.right) return;
-                ctx.beginPath();
-                ctx.strokeStyle = color;
-                ctx.lineWidth = 1;
-                ctx.setLineDash([4, 4]);
-                ctx.moveTo(px, area.top);
-                ctx.lineTo(px, area.bottom);
-                ctx.stroke();
-                ctx.setLineDash([]);
-                // Rotated label
-                ctx.save();
-                ctx.translate(px - 3, area.top + 4);
-                ctx.rotate(-Math.PI / 2);
-                ctx.font = '10px system-ui, sans-serif';
-                ctx.fillStyle = textColor;
-                ctx.textAlign = 'left';
-                ctx.fillText(label, 0, 0);
-                ctx.restore();
-            };
-
-            drawLine(hwfetMph, lineHwfet, `HWFET avg (${convSpeed(hwfetMph, units)} ${speedLabel(units)})`);
-            drawLine(us06Mph,  lineUs06,  `US06 avg (${convSpeed(us06Mph, units)} ${speedLabel(units)})`);
-
             // Band label
             ctx.font = '9px system-ui, sans-serif';
             ctx.fillStyle = textColor;
             ctx.textAlign = 'center';
-            const bandMid = (xBand0 + xBand1) / 2;
-            ctx.fillText('Hwy', bandMid, area.top + 10);
+            ctx.fillText('Hwy', (xBand0 + xBand1) / 2, area.top + 10);
 
             ctx.restore();
         },
@@ -326,9 +297,7 @@ export default function EpaCurvesView({
         const gridColor   = isDark ? 'rgba(100,116,139,0.35)'   : 'rgba(229,231,235,0.8)';
         const legendColor = isDark ? 'rgb(241,245,249)'         : 'rgb(55,65,81)';
 
-        const refPlugin      = makeReferencePlugin(
-            HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH, units, isDark
-        );
+        const refPlugin      = makeReferencePlugin(HIGHWAY_BAND_MPH, units, isDark);
         const calloutPlugin  = makeCalloutPlugin([70, 80], yAxis, units, isDark);
 
         chartRef.current = new Chart(canvasRef.current, {
@@ -365,49 +334,39 @@ export default function EpaCurvesView({
                     tooltip: {
                         callbacks: {
                             title(items) {
-                                const item = items[0];
-                                const spd = item.parsed.x;
-                                return `${spd.toFixed(1)} ${speedLabel(units)}`;
+                                const spd = items[0]?.parsed.x;
+                                return `${spd?.toFixed(1)} ${speedLabel(units)}`;
                             },
                             label(item) {
                                 const ds = item.dataset;
-                                const curve   = ds._curve;
+                                const curve = ds._curve;
                                 const speedMph = units === 'metric'
                                     ? item.parsed.x / 1.60934
                                     : item.parsed.x;
-                                // Find nearest curve point
-                                const pt = curve.reduce((best, p) =>
+                                const pt = curve?.reduce((best, p) =>
                                     Math.abs(p.mph - speedMph) < Math.abs(best.mph - speedMph) ? p : best
                                 , curve[0]);
                                 if (!pt) return ds.label;
-                                const lines = [
-                                    `${ds.label}`,
-                                    `  kWh/100mi:  ${pt.kwh100mi?.toFixed(1)}`,
-                                    `  mi/kWh:     ${pt.miPerKwh?.toFixed(2)}`,
-                                    `  MPGe:       ${pt.mpge?.toFixed(1)}`,
-                                ];
-                                if (pt.rangeMi != null) {
-                                    lines.push(`  Range:      ${units === 'metric' ? (pt.rangeMi * 1.60934).toFixed(0) : pt.rangeMi.toFixed(0)} ${distanceLabel(units)}`);
+
+                                // Format the value for whichever Y axis is active
+                                let valStr = '';
+                                if (yAxis === 'kwh100mi') {
+                                    valStr = pt.kwh100mi != null
+                                        ? `${(units === 'metric' ? pt.kwh100mi / 1.60934 : pt.kwh100mi).toFixed(1)} ${units === 'metric' ? 'kWh/100km' : 'kWh/100mi'}`
+                                        : '—';
+                                } else if (yAxis === 'mi_kwh') {
+                                    valStr = pt.miPerKwh != null
+                                        ? `${(units === 'metric' ? pt.miPerKwh * 1.60934 : pt.miPerKwh).toFixed(2)} ${units === 'metric' ? 'km/kWh' : 'mi/kWh'}`
+                                        : '—';
+                                } else if (yAxis === 'mpge') {
+                                    valStr = pt.mpge != null ? `${pt.mpge.toFixed(1)} MPGe` : '—';
+                                } else if (yAxis === 'range_mi') {
+                                    valStr = pt.rangeMi != null
+                                        ? `${(units === 'metric' ? pt.rangeMi * 1.60934 : pt.rangeMi).toFixed(0)} ${distanceLabel(units)}`
+                                        : '—';
                                 }
-                                lines.push(`  Confidence: ${ds._confidence}`);
-                                return lines;
-                            },
-                            afterBody(items) {
-                                const ds = items[0]?.dataset;
-                                const eg = ds?._epaGroup;
-                                if (!eg) return [];
-                                const lines = [''];
-                                if (eg.display_name) {
-                                    lines.push(`Display name: ${eg.display_name}`);
-                                }
-                                lines.push(
-                                    `EPA carline:  ${eg.epa_carline_name} (${eg.model_year})`,
-                                    `Test group:   ${eg.test_group_id}`,
-                                    ds._useableKwh
-                                        ? `Useable kWh:  ${Number(ds._useableKwh).toFixed(1)} (${ds._useableKwhSource === 'EPA' ? 'EPA' : ds._useableKwhSource === 'spec' ? 'from specs' : 'gross'})`
-                                        : 'Useable kWh:  N/A',
-                                );
-                                return lines;
+
+                                return `${ds.label}: ${valStr}`;
                             },
                         },
                         mode: 'index',
@@ -515,14 +474,6 @@ export default function EpaCurvesView({
                                 <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
                             </span>
                             <span>
-                                <span className="font-medium" style={{ color: 'rgb(99,102,241)' }}>Purple dashes</span> — HWFET avg (48.3 mph) · basis for EPA highway label
-                                <InfoIcon text={EPA_EXPLAINERS.hwfetCycle} />
-                            </span>
-                            <span>
-                                <span className="font-medium" style={{ color: 'rgb(168,85,247)' }}>Violet dashes</span> — US06 avg (48.4 mph) · aggressive cycle with transients to 80+ mph
-                                <InfoIcon text={EPA_EXPLAINERS.us06Cycle} />
-                            </span>
-                            <span>
                                 <span className="font-medium">● Dots</span> — range at 70 &amp; 80 mph
                             </span>
                         </div>
@@ -596,8 +547,8 @@ export default function EpaCurvesView({
                                     <ConfidenceBadge confidence={confidence} />
                                     {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
                                         <span style={{ color: 'var(--color-text-secondary)' }}>
-                                            Label: {epaGroup.label_combined_mpge} MPGe combined
-                                            {epaGroup.label_method && <InfoIcon text={EPA_EXPLAINERS.labelMethod} />}
+                                            EPA rated: {epaGroup.label_combined_mpge} MPGe
+                                            {epaGroup.label_method && <> · {epaGroup.label_method}<InfoIcon text={EPA_EXPLAINERS.labelMethod} /></>}
                                         </span>
                                     )}
                                     {eta != null && (

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -273,8 +273,10 @@ export default function EpaCurvesView({
                 const baseColor = vehicle.color || PALETTE[vi % PALETTE.length];
                 // Use a slightly lighter alpha for additional mappings on the same vehicle
                 const color = mi === 0 ? baseColor : baseColor + 'bb';
+                // Prefer display_name (friendly) over raw EPA carline name for labels
+                const epaLabel = epaGroup.display_name || epaGroup.epa_carline_name;
                 const label = vehiclesWithEpa.length > 1 || mi > 0
-                    ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaGroup.epa_carline_name})` : ''}`
+                    ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
                     : vehicleLabel(vehicle);
 
                 result.push({
@@ -386,14 +388,18 @@ export default function EpaCurvesView({
                                 const ds = items[0]?.dataset;
                                 const eg = ds?._epaGroup;
                                 if (!eg) return [];
-                                return [
-                                    '',
-                                    `EPA carline: ${eg.epa_carline_name} (${eg.model_year})`,
-                                    `Test group:  ${eg.test_group_id}`,
+                                const lines = [''];
+                                if (eg.display_name) {
+                                    lines.push(`Display name: ${eg.display_name}`);
+                                }
+                                lines.push(
+                                    `EPA carline:  ${eg.epa_carline_name} (${eg.model_year})`,
+                                    `Test group:   ${eg.test_group_id}`,
                                     ds._useableKwh
-                                        ? `Useable kWh: ${Number(ds._useableKwh).toFixed(1)}`
-                                        : 'Useable kWh: N/A',
-                                ];
+                                        ? `Useable kWh:  ${Number(ds._useableKwh).toFixed(1)}`
+                                        : 'Useable kWh:  N/A',
+                                );
+                                return lines;
                             },
                         },
                         mode: 'index',
@@ -565,7 +571,13 @@ export default function EpaCurvesView({
                                     style={{ background: 'var(--color-card)', border: '1px solid var(--color-border)' }}
                                 >
                                     <span className="font-medium">{vehicleLabel(vehicle)}</span>
-                                    <span style={{ color: 'var(--color-text-muted)' }}>{epaGroup.epa_carline_name} · {epaGroup.model_year} · {epaGroup.test_group_id}</span>
+                                    <span style={{ color: 'var(--color-text-muted)' }}>
+                                        {epaGroup.display_name
+                                            ? <><span className="font-medium" style={{ color: 'var(--color-text-secondary)' }}>{epaGroup.display_name}</span> · <span className="italic">{epaGroup.epa_carline_name}</span></>
+                                            : epaGroup.epa_carline_name
+                                        }
+                                        {' '}· {epaGroup.model_year} · {epaGroup.test_group_id}
+                                    </span>
                                     <ConfidenceBadge confidence={confidence} />
                                     {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
                                         <span style={{ color: 'var(--color-text-secondary)' }}>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -6,7 +6,8 @@ import { convSpeed, speedLabel, distanceLabel } from '../utils/unitConversions';
 import { vehicleColor, vehicleLabel } from '../utils/specHelpers';
 import { PALETTE } from '../utils/specHelpers';
 import {
-    buildEpaCurve, resolveUseableKwh, resolveCoeffs, calibrateEfficiency,
+    buildEpaCurve, resolveUseableKwh, resolveUseableKwhSource,
+    resolveCoeffs, calibrateEfficiency,
     HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH,
 } from '../utils/epaPhysics';
 import AxisScaleControls from './AxisScaleControls';
@@ -266,8 +267,9 @@ export default function EpaCurvesView({
             vehicle.epa_mappings.forEach((mapping, mi) => {
                 const { epaGroup, confidence } = mapping;
                 if (!epaGroup) return;
-                const useableKwh = resolveUseableKwh(epaGroup, vehicle);
-                const curve      = buildEpaCurve(epaGroup, useableKwh);
+                const useableKwh       = resolveUseableKwh(epaGroup, vehicle);
+                const useableKwhSource = resolveUseableKwhSource(epaGroup, vehicle);
+                const curve            = buildEpaCurve(epaGroup, useableKwh);
                 if (!curve.length) return;
 
                 const baseColor = vehicle.color || PALETTE[vi % PALETTE.length];
@@ -293,12 +295,13 @@ export default function EpaCurvesView({
                     pointHoverRadius: 4,
                     tension: 0.3,
                     // Store metadata for tooltip
-                    _vehicleId:   vehicle.id,
-                    _mappingId:   mapping.id,
-                    _confidence:  confidence,
-                    _epaGroup:    epaGroup,
-                    _useableKwh:  useableKwh,
-                    _curve:       curve,            // full curve for tooltip lookup
+                    _vehicleId:        vehicle.id,
+                    _mappingId:        mapping.id,
+                    _confidence:       confidence,
+                    _epaGroup:         epaGroup,
+                    _useableKwh:       useableKwh,
+                    _useableKwhSource: useableKwhSource,
+                    _curve:            curve,       // full curve for tooltip lookup
                 });
             });
         });
@@ -396,7 +399,7 @@ export default function EpaCurvesView({
                                     `EPA carline:  ${eg.epa_carline_name} (${eg.model_year})`,
                                     `Test group:   ${eg.test_group_id}`,
                                     ds._useableKwh
-                                        ? `Useable kWh:  ${Number(ds._useableKwh).toFixed(1)}`
+                                        ? `Useable kWh:  ${Number(ds._useableKwh).toFixed(1)} (${ds._useableKwhSource === 'EPA' ? 'EPA' : ds._useableKwhSource === 'spec' ? 'from specs' : 'gross'})`
                                         : 'Useable kWh:  N/A',
                                 );
                                 return lines;
@@ -563,7 +566,8 @@ export default function EpaCurvesView({
                             const hwfetSource = epaGroup.hwfet_unadj_kwh_100mi != null ? 'unadj'
                                               : epaGroup.hwfet_adj_kwh_100mi    != null ? 'adj'
                                               : null;
-                            const useableKwh = resolveUseableKwh(epaGroup, vehicle);
+                            const useableKwh       = resolveUseableKwh(epaGroup, vehicle);
+                            const useableKwhSource = resolveUseableKwhSource(epaGroup, vehicle);
                             return (
                                 <div
                                     key={mapping.id}
@@ -601,7 +605,10 @@ export default function EpaCurvesView({
                                     )}
                                     {useableKwh && (
                                         <span style={{ color: 'var(--color-text-muted)' }}>
-                                            Useable: {Number(useableKwh).toFixed(1)} kWh
+                                            {Number(useableKwh).toFixed(1)} kWh
+                                            {useableKwhSource === 'EPA'   && ' (EPA useable)'}
+                                            {useableKwhSource === 'spec'  && ' (useable, from specs)'}
+                                            {useableKwhSource === 'gross' && ' (gross — useable not set)'}
                                         </span>
                                     )}
                                 </div>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -3,7 +3,7 @@ import Chart from 'chart.js/auto';
 import { useTheme } from '../hooks/useTheme';
 import { useAppContext } from '../context/AppContext';
 import { convSpeed, speedLabel, distanceLabel } from '../utils/unitConversions';
-import { vehicleColor, vehicleLabel, resolveEffectiveSpecs } from '../utils/specHelpers';
+import { vehicleLabel, resolveEffectiveSpecs } from '../utils/specHelpers';
 import { PALETTE } from '../utils/specHelpers';
 import {
     buildEpaCurve, resolveUseableKwh, resolveUseableKwhSource,
@@ -14,12 +14,11 @@ import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 
-// ── Reference line / highway band plugin ─────────────────────────────────────
+// ── Highway band plugin ───────────────────────────────────────────────────────
 
 /**
- * Draws the highway speed band and two reference speed lines after Chart.js
- * renders its datasets. Follows the same afterDraw pattern as barGroupPlugin
- * and makeBarPlugin in other chart views.
+ * Draws the 65–75 mph highway band after Chart.js renders its datasets.
+ * Follows the same afterDraw pattern as barGroupPlugin / makeBarPlugin.
  */
 function makeReferencePlugin(bandMph, units, isDark) {
     return {
@@ -34,13 +33,11 @@ function makeReferencePlugin(bandMph, units, isDark) {
 
             ctx.save();
 
-            // 65–75 mph highway band
             const xBand0 = x(bandMph[0]);
             const xBand1 = x(bandMph[1]);
             ctx.fillStyle = bandColor;
             ctx.fillRect(xBand0, area.top, xBand1 - xBand0, area.bottom - area.top);
 
-            // Band label
             ctx.font = '9px system-ui, sans-serif';
             ctx.fillStyle = textColor;
             ctx.textAlign = 'center';
@@ -55,15 +52,15 @@ function makeReferencePlugin(bandMph, units, isDark) {
 
 /**
  * Draws filled dots + range labels on each curve at specified reference speeds.
+ * Pass an empty array to disable without removing the code.
  *
- * The label always shows range (mi or km) regardless of the current Y axis, so
- * users see "what range does this speed translate to?" in any view mode.
- * Labels only appear when useableKwh is available (rangeMi != null).
+ * To re-enable: pass [70, 80] (or any mph values) at the call site.
  */
 function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
     return {
         id: 'epaCallouts',
         afterDatasetsDraw(chart) {
+            if (!calloutMphs.length) return;
             const { ctx, chartArea: area, scales, data } = chart;
             if (!area || !scales.x || !scales.y) return;
 
@@ -74,7 +71,6 @@ function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
                 const color = ds.borderColor;
 
                 calloutMphs.forEach((targetMph) => {
-                    // Find nearest curve point to this reference speed
                     const pt = curve.reduce((best, p) =>
                         Math.abs(p.mph - targetMph) < Math.abs(best.mph - targetMph) ? p : best
                     , curve[0]);
@@ -89,8 +85,6 @@ function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
                     if (px < area.left || px > area.right || py < area.top || py > area.bottom) return;
 
                     ctx.save();
-
-                    // Filled dot on the curve
                     ctx.beginPath();
                     ctx.arc(px, py, 4.5, 0, Math.PI * 2);
                     ctx.fillStyle = color;
@@ -99,7 +93,6 @@ function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
                     ctx.lineWidth = 1.5;
                     ctx.stroke();
 
-                    // Range label — only when rangeMi is available
                     if (pt.rangeMi != null) {
                         const rangeDisplay = units === 'metric'
                             ? `${(pt.rangeMi * 1.60934).toFixed(0)} km`
@@ -111,15 +104,10 @@ function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
 
                         const textW = ctx.measureText(rangeDisplay).width;
                         const labelY = py - 9;
-
-                        // Pill background for legibility over other curves
                         const padX = 3, padY = 2;
                         ctx.fillStyle = isDark ? 'rgba(15,23,42,0.82)' : 'rgba(255,255,255,0.88)';
                         ctx.beginPath();
-                        ctx.roundRect(
-                            px - textW / 2 - padX, labelY - 10 - padY,
-                            textW + padX * 2, 11 + padY * 2, 3
-                        );
+                        ctx.roundRect(px - textW / 2 - padX, labelY - 10 - padY, textW + padX * 2, 11 + padY * 2, 3);
                         ctx.fill();
 
                         ctx.fillStyle = color;
@@ -164,14 +152,13 @@ function yAxisLabel(yAxis, units) {
     return '';
 }
 
-/** Convert a Y value from imperial to metric for display. */
 function convertYValue(val, yAxis, units) {
     if (val == null) return null;
     if (units !== 'metric') return val;
-    if (yAxis === 'kwh100mi') return val / 1.60934;  // kWh/100mi → kWh/100km
-    if (yAxis === 'mi_kwh')   return val * 1.60934;  // mi/kWh → km/kWh
-    if (yAxis === 'range_mi') return val * 1.60934;  // mi → km
-    return val; // MPGe stays as-is
+    if (yAxis === 'kwh100mi') return val / 1.60934;
+    if (yAxis === 'mi_kwh')   return val * 1.60934;
+    if (yAxis === 'range_mi') return val * 1.60934;
+    return val;
 }
 
 // ── Confidence badge ──────────────────────────────────────────────────────────
@@ -190,14 +177,23 @@ function ConfidenceBadge({ confidence }) {
     );
 }
 
+// ── Default color for a mapping ───────────────────────────────────────────────
+
+function defaultMappingColor(vehicle, vehicleIdx, mappingIdx) {
+    const base = vehicle.color || PALETTE[vehicleIdx % PALETTE.length];
+    return mappingIdx === 0 ? base : base + 'bb';
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 /**
  * EpaCurvesView — "EPA Curves" chart sub-tab.
  *
- * Renders theoretical steady-state efficiency vs speed curves derived from
- * EPA road-load coefficients for each selected vehicle that has an EPA test
- * group linked. Vehicles without a mapping are listed in an empty-state callout.
+ * Layout mirrors ChargingView:
+ *   1. Chart Options card  — Y-axis toggles, axis scale controls, collapsible
+ *      per-mapping selector with color pickers and metadata
+ *   2. Chart card          — canvas
+ *   3. Below chart         — legend note, Copy URL, Copy PNG
  *
  * Props:
  *   vehicles           {Array}    — full vehicles array from context (with epa_mappings)
@@ -217,25 +213,28 @@ export default function EpaCurvesView({
     const { isDark } = useTheme();
     const canvasRef = useRef(null);
     const chartRef  = useRef(null);
-    const [imageCopied, setImageCopied] = useState(false);
+
+    // ── UI state ──────────────────────────────────────────────────────────────
+    const [selectorExpanded, setSelectorExpanded] = useState(false);
+    const [hiddenMappings,   setHiddenMappings]   = useState(new Set()); // mapping.id
+    const [mappingColors,    setMappingColors]    = useState({});        // mapping.id → hex
+    const [urlCopied,        setUrlCopied]        = useState(false);
+    const [imageCopied,      setImageCopied]      = useState(false);
 
     const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
 
-    // Resolve selected vehicles that have EPA data vs those that don't
-    const selectedVehicles = useMemo(() => {
-        return selectedVehicleIds
-            .map(id => vehicles.find(v => v.id === id))
-            .filter(Boolean);
-    }, [vehicles, selectedVehicleIds]);
+    // ── Vehicle lists ─────────────────────────────────────────────────────────
+    const selectedVehicles = useMemo(() =>
+        selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean),
+    [vehicles, selectedVehicleIds]);
 
     const vehiclesWithEpa    = selectedVehicles.filter(v => v.epa_mappings?.length > 0);
     const vehiclesWithoutEpa = selectedVehicles.filter(v => !v.epa_mappings?.length);
 
-    // Build curve datasets: one per vehicle-mapping combination
+    // ── Datasets ──────────────────────────────────────────────────────────────
     const datasets = useMemo(() => {
         const result = [];
         vehiclesWithEpa.forEach((vehicle, vi) => {
-            // Resolve inherited specs so battery_usable_kwh from a parent vehicle is visible
             const effectiveVehicle = {
                 ...vehicle,
                 specs: resolveEffectiveSpecs(vehicle, vehicles),
@@ -243,15 +242,15 @@ export default function EpaCurvesView({
             vehicle.epa_mappings.forEach((mapping, mi) => {
                 const { epaGroup, confidence } = mapping;
                 if (!epaGroup) return;
+                if (hiddenMappings.has(mapping.id)) return;
+
                 const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
                 const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
                 const curve            = buildEpaCurve(epaGroup, useableKwh);
                 if (!curve.length) return;
 
-                const baseColor = vehicle.color || PALETTE[vi % PALETTE.length];
-                // Use a slightly lighter alpha for additional mappings on the same vehicle
-                const color = mi === 0 ? baseColor : baseColor + 'bb';
-                // Prefer display_name (friendly) over raw EPA carline name for labels
+                // Color: user override → vehicle color → palette (with alpha for 2nd+ mapping)
+                const color = mappingColors[mapping.id] ?? defaultMappingColor(vehicle, vi, mi);
                 const epaLabel = epaGroup.display_name || epaGroup.epa_carline_name;
                 const label = vehiclesWithEpa.length > 1 || mi > 0
                     ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
@@ -263,44 +262,40 @@ export default function EpaCurvesView({
                         x: convSpeed(pt.mph, units),
                         y: convertYValue(getYValue(pt, yAxis), yAxis, units),
                     })).filter(pt => pt.y != null),
-                    borderColor: color,
+                    borderColor:     color,
                     backgroundColor: color + '22',
-                    borderWidth: 2,
-                    borderDash: [6, 4],            // dashed = theoretical (vs solid empirical runs)
-                    pointRadius: 0,
+                    borderWidth:     2,
+                    borderDash:      [6, 4],
+                    pointRadius:     0,
                     pointHoverRadius: 4,
-                    tension: 0.3,
-                    // Store metadata for tooltip
+                    tension:         0.3,
                     _vehicleId:        vehicle.id,
                     _mappingId:        mapping.id,
                     _confidence:       confidence,
                     _epaGroup:         epaGroup,
                     _useableKwh:       useableKwh,
                     _useableKwhSource: useableKwhSource,
-                    _curve:            curve,       // full curve for tooltip lookup
+                    _curve:            curve,
                 });
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors]);
 
-    // Build / rebuild chart whenever deps change
+    // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
         if (!canvasRef.current) return;
-        if (chartRef.current) {
-            chartRef.current.destroy();
-            chartRef.current = null;
-        }
+        if (chartRef.current) { chartRef.current.destroy(); chartRef.current = null; }
         if (!datasets.length) return;
 
-        const tickColor   = isDark ? 'rgb(226,232,240)'         : 'rgb(107,114,128)';
-        const gridColor   = isDark ? 'rgba(100,116,139,0.35)'   : 'rgba(229,231,235,0.8)';
-        const legendColor = isDark ? 'rgb(241,245,249)'         : 'rgb(55,65,81)';
+        const tickColor   = isDark ? 'rgb(226,232,240)'       : 'rgb(107,114,128)';
+        const gridColor   = isDark ? 'rgba(100,116,139,0.35)' : 'rgba(229,231,235,0.8)';
+        const legendColor = isDark ? 'rgb(241,245,249)'       : 'rgb(55,65,81)';
 
-        const refPlugin      = makeReferencePlugin(HIGHWAY_BAND_MPH, units, isDark);
+        const refPlugin     = makeReferencePlugin(HIGHWAY_BAND_MPH, units, isDark);
         // Speed callouts disabled — labels overlap with multiple curves.
         // Re-enable by restoring [70, 80] (or any mph values) here.
-        const calloutPlugin  = makeCalloutPlugin([], yAxis, units, isDark);
+        const calloutPlugin = makeCalloutPlugin([], yAxis, units, isDark);
 
         chartRef.current = new Chart(canvasRef.current, {
             type: 'line',
@@ -330,7 +325,7 @@ export default function EpaCurvesView({
                 },
                 plugins: {
                     legend: {
-                        display:  datasets.length > 1,
+                        display: datasets.length > 1,
                         labels: { color: legendColor, usePointStyle: true, pointStyleWidth: 16 },
                     },
                     tooltip: {
@@ -350,7 +345,6 @@ export default function EpaCurvesView({
                                 , curve[0]);
                                 if (!pt) return ds.label;
 
-                                // Format the value for whichever Y axis is active
                                 let valStr = '';
                                 if (yAxis === 'kwh100mi') {
                                     valStr = pt.kwh100mi != null
@@ -367,7 +361,6 @@ export default function EpaCurvesView({
                                         ? `${(units === 'metric' ? pt.rangeMi * 1.60934 : pt.rangeMi).toFixed(0)} ${distanceLabel(units)}`
                                         : '—';
                                 }
-
                                 return `${ds.label}: ${valStr}`;
                             },
                         },
@@ -378,17 +371,14 @@ export default function EpaCurvesView({
             },
         });
 
-        return () => {
-            chartRef.current?.destroy();
-            chartRef.current = null;
-        };
+        return () => { chartRef.current?.destroy(); chartRef.current = null; };
     }, [datasets, yAxis, units, isDark, xMin, xMax, yMin, yMax]);
 
-    // ── PNG copy ──────────────────────────────────────────────────────────────
+    // ── Copy PNG ──────────────────────────────────────────────────────────────
     const handleCopyPng = async () => {
         if (!chartRef.current) return;
         const canvas = chartRef.current.canvas;
-        const bg = isDark ? 'rgb(8,12,28)' : '#ffffff';
+        const bg  = isDark ? 'rgb(8,12,28)' : '#ffffff';
         const tmp = document.createElement('canvas');
         tmp.width  = canvas.width;
         tmp.height = canvas.height;
@@ -402,14 +392,23 @@ export default function EpaCurvesView({
             setImageCopied(true);
             setTimeout(() => setImageCopied(false), 2000);
         } catch {
-            // Fallback: open in new tab
             window.open(tmp.toDataURL('image/png'));
         }
     };
 
-    // ── Render ────────────────────────────────────────────────────────────────
+    // ── Copy URL ──────────────────────────────────────────────────────────────
+    const handleCopyUrl = () => {
+        navigator.clipboard.writeText(window.location.href).then(() => {
+            setUrlCopied(true);
+            setTimeout(() => setUrlCopied(false), 2000);
+        });
+    };
 
-    // Empty state: no vehicles selected
+    // ── Total visible mapping count (for selector badge) ──────────────────────
+    const totalMappings = vehiclesWithEpa.reduce((n, v) => n + (v.epa_mappings?.length ?? 0), 0);
+    const visibleCount  = totalMappings - hiddenMappings.size;
+
+    // ── Empty state ───────────────────────────────────────────────────────────
     if (selectedVehicleIds.length === 0) {
         return (
             <div>
@@ -421,71 +420,209 @@ export default function EpaCurvesView({
         );
     }
 
+    // ── Render ────────────────────────────────────────────────────────────────
     return (
         <div>
+            {/* ── Chart Options card ────────────────────────────────────────── */}
             {!presentationMode && (
-                <div className="flex items-center gap-3 mb-4">
-                    <h2 className="page-title mb-0">
-                        EPA Efficiency Curves
-                        <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="below" />
-                    </h2>
-                    <button
-                        type="button"
-                        onClick={handleCopyPng}
-                        disabled={!datasets.length}
-                        className={`chart-copy-btn ml-auto ${imageCopied ? 'chart-copy-btn-active' : ''}`}
-                    >
-                        {imageCopied ? '✓ Copied!' : '📋 Copy PNG'}
-                    </button>
-                </div>
-            )}
+                <div className="card mb-6">
+                    <div className="flex items-center justify-between mb-4">
+                        <h3 className="section-title">
+                            Chart Options — EPA Efficiency Curves
+                            <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
+                        </h3>
+                    </div>
 
-            {/* Y-axis mode toggle */}
-            {!presentationMode && (
-                <div className="chart-toggles mb-4">
-                    <span className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>Y axis:</span>
-                    <div className="chart-type-buttons">
-                        {Y_MODES.map(m => (
+                    {/* Y-axis toggle */}
+                    <div className="chart-toggles mb-4">
+                        <span className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>Y axis:</span>
+                        <div className="chart-type-buttons">
+                            {Y_MODES.map(m => (
+                                <button
+                                    key={m.key}
+                                    type="button"
+                                    className={`btn btn-sm ${yAxis === m.key ? 'btn-primary' : 'btn-secondary'}`}
+                                    onClick={() => setEpaConfig(p => ({ ...p, yAxis: m.key }))}
+                                >
+                                    {m.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Axis scale controls */}
+                    <AxisScaleControls
+                        xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}
+                        xAxisLabel={`Speed (${speedLabel(units)})`}
+                        yAxisLabel={yAxisLabel(yAxis, units)}
+                        onChange={(key, value) => setEpaConfig(p => ({ ...p, [key]: value }))}
+                    />
+
+                    {/* Collapsible EPA test selector */}
+                    {vehiclesWithEpa.length > 0 && (
+                        <div className="mt-4">
                             <button
-                                key={m.key}
-                                type="button"
-                                className={`btn btn-sm ${yAxis === m.key ? 'btn-primary' : 'btn-secondary'}`}
-                                onClick={() => setEpaConfig(p => ({ ...p, yAxis: m.key }))}
+                                onClick={() => setSelectorExpanded(p => !p)}
+                                className="run-selector-header"
                             >
-                                {m.label}
+                                <span style={{ display: 'inline-block', transform: selectorExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
+                                Select Vehicle Tests to Display
+                                <span className="text-sm font-normal text-gray-500">({visibleCount} of {totalMappings} shown)</span>
                             </button>
-                        ))}
-                    </div>
-                    <div className="flex items-center gap-1.5 ml-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                        <span className="inline-block w-8 border-t-2 border-dashed border-indigo-400" />
-                        <span>Theoretical (EPA road load)</span>
-                        <InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} />
-                    </div>
-                </div>
-            )}
 
-            {/* Chart canvas */}
-            {datasets.length > 0 ? (
-                <div className="specs-chart-card">
-                    <div style={{ height: presentationMode ? 'calc(100vh - 120px)' : 480 }}>
-                        <canvas ref={canvasRef} />
-                    </div>
-                    {!presentationMode && (
-                        <div className="mt-3 flex flex-wrap gap-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                            <span>
-                                <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
-                            </span>
+                            {selectorExpanded && (
+                                <div className="mt-3">
+                                    <div className="runs-list">
+                                        {vehiclesWithEpa.map((vehicle, vi) => {
+                                            const effectiveVehicle = {
+                                                ...vehicle,
+                                                specs: resolveEffectiveSpecs(vehicle, vehicles),
+                                            };
+                                            return (
+                                                <div key={vehicle.id} className="vehicle-run-group" style={{ borderColor: 'var(--color-primary)' }}>
+                                                    <h4 className="text-sm font-semibold text-gray-700 dark:text-slate-300 mb-2">
+                                                        {vehicleLabel(vehicle)}
+                                                    </h4>
+                                                    <div className="run-items">
+                                                        {vehicle.epa_mappings.map((mapping, mi) => {
+                                                            const { epaGroup, confidence } = mapping;
+                                                            if (!epaGroup) return null;
+                                                            const isVisible  = !hiddenMappings.has(mapping.id);
+                                                            const color      = mappingColors[mapping.id] ?? defaultMappingColor(vehicle, vi, mi).replace(/[0-9a-f]{2}$/i, '');
+                                                            // Strip any alpha suffix for the color input
+                                                            const pickerColor = (mappingColors[mapping.id] ?? (vehicle.color || PALETTE[vi % PALETTE.length])).slice(0, 7);
+
+                                                            const { a, b, c } = resolveCoeffs(epaGroup);
+                                                            const hwfetKwh = epaGroup.hwfet_unadj_kwh_100mi ?? epaGroup.hwfet_adj_kwh_100mi;
+                                                            const eta = a != null ? calibrateEfficiency(a, b, c, hwfetKwh) : null;
+                                                            const hwfetSource = epaGroup.hwfet_unadj_kwh_100mi != null ? 'unadj'
+                                                                              : epaGroup.hwfet_adj_kwh_100mi    != null ? 'adj'
+                                                                              : null;
+                                                            const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
+                                                            const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
+                                                            const epaLabel = epaGroup.display_name || epaGroup.epa_carline_name;
+
+                                                            return (
+                                                                <div
+                                                                    key={mapping.id}
+                                                                    className={`flex items-start gap-2 ${!isVisible ? 'opacity-50' : ''}`}
+                                                                >
+                                                                    {/* Checkbox */}
+                                                                    <input
+                                                                        type="checkbox"
+                                                                        checked={isVisible}
+                                                                        onChange={() => setHiddenMappings(prev => {
+                                                                            const s = new Set(prev);
+                                                                            s.has(mapping.id) ? s.delete(mapping.id) : s.add(mapping.id);
+                                                                            return s;
+                                                                        })}
+                                                                        className="w-4 h-4 mt-0.5 shrink-0"
+                                                                    />
+                                                                    {/* Color picker */}
+                                                                    <input
+                                                                        type="color"
+                                                                        value={pickerColor}
+                                                                        onChange={e => setMappingColors(prev => ({ ...prev, [mapping.id]: e.target.value }))}
+                                                                        onClick={e => e.stopPropagation()}
+                                                                        className="w-8 h-6 border-0 rounded cursor-pointer shrink-0"
+                                                                        title="Change curve color"
+                                                                    />
+                                                                    {/* Label + metadata */}
+                                                                    <div className="run-label min-w-0">
+                                                                        <span className="font-medium">{epaLabel}</span>
+                                                                        <span className="text-sm text-gray-500 dark:text-slate-400 ml-2">{epaGroup.model_year} · {epaGroup.test_group_id}</span>
+                                                                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                                                                            <ConfidenceBadge confidence={confidence} />
+                                                                            {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
+                                                                                <span>
+                                                                                    EPA rated: {epaGroup.label_combined_mpge} MPGe
+                                                                                    {epaGroup.label_method && <> · {epaGroup.label_method}<InfoIcon text={EPA_EXPLAINERS.labelMethod} /></>}
+                                                                                </span>
+                                                                            )}
+                                                                            {eta != null && (
+                                                                                <span>
+                                                                                    η<sub>eff</sub>: {(eta * 100).toFixed(1)}%
+                                                                                    {hwfetSource === 'unadj' && <> · HWFET unadj<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>}
+                                                                                    {hwfetSource === 'adj'   && <> · HWFET adj<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>}
+                                                                                    {hwfetSource === null    && <> · default η<InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} /></>}
+                                                                                </span>
+                                                                            )}
+                                                                            {useableKwh && (
+                                                                                <span>
+                                                                                    {Number(useableKwh).toFixed(1)} kWh
+                                                                                    {useableKwhSource === 'EPA'   && ' (EPA)'}
+                                                                                    {useableKwhSource === 'spec'  && ' (spec)'}
+                                                                                    {useableKwhSource === 'gross' && ' (gross)'}
+                                                                                </span>
+                                                                            )}
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            );
+                                                        })}
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+
+                                    {/* Vehicles without EPA data */}
+                                    {vehiclesWithoutEpa.length > 0 && (
+                                        <div className="mt-2 text-sm" style={{ color: 'var(--color-text-muted)' }}>
+                                            <span className="font-medium">No EPA data:</span>{' '}
+                                            {vehiclesWithoutEpa.map(v => vehicleLabel(v)).join(', ')}
+                                            {' '}— link a test group via Edit Vehicle.
+                                        </div>
+                                    )}
+                                </div>
+                            )}
                         </div>
                     )}
-                    {!presentationMode && (
-                        <div className="mt-4 pt-4 border-t" style={{ borderColor: 'var(--color-border)' }}>
-                            <AxisScaleControls
-                                xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}
-                                xAxisLabel={`Speed (${speedLabel(units)})`}
-                                yAxisLabel={yAxisLabel(yAxis, units)}
-                                onChange={(key, value) => setEpaConfig(p => ({ ...p, [key]: value }))}
-                            />
+
+                    {/* All selected vehicles lack EPA data */}
+                    {vehiclesWithEpa.length === 0 && vehiclesWithoutEpa.length > 0 && (
+                        <div className="mt-4 text-sm" style={{ color: 'var(--color-text-muted)' }}>
+                            No EPA test group linked for the selected vehicles. Link one via Edit Vehicle.
                         </div>
+                    )}
+                </div>
+            )}
+
+            {/* ── Chart card ────────────────────────────────────────────────── */}
+            {datasets.length > 0 ? (
+                <div className="card mb-4">
+                    <div style={{ height: presentationMode ? 'calc(100vh - 2rem)' : 500 }}>
+                        <canvas ref={canvasRef} />
+                    </div>
+
+                    {!presentationMode && (
+                        <>
+                            {/* Legend note */}
+                            <div className="mt-3 flex flex-wrap gap-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                                <span>
+                                    <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
+                                </span>
+                            </div>
+
+                            {/* Action buttons */}
+                            <div className="mt-3 flex items-center gap-3 flex-wrap">
+                                <button
+                                    onClick={handleCopyUrl}
+                                    className={`chart-copy-btn ${urlCopied ? 'chart-copy-btn-active' : ''}`}
+                                    title="Copy link to this chart view"
+                                >
+                                    {urlCopied ? '✓ Copied!' : '🔗 Copy URL'}
+                                </button>
+                                <button
+                                    onClick={handleCopyPng}
+                                    disabled={!datasets.length}
+                                    className={`chart-copy-btn ${imageCopied ? 'chart-copy-btn-active' : ''}`}
+                                    title="Copy chart as PNG"
+                                >
+                                    {imageCopied ? '✓ Copied to clipboard!' : '📋 Copy Chart as PNG'}
+                                </button>
+                            </div>
+                        </>
                     )}
                 </div>
             ) : (
@@ -494,88 +631,6 @@ export default function EpaCurvesView({
                     <p className="text-sm mt-2" style={{ color: 'var(--color-text-muted)' }}>
                         Link an EPA test group via Edit Vehicle to enable this chart.
                     </p>
-                </div>
-            )}
-
-            {/* Vehicles without EPA data */}
-            {vehiclesWithoutEpa.length > 0 && !presentationMode && (
-                <div className="mt-4 p-3 rounded-lg text-sm" style={{ background: 'var(--color-surface-muted)', color: 'var(--color-text-secondary)' }}>
-                    <span className="font-medium">No EPA data:</span>{' '}
-                    {vehiclesWithoutEpa.map(v => vehicleLabel(v)).join(', ')}
-                    {' '}— link an EPA test group via Edit Vehicle.
-                </div>
-            )}
-
-            {/* Per-vehicle metadata summary */}
-            {vehiclesWithEpa.length > 0 && !presentationMode && (
-                <div className="mt-4 space-y-2">
-                    {vehiclesWithEpa.map(vehicle =>
-                        vehicle.epa_mappings.map(mapping => {
-                            const { epaGroup, confidence } = mapping;
-                            if (!epaGroup) return null;
-                            const { a, b, c } = resolveCoeffs(epaGroup);
-                            const hwfetKwh = epaGroup.hwfet_unadj_kwh_100mi ?? epaGroup.hwfet_adj_kwh_100mi;
-                            const eta = (a != null)
-                                ? calibrateEfficiency(a, b, c, hwfetKwh)
-                                : null;
-                            const hwfetSource = epaGroup.hwfet_unadj_kwh_100mi != null ? 'unadj'
-                                              : epaGroup.hwfet_adj_kwh_100mi    != null ? 'adj'
-                                              : null;
-                            // Use effective (inherited) specs so battery_usable_kwh from
-                            // a parent vehicle is visible when the child hasn't set it.
-                            const effectiveVehicle = {
-                                ...vehicle,
-                                specs: resolveEffectiveSpecs(vehicle, vehicles),
-                            };
-                            const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
-                            const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
-                            return (
-                                <div
-                                    key={mapping.id}
-                                    className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2 rounded-lg text-xs"
-                                    style={{ background: 'var(--color-card)', border: '1px solid var(--color-border)' }}
-                                >
-                                    <span className="font-medium">{vehicleLabel(vehicle)}</span>
-                                    <span style={{ color: 'var(--color-text-muted)' }}>
-                                        {epaGroup.display_name
-                                            ? <><span className="font-medium" style={{ color: 'var(--color-text-secondary)' }}>{epaGroup.display_name}</span> · <span className="italic">{epaGroup.epa_carline_name}</span></>
-                                            : epaGroup.epa_carline_name
-                                        }
-                                        {' '}· {epaGroup.model_year} · {epaGroup.test_group_id}
-                                    </span>
-                                    <ConfidenceBadge confidence={confidence} />
-                                    {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
-                                        <span style={{ color: 'var(--color-text-secondary)' }}>
-                                            EPA rated: {epaGroup.label_combined_mpge} MPGe
-                                            {epaGroup.label_method && <> · {epaGroup.label_method}<InfoIcon text={EPA_EXPLAINERS.labelMethod} /></>}
-                                        </span>
-                                    )}
-                                    {eta != null && (
-                                        <span style={{ color: 'var(--color-text-muted)' }}>
-                                            η<sub>eff</sub>: {(eta * 100).toFixed(1)}%
-                                            {hwfetSource === 'unadj' && (
-                                                <> · calibrated from HWFET unadj ({epaGroup.hwfet_unadj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
-                                            )}
-                                            {hwfetSource === 'adj' && (
-                                                <> · calibrated from HWFET adj ({epaGroup.hwfet_adj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
-                                            )}
-                                            {hwfetSource === null && (
-                                                <> · default fallback (no HWFET data)<InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} /></>
-                                            )}
-                                        </span>
-                                    )}
-                                    {useableKwh && (
-                                        <span style={{ color: 'var(--color-text-muted)' }}>
-                                            {Number(useableKwh).toFixed(1)} kWh
-                                            {useableKwhSource === 'EPA'   && ' (EPA useable)'}
-                                            {useableKwhSource === 'spec'  && ' (useable, from specs)'}
-                                            {useableKwhSource === 'gross' && ' (gross — useable not set)'}
-                                        </span>
-                                    )}
-                                </div>
-                            );
-                        })
-                    )}
                 </div>
             )}
         </div>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -626,7 +626,7 @@ export default function EpaCurvesView({
                 </div>
             )}
 
-            {/* ── Axis scale controls (below chart, per convention) ──────────── */}
+            {/* ── Axis scale controls (card provided by AxisScaleControls) ──── */}
             {!presentationMode && datasets.length > 0 && (
                 <AxisScaleControls
                     xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -478,7 +478,7 @@ export default function EpaCurvesView({
                                     <span className="font-medium">{vehicleLabel(vehicle)}</span>
                                     <span style={{ color: 'var(--color-text-muted)' }}>{epaGroup.epa_carline_name} · {epaGroup.model_year} · {epaGroup.test_group_id}</span>
                                     <ConfidenceBadge confidence={confidence} />
-                                    {epaGroup.label_combined_mpge && (
+                                    {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
                                         <span style={{ color: 'var(--color-text-secondary)' }}>
                                             Label: {epaGroup.label_combined_mpge} MPGe combined
                                             {epaGroup.label_method && <InfoIcon text={EPA_EXPLAINERS.labelMethod} />}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -298,7 +298,9 @@ export default function EpaCurvesView({
         const legendColor = isDark ? 'rgb(241,245,249)'         : 'rgb(55,65,81)';
 
         const refPlugin      = makeReferencePlugin(HIGHWAY_BAND_MPH, units, isDark);
-        const calloutPlugin  = makeCalloutPlugin([70, 80], yAxis, units, isDark);
+        // Speed callouts disabled — labels overlap with multiple curves.
+        // Re-enable by restoring [70, 80] (or any mph values) here.
+        const calloutPlugin  = makeCalloutPlugin([], yAxis, units, isDark);
 
         chartRef.current = new Chart(canvasRef.current, {
             type: 'line',
@@ -472,9 +474,6 @@ export default function EpaCurvesView({
                         <div className="mt-3 flex flex-wrap gap-4 text-xs" style={{ color: 'var(--color-text-muted)' }}>
                             <span>
                                 <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
-                            </span>
-                            <span>
-                                <span className="font-medium">● Dots</span> — range at 70 &amp; 80 mph
                             </span>
                         </div>
                     )}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -79,6 +79,88 @@ function makeReferencePlugin(hwfetMph, us06Mph, bandMph, units, isDark) {
     };
 }
 
+// ── Speed callout plugin ──────────────────────────────────────────────────────
+
+/**
+ * Draws filled dots + range labels on each curve at specified reference speeds.
+ *
+ * The label always shows range (mi or km) regardless of the current Y axis, so
+ * users see "what range does this speed translate to?" in any view mode.
+ * Labels only appear when useableKwh is available (rangeMi != null).
+ */
+function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
+    return {
+        id: 'epaCallouts',
+        afterDatasetsDraw(chart) {
+            const { ctx, chartArea: area, scales, data } = chart;
+            if (!area || !scales.x || !scales.y) return;
+
+            data.datasets.forEach((ds) => {
+                const curve = ds._curve;
+                if (!curve?.length) return;
+
+                const color = ds.borderColor;
+
+                calloutMphs.forEach((targetMph) => {
+                    // Find nearest curve point to this reference speed
+                    const pt = curve.reduce((best, p) =>
+                        Math.abs(p.mph - targetMph) < Math.abs(best.mph - targetMph) ? p : best
+                    , curve[0]);
+                    if (!pt) return;
+
+                    const xVal = convSpeed(targetMph, units);
+                    const yVal = convertYValue(getYValue(pt, yAxis), yAxis, units);
+                    if (yVal == null) return;
+
+                    const px = scales.x.getPixelForValue(xVal);
+                    const py = scales.y.getPixelForValue(yVal);
+                    if (px < area.left || px > area.right || py < area.top || py > area.bottom) return;
+
+                    ctx.save();
+
+                    // Filled dot on the curve
+                    ctx.beginPath();
+                    ctx.arc(px, py, 4.5, 0, Math.PI * 2);
+                    ctx.fillStyle = color;
+                    ctx.fill();
+                    ctx.strokeStyle = isDark ? 'rgba(15,23,42,0.9)' : 'rgba(255,255,255,0.9)';
+                    ctx.lineWidth = 1.5;
+                    ctx.stroke();
+
+                    // Range label — only when rangeMi is available
+                    if (pt.rangeMi != null) {
+                        const rangeDisplay = units === 'metric'
+                            ? `${(pt.rangeMi * 1.60934).toFixed(0)} km`
+                            : `${pt.rangeMi.toFixed(0)} mi`;
+
+                        ctx.font = '10px system-ui, sans-serif';
+                        ctx.textAlign = 'center';
+                        ctx.textBaseline = 'alphabetic';
+
+                        const textW = ctx.measureText(rangeDisplay).width;
+                        const labelY = py - 9;
+
+                        // Pill background for legibility over other curves
+                        const padX = 3, padY = 2;
+                        ctx.fillStyle = isDark ? 'rgba(15,23,42,0.82)' : 'rgba(255,255,255,0.88)';
+                        ctx.beginPath();
+                        ctx.roundRect(
+                            px - textW / 2 - padX, labelY - 10 - padY,
+                            textW + padX * 2, 11 + padY * 2, 3
+                        );
+                        ctx.fill();
+
+                        ctx.fillStyle = color;
+                        ctx.fillText(rangeDisplay, px, labelY);
+                    }
+
+                    ctx.restore();
+                });
+            });
+        },
+    };
+}
+
 // ── Y-axis mode config ────────────────────────────────────────────────────────
 
 const Y_MODES = [
@@ -234,13 +316,14 @@ export default function EpaCurvesView({
         const gridColor   = isDark ? 'rgba(100,116,139,0.35)'   : 'rgba(229,231,235,0.8)';
         const legendColor = isDark ? 'rgb(241,245,249)'         : 'rgb(55,65,81)';
 
-        const refPlugin = makeReferencePlugin(
+        const refPlugin      = makeReferencePlugin(
             HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH, units, isDark
         );
+        const calloutPlugin  = makeCalloutPlugin([70, 80], yAxis, units, isDark);
 
         chartRef.current = new Chart(canvasRef.current, {
             type: 'line',
-            plugins: [refPlugin],
+            plugins: [refPlugin, calloutPlugin],
             data: { datasets },
             options: {
                 animation: false,
@@ -424,6 +507,9 @@ export default function EpaCurvesView({
                             <span>
                                 <span className="font-medium" style={{ color: 'rgb(168,85,247)' }}>Violet dashes</span> — US06 avg (48.4 mph) · aggressive cycle with transients to 80+ mph
                                 <InfoIcon text={EPA_EXPLAINERS.us06Cycle} />
+                            </span>
+                            <span>
+                                <span className="font-medium">● Dots</span> — range at 70 &amp; 80 mph
                             </span>
                         </div>
                     )}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -3,7 +3,7 @@ import Chart from 'chart.js/auto';
 import { useTheme } from '../hooks/useTheme';
 import { useAppContext } from '../context/AppContext';
 import { convSpeed, speedLabel, distanceLabel } from '../utils/unitConversions';
-import { vehicleColor, vehicleLabel } from '../utils/specHelpers';
+import { vehicleColor, vehicleLabel, resolveEffectiveSpecs } from '../utils/specHelpers';
 import { PALETTE } from '../utils/specHelpers';
 import {
     buildEpaCurve, resolveUseableKwh, resolveUseableKwhSource,
@@ -264,11 +264,16 @@ export default function EpaCurvesView({
     const datasets = useMemo(() => {
         const result = [];
         vehiclesWithEpa.forEach((vehicle, vi) => {
+            // Resolve inherited specs so battery_usable_kwh from a parent vehicle is visible
+            const effectiveVehicle = {
+                ...vehicle,
+                specs: resolveEffectiveSpecs(vehicle, vehicles),
+            };
             vehicle.epa_mappings.forEach((mapping, mi) => {
                 const { epaGroup, confidence } = mapping;
                 if (!epaGroup) return;
-                const useableKwh       = resolveUseableKwh(epaGroup, vehicle);
-                const useableKwhSource = resolveUseableKwhSource(epaGroup, vehicle);
+                const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
+                const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
                 const curve            = buildEpaCurve(epaGroup, useableKwh);
                 if (!curve.length) return;
 
@@ -306,7 +311,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, yAxis, units]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units]);
 
     // Build / rebuild chart whenever deps change
     useEffect(() => {
@@ -566,8 +571,14 @@ export default function EpaCurvesView({
                             const hwfetSource = epaGroup.hwfet_unadj_kwh_100mi != null ? 'unadj'
                                               : epaGroup.hwfet_adj_kwh_100mi    != null ? 'adj'
                                               : null;
-                            const useableKwh       = resolveUseableKwh(epaGroup, vehicle);
-                            const useableKwhSource = resolveUseableKwhSource(epaGroup, vehicle);
+                            // Use effective (inherited) specs so battery_usable_kwh from
+                            // a parent vehicle is visible when the child hasn't set it.
+                            const effectiveVehicle = {
+                                ...vehicle,
+                                specs: resolveEffectiveSpecs(vehicle, vehicles),
+                            };
+                            const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
+                            const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
                             return (
                                 <div
                                     key={mapping.id}

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -6,9 +6,10 @@ import { convSpeed, speedLabel, distanceLabel } from '../utils/unitConversions';
 import { vehicleColor, vehicleLabel } from '../utils/specHelpers';
 import { PALETTE } from '../utils/specHelpers';
 import {
-    buildEpaCurve, resolveUseableKwh,
+    buildEpaCurve, resolveUseableKwh, resolveCoeffs, calibrateEfficiency,
     HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH,
 } from '../utils/epaPhysics';
+import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 
@@ -417,13 +418,23 @@ export default function EpaCurvesView({
                                 <span className="font-medium">Shaded band</span> — 65–75 mph typical highway
                             </span>
                             <span>
-                                <span className="font-medium" style={{ color: 'rgb(99,102,241)' }}>Purple dashes</span> — HWFET avg (48.3 mph) · the basis for EPA highway label
+                                <span className="font-medium" style={{ color: 'rgb(99,102,241)' }}>Purple dashes</span> — HWFET avg (48.3 mph) · basis for EPA highway label
                                 <InfoIcon text={EPA_EXPLAINERS.hwfetCycle} />
                             </span>
                             <span>
                                 <span className="font-medium" style={{ color: 'rgb(168,85,247)' }}>Violet dashes</span> — US06 avg (48.4 mph) · aggressive cycle with transients to 80+ mph
                                 <InfoIcon text={EPA_EXPLAINERS.us06Cycle} />
                             </span>
+                        </div>
+                    )}
+                    {!presentationMode && (
+                        <div className="mt-4 pt-4 border-t" style={{ borderColor: 'var(--color-border)' }}>
+                            <AxisScaleControls
+                                xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}
+                                xAxisLabel={`Speed (${speedLabel(units)})`}
+                                yAxisLabel={yAxisLabel(yAxis, units)}
+                                onChange={(key, value) => setEpaConfig(p => ({ ...p, [key]: value }))}
+                            />
                         </div>
                     )}
                 </div>
@@ -452,6 +463,12 @@ export default function EpaCurvesView({
                         vehicle.epa_mappings.map(mapping => {
                             const { epaGroup, confidence } = mapping;
                             if (!epaGroup) return null;
+                            const { a, b, c } = resolveCoeffs(epaGroup);
+                            const eta = (a != null)
+                                ? calibrateEfficiency(a, b, c, epaGroup.hwfet_unadj_kwh_100mi)
+                                : null;
+                            const etaFromHwfet = eta != null && epaGroup.hwfet_unadj_kwh_100mi != null;
+                            const useableKwh = resolveUseableKwh(epaGroup, vehicle);
                             return (
                                 <div
                                     key={mapping.id}
@@ -467,10 +484,18 @@ export default function EpaCurvesView({
                                             {epaGroup.label_method && <InfoIcon text={EPA_EXPLAINERS.labelMethod} />}
                                         </span>
                                     )}
-                                    {epaGroup.hwfet_unadj_kwh_100mi && (
+                                    {eta != null && (
                                         <span style={{ color: 'var(--color-text-muted)' }}>
-                                            HWFET unadj: {epaGroup.hwfet_unadj_kwh_100mi} kWh/100mi
-                                            <InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} />
+                                            η<sub>eff</sub>: {(eta * 100).toFixed(1)}%
+                                            {etaFromHwfet
+                                                ? <> · calibrated from HWFET unadj ({epaGroup.hwfet_unadj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
+                                                : <> · default fallback (no HWFET data)<InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} /></>
+                                            }
+                                        </span>
+                                    )}
+                                    {useableKwh && (
+                                        <span style={{ color: 'var(--color-text-muted)' }}>
+                                            Useable: {Number(useableKwh).toFixed(1)} kWh
                                         </span>
                                     )}
                                 </div>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -450,14 +450,6 @@ export default function EpaCurvesView({
                         </div>
                     </div>
 
-                    {/* Axis scale controls */}
-                    <AxisScaleControls
-                        xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}
-                        xAxisLabel={`Speed (${speedLabel(units)})`}
-                        yAxisLabel={yAxisLabel(yAxis, units)}
-                        onChange={(key, value) => setEpaConfig(p => ({ ...p, [key]: value }))}
-                    />
-
                     {/* Collapsible EPA test selector */}
                     {vehiclesWithEpa.length > 0 && (
                         <div className="mt-4">
@@ -632,6 +624,16 @@ export default function EpaCurvesView({
                         Link an EPA test group via Edit Vehicle to enable this chart.
                     </p>
                 </div>
+            )}
+
+            {/* ── Axis scale controls (below chart, per convention) ──────────── */}
+            {!presentationMode && datasets.length > 0 && (
+                <AxisScaleControls
+                    xMin={xMin} xMax={xMax} yMin={yMin} yMax={yMax}
+                    xAxisLabel={`Speed (${speedLabel(units)})`}
+                    yAxisLabel={yAxisLabel(yAxis, units)}
+                    onChange={(key, value) => setEpaConfig(p => ({ ...p, [key]: value }))}
+                />
             )}
         </div>
     );

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -464,10 +464,13 @@ export default function EpaCurvesView({
                             const { epaGroup, confidence } = mapping;
                             if (!epaGroup) return null;
                             const { a, b, c } = resolveCoeffs(epaGroup);
+                            const hwfetKwh = epaGroup.hwfet_unadj_kwh_100mi ?? epaGroup.hwfet_adj_kwh_100mi;
                             const eta = (a != null)
-                                ? calibrateEfficiency(a, b, c, epaGroup.hwfet_unadj_kwh_100mi)
+                                ? calibrateEfficiency(a, b, c, hwfetKwh)
                                 : null;
-                            const etaFromHwfet = eta != null && epaGroup.hwfet_unadj_kwh_100mi != null;
+                            const hwfetSource = epaGroup.hwfet_unadj_kwh_100mi != null ? 'unadj'
+                                              : epaGroup.hwfet_adj_kwh_100mi    != null ? 'adj'
+                                              : null;
                             const useableKwh = resolveUseableKwh(epaGroup, vehicle);
                             return (
                                 <div
@@ -487,10 +490,15 @@ export default function EpaCurvesView({
                                     {eta != null && (
                                         <span style={{ color: 'var(--color-text-muted)' }}>
                                             η<sub>eff</sub>: {(eta * 100).toFixed(1)}%
-                                            {etaFromHwfet
-                                                ? <> · calibrated from HWFET unadj ({epaGroup.hwfet_unadj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
-                                                : <> · default fallback (no HWFET data)<InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} /></>
-                                            }
+                                            {hwfetSource === 'unadj' && (
+                                                <> · calibrated from HWFET unadj ({epaGroup.hwfet_unadj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
+                                            )}
+                                            {hwfetSource === 'adj' && (
+                                                <> · calibrated from HWFET adj ({epaGroup.hwfet_adj_kwh_100mi?.toFixed(1)} kWh/100mi)<InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} /></>
+                                            )}
+                                            {hwfetSource === null && (
+                                                <> · default fallback (no HWFET data)<InfoIcon text={EPA_EXPLAINERS.hwfetCalibration} /></>
+                                            )}
                                         </span>
                                     )}
                                     {useableKwh && (

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -2,13 +2,16 @@
  * Admin panel card — lists all imported EPA test groups with filter + delete.
  *
  * Filter is client-side (the full list loads once on mount) and matches on
- * make, carline name, vehicle config ID, EPA family ID, and linked vehicle
- * names — the same fields visible in the table.
+ * make, carline name, vehicle config ID, EPA family ID, display name, and
+ * linked vehicle names — the same fields visible in the table.
  *
  * Delete removes the vehicle mapping(s) first (no CASCADE on the FK) then the
  * test group row, and shows a confirmation that names any linked vehicles.
+ *
+ * Display name and label method are inline-editable. Display name is folded
+ * into the carline column to avoid horizontal scroll.
  */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
@@ -16,28 +19,28 @@ const CONFIDENCE_COLORS = {
     inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
 };
 
+// Short labels keep the select narrow; full names shown in title tooltip
 const LABEL_METHOD_OPTIONS = [
-    { value: '',                  label: '— unknown —'       },
-    { value: '2-cycle',           label: '2-cycle'           },
-    { value: '5-cycle',           label: '5-cycle'           },
-    { value: 'vehicle-specific',  label: 'Vehicle-specific'  },
-    { value: 'mpg-based',         label: 'MPG-based'         },
+    { value: '',                 label: '—',        title: 'Unknown / not set'    },
+    { value: '2-cycle',          label: '2-cycle',  title: '2-cycle (city + hwy)' },
+    { value: '5-cycle',          label: '5-cycle',  title: '5-cycle adjusted'     },
+    { value: 'vehicle-specific', label: 'Veh-spec', title: 'Vehicle-specific test' },
+    { value: 'mpg-based',        label: 'MPG',      title: 'MPG-based (PHEV)'     },
 ];
 
 export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod, updateEpaTestGroup }) {
-    const [groups,          setGroups]          = useState([]);
-    const [loading,         setLoading]         = useState(true);
-    const [query,           setQuery]           = useState('');
-    const [deleting,        setDeleting]        = useState(new Set()); // set of test_group_ids in-flight
-    const [updatingMethod,  setUpdatingMethod]  = useState(new Set()); // set of test_group_ids updating label_method
-    // display_name: local draft edits keyed by test_group_id (string); saved on blur/Enter
-    const [draftNames,      setDraftNames]      = useState({});
-    const [savingName,      setSavingName]      = useState(new Set());
-    const [error,           setError]           = useState(null);
+    const [groups,         setGroups]         = useState([]);
+    const [loading,        setLoading]        = useState(true);
+    const [query,          setQuery]          = useState('');
+    const [deleting,       setDeleting]       = useState(new Set());
+    const [updatingMethod, setUpdatingMethod] = useState(new Set());
+    const [draftNames,     setDraftNames]     = useState({});   // keyed by test_group_id
+    const [savingName,     setSavingName]     = useState(new Set());
+    const [error,          setError]          = useState(null);
 
     useEffect(() => { load(); }, []);
 
-    // Seed draft names whenever groups load / reload
+    // Seed drafts whenever the group list changes
     useEffect(() => {
         const seed = {};
         groups.forEach(g => { seed[g.test_group_id] = g.display_name ?? ''; });
@@ -76,9 +79,9 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
     }
 
     async function handleDisplayNameSave(group) {
-        const draft = (draftNames[group.test_group_id] ?? '').trim();
+        const draft   = (draftNames[group.test_group_id] ?? '').trim();
         const current = group.display_name ?? '';
-        if (draft === current) return; // no change
+        if (draft === current) return;
         setSavingName(prev => new Set(prev).add(group.test_group_id));
         try {
             await updateEpaTestGroup?.(group.test_group_id, { display_name: draft || null });
@@ -89,7 +92,6 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
             ));
         } catch (e) {
             setError('Save failed: ' + e.message);
-            // Revert draft
             setDraftNames(prev => ({ ...prev, [group.test_group_id]: current }));
         } finally {
             setSavingName(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
@@ -119,6 +121,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
         ? groups.filter(g =>
             g.make?.toLowerCase().includes(q) ||
             g.epa_carline_name?.toLowerCase().includes(q) ||
+            g.display_name?.toLowerCase().includes(q) ||
             g.test_group_id?.toLowerCase().includes(q) ||
             g.epa_test_family_id?.toLowerCase().includes(q) ||
             (g.epa_vehicle_mappings || []).some(m => m.vehicles?.name?.toLowerCase().includes(q))
@@ -178,13 +181,12 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                     <table className="w-full text-xs">
                         <thead>
                             <tr className="border-b bg-gray-50 dark:bg-slate-800/50 text-left">
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Display Name</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Vehicle Config ID</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Config ID</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold">Year · Make · Carline</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Road-Load A / B / C</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label MPGe</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label Method</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">A · B · C</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">MPGe</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Method</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
                                 <th className="px-3 py-2" />
                             </tr>
@@ -192,35 +194,15 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                         <tbody className="divide-y">
                             {filtered.map(g => {
                                 const mappings = g.epa_vehicle_mappings || [];
-                                const isDel = deleting.has(g.test_group_id);
+                                const isDel    = deleting.has(g.test_group_id);
+                                const isSaving = savingName.has(g.test_group_id);
                                 return (
                                     <tr
                                         key={g.test_group_id}
                                         className={`transition hover:bg-gray-50/50 dark:hover:bg-slate-800/30 ${isDel ? 'opacity-40 pointer-events-none' : ''}`}
                                     >
-                                        {/* Display name — inline editable, save on blur or Enter */}
-                                        <td className="px-3 py-2 min-w-[160px]">
-                                            <input
-                                                type="text"
-                                                value={draftNames[g.test_group_id] ?? g.display_name ?? ''}
-                                                placeholder={g.epa_carline_name}
-                                                disabled={isDel || savingName.has(g.test_group_id)}
-                                                onChange={e => setDraftNames(prev => ({ ...prev, [g.test_group_id]: e.target.value }))}
-                                                onBlur={() => handleDisplayNameSave(g)}
-                                                onKeyDown={e => {
-                                                    if (e.key === 'Enter') { e.target.blur(); }
-                                                    if (e.key === 'Escape') {
-                                                        setDraftNames(prev => ({ ...prev, [g.test_group_id]: g.display_name ?? '' }));
-                                                        e.target.blur();
-                                                    }
-                                                }}
-                                                className="form-input text-xs py-0.5 w-full disabled:opacity-50 placeholder:text-gray-300 dark:placeholder:text-slate-600 placeholder:italic"
-                                                title="Friendly name used in charts. Leave blank to use the EPA carline name."
-                                            />
-                                        </td>
-
-                                        {/* Vehicle config ID + family ID */}
-                                        <td className="px-3 py-2 font-mono">
+                                        {/* Config ID + family ID */}
+                                        <td className="px-3 py-2 font-mono whitespace-nowrap">
                                             <div className="text-gray-700 dark:text-slate-300">{g.test_group_id}</div>
                                             {g.epa_test_family_id && g.epa_test_family_id !== g.test_group_id && (
                                                 <div className="text-[10px] text-gray-400 dark:text-slate-500 mt-0.5">
@@ -229,17 +211,33 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                             )}
                                         </td>
 
-                                        {/* Year / Make / Carline */}
-                                        <td className="px-3 py-2">
-                                            <div
-                                                className="font-medium text-gray-700 dark:text-slate-300 max-w-[220px] truncate"
-                                                title={g.epa_carline_name}
-                                            >
+                                        {/* Year / Make / Carline + inline display-name edit */}
+                                        <td className="px-3 py-2 max-w-[200px]">
+                                            {/* Carline name: wraps, no truncation */}
+                                            <div className="font-medium text-gray-700 dark:text-slate-300 leading-snug">
                                                 {g.epa_carline_name}
                                             </div>
-                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5">
+                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5 whitespace-nowrap">
                                                 {g.model_year}{g.make ? ` · ${g.make}` : ''}
                                             </div>
+                                            {/* Display name input — inline below the carline */}
+                                            <input
+                                                type="text"
+                                                value={draftNames[g.test_group_id] ?? ''}
+                                                placeholder="Display name…"
+                                                disabled={isDel || isSaving}
+                                                onChange={e => setDraftNames(prev => ({ ...prev, [g.test_group_id]: e.target.value }))}
+                                                onBlur={() => handleDisplayNameSave(g)}
+                                                onKeyDown={e => {
+                                                    if (e.key === 'Enter')  { e.target.blur(); }
+                                                    if (e.key === 'Escape') {
+                                                        setDraftNames(prev => ({ ...prev, [g.test_group_id]: g.display_name ?? '' }));
+                                                        e.target.blur();
+                                                    }
+                                                }}
+                                                className="form-input text-xs py-0.5 mt-1.5 w-full disabled:opacity-50 placeholder:text-gray-300 dark:placeholder:text-slate-600 placeholder:italic"
+                                                title="Friendly display name used in charts. Leave blank to use the EPA carline name."
+                                            />
                                         </td>
 
                                         {/* Drive / ETW */}
@@ -261,8 +259,10 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                                 const isTarget = g.target_a != null;
                                                 if (a == null) return <span className="text-gray-300 dark:text-slate-600">—</span>;
                                                 return (
-                                                    <div className={`text-[11px] leading-tight ${isTarget ? 'text-gray-600 dark:text-slate-300' : 'text-gray-400 dark:text-slate-500'}`}
-                                                         title={isTarget ? 'Target coefficients (road load)' : 'Set coefficients (dyno-programmed)'}>
+                                                    <div
+                                                        className={`text-[11px] leading-tight ${isTarget ? 'text-gray-600 dark:text-slate-300' : 'text-gray-400 dark:text-slate-500'}`}
+                                                        title={isTarget ? 'Target coefficients (road load)' : 'Set coefficients (dyno-programmed)'}
+                                                    >
                                                         <div>{Number(a).toFixed(2)}</div>
                                                         <div>{Number(b).toFixed(4)}</div>
                                                         <div>{Number(c).toFixed(5)}</div>
@@ -280,28 +280,29 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                                         ? 'text-amber-600 dark:text-amber-400 font-medium'
                                                         : 'text-gray-500 dark:text-slate-400'}
                                                     title={g.label_combined_mpge < 60
-                                                        ? 'Label < 60 MPGe — the source column may have been in MPGe rather than kWh/100mi. Re-import with the unit flip toggle to correct.'
+                                                        ? 'Label < 60 MPGe — source column may be in MPGe not kWh/100mi. Re-import with the unit flip toggle.'
                                                         : undefined}
                                                 >
                                                     {g.label_combined_mpge < 60 && '⚠ '}
-                                                    {g.label_combined_mpge} MPGe
+                                                    {g.label_combined_mpge}
                                                 </span>
                                             ) : (
                                                 <span className="text-gray-300 dark:text-slate-600">—</span>
                                             )}
                                         </td>
 
-                                        {/* Label method — admin-editable select */}
+                                        {/* Label method — compact select */}
                                         <td className="px-3 py-2">
                                             <select
                                                 value={g.label_method ?? ''}
                                                 disabled={updatingMethod.has(g.test_group_id) || isDel}
                                                 onChange={e => handleLabelMethodChange(g, e.target.value)}
-                                                className="form-input text-xs py-0.5 w-36 disabled:opacity-50"
-                                                title="Range label derivation method — not in the Test Car List; look up on fueleconomy.gov"
+                                                className="form-input text-xs py-0.5 w-24 disabled:opacity-50"
+                                                title={LABEL_METHOD_OPTIONS.find(o => o.value === (g.label_method ?? ''))?.title
+                                                    ?? 'Range label derivation method — look up on fueleconomy.gov'}
                                             >
                                                 {LABEL_METHOD_OPTIONS.map(o => (
-                                                    <option key={o.value} value={o.value}>{o.label}</option>
+                                                    <option key={o.value} value={o.value} title={o.title}>{o.label}</option>
                                                 ))}
                                             </select>
                                         </td>
@@ -344,7 +345,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                 </div>
             )}
 
-            {/* Footer: source file info when filtering is active */}
+            {/* Footer: row count when filter is active */}
             {!loading && groups.length > 0 && q && filtered.length !== groups.length && (
                 <div className="px-4 py-2 border-t text-xs text-gray-400 dark:text-slate-500">
                     Showing {filtered.length} of {groups.length} test groups

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -125,8 +125,8 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Vehicle Config ID</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold text-center whitespace-nowrap">A/B/C</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Road-Load A / B / C</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label MPGe</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
                                 <th className="px-3 py-2" />
                             </tr>
@@ -173,17 +173,29 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
                                             </div>
                                         </td>
 
-                                        {/* Has road-load coefficients? */}
-                                        <td className="px-3 py-2 text-center">
-                                            {g.target_a != null || g.set_a != null
-                                                ? <span className="text-green-600 dark:text-green-400 font-medium">✓</span>
-                                                : <span className="text-gray-300 dark:text-slate-600">—</span>
-                                            }
+                                        {/* Road-load A / B / C — prefer target; fall back to set */}
+                                        <td className="px-3 py-2 font-mono whitespace-nowrap">
+                                            {(() => {
+                                                const a = g.target_a ?? g.set_a;
+                                                const b = g.target_b ?? g.set_b;
+                                                const c = g.target_c ?? g.set_c;
+                                                const isTarget = g.target_a != null;
+                                                if (a == null) return <span className="text-gray-300 dark:text-slate-600">—</span>;
+                                                return (
+                                                    <div className={`text-[11px] leading-tight ${isTarget ? 'text-gray-600 dark:text-slate-300' : 'text-gray-400 dark:text-slate-500'}`}
+                                                         title={isTarget ? 'Target coefficients (road load)' : 'Set coefficients (dyno-programmed)'}>
+                                                        <div>{Number(a).toFixed(2)}</div>
+                                                        <div>{Number(b).toFixed(4)}</div>
+                                                        <div>{Number(c).toFixed(5)}</div>
+                                                        {!isTarget && <div className="text-[9px] text-amber-500 mt-0.5">set only</div>}
+                                                    </div>
+                                                );
+                                            })()}
                                         </td>
 
-                                        {/* Label MPGe */}
+                                        {/* Label MPGe — 999 is an EPA sentinel meaning "label not yet assigned" */}
                                         <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
-                                            {g.label_combined_mpge != null
+                                            {g.label_combined_mpge != null && g.label_combined_mpge < 500
                                                 ? `${g.label_combined_mpge} MPGe`
                                                 : <span className="text-gray-300 dark:text-slate-600">—</span>
                                             }

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -193,12 +193,23 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
                                             })()}
                                         </td>
 
-                                        {/* Label MPGe — 999 is an EPA sentinel meaning "label not yet assigned" */}
-                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
-                                            {g.label_combined_mpge != null && g.label_combined_mpge < 500
-                                                ? `${g.label_combined_mpge} MPGe`
-                                                : <span className="text-gray-300 dark:text-slate-600">—</span>
-                                            }
+                                        {/* Label MPGe */}
+                                        <td className="px-3 py-2 whitespace-nowrap">
+                                            {g.label_combined_mpge != null && g.label_combined_mpge < 500 ? (
+                                                <span
+                                                    className={g.label_combined_mpge < 60
+                                                        ? 'text-amber-600 dark:text-amber-400 font-medium'
+                                                        : 'text-gray-500 dark:text-slate-400'}
+                                                    title={g.label_combined_mpge < 60
+                                                        ? 'Label < 60 MPGe — the source column may have been in MPGe rather than kWh/100mi. Re-import with the unit flip toggle to correct.'
+                                                        : undefined}
+                                                >
+                                                    {g.label_combined_mpge < 60 && '⚠ '}
+                                                    {g.label_combined_mpge} MPGe
+                                                </span>
+                                            ) : (
+                                                <span className="text-gray-300 dark:text-slate-600">—</span>
+                                            )}
                                         </td>
 
                                         {/* Linked vehicles with confidence badges */}

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -16,12 +16,21 @@ const CONFIDENCE_COLORS = {
     inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
 };
 
-export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup }) {
-    const [groups,   setGroups]   = useState([]);
-    const [loading,  setLoading]  = useState(true);
-    const [query,    setQuery]    = useState('');
-    const [deleting, setDeleting] = useState(new Set()); // set of test_group_ids in-flight
-    const [error,    setError]    = useState(null);
+const LABEL_METHOD_OPTIONS = [
+    { value: '',                  label: '— unknown —'       },
+    { value: '2-cycle',           label: '2-cycle'           },
+    { value: '5-cycle',           label: '5-cycle'           },
+    { value: 'vehicle-specific',  label: 'Vehicle-specific'  },
+    { value: 'mpg-based',         label: 'MPG-based'         },
+];
+
+export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod }) {
+    const [groups,          setGroups]          = useState([]);
+    const [loading,         setLoading]         = useState(true);
+    const [query,           setQuery]           = useState('');
+    const [deleting,        setDeleting]        = useState(new Set()); // set of test_group_ids in-flight
+    const [updatingMethod,  setUpdatingMethod]  = useState(new Set()); // set of test_group_ids updating label_method
+    const [error,           setError]           = useState(null);
 
     useEffect(() => { load(); }, []);
 
@@ -53,6 +62,22 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
             setError('Delete failed: ' + e.message);
         } finally {
             setDeleting(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
+        }
+    }
+
+    async function handleLabelMethodChange(group, method) {
+        setUpdatingMethod(prev => new Set(prev).add(group.test_group_id));
+        try {
+            await updateEpaLabelMethod?.(group.test_group_id, method);
+            setGroups(prev => prev.map(g =>
+                g.test_group_id === group.test_group_id
+                    ? { ...g, label_method: method || null }
+                    : g
+            ));
+        } catch (e) {
+            setError('Update failed: ' + e.message);
+        } finally {
+            setUpdatingMethod(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
         }
     }
 
@@ -127,6 +152,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Road-Load A / B / C</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label MPGe</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label Method</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
                                 <th className="px-3 py-2" />
                             </tr>
@@ -210,6 +236,21 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup 
                                             ) : (
                                                 <span className="text-gray-300 dark:text-slate-600">—</span>
                                             )}
+                                        </td>
+
+                                        {/* Label method — admin-editable select */}
+                                        <td className="px-3 py-2">
+                                            <select
+                                                value={g.label_method ?? ''}
+                                                disabled={updatingMethod.has(g.test_group_id) || isDel}
+                                                onChange={e => handleLabelMethodChange(g, e.target.value)}
+                                                className="form-input text-xs py-0.5 w-36 disabled:opacity-50"
+                                                title="Range label derivation method — not in the Test Car List; look up on fueleconomy.gov"
+                                            >
+                                                {LABEL_METHOD_OPTIONS.map(o => (
+                                                    <option key={o.value} value={o.value}>{o.label}</option>
+                                                ))}
+                                            </select>
                                         </td>
 
                                         {/* Linked vehicles with confidence badges */}

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -8,7 +8,7 @@
  * Delete removes the vehicle mapping(s) first (no CASCADE on the FK) then the
  * test group row, and shows a confirmation that names any linked vehicles.
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
@@ -24,15 +24,25 @@ const LABEL_METHOD_OPTIONS = [
     { value: 'mpg-based',         label: 'MPG-based'         },
 ];
 
-export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod }) {
+export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod, updateEpaTestGroup }) {
     const [groups,          setGroups]          = useState([]);
     const [loading,         setLoading]         = useState(true);
     const [query,           setQuery]           = useState('');
     const [deleting,        setDeleting]        = useState(new Set()); // set of test_group_ids in-flight
     const [updatingMethod,  setUpdatingMethod]  = useState(new Set()); // set of test_group_ids updating label_method
+    // display_name: local draft edits keyed by test_group_id (string); saved on blur/Enter
+    const [draftNames,      setDraftNames]      = useState({});
+    const [savingName,      setSavingName]      = useState(new Set());
     const [error,           setError]           = useState(null);
 
     useEffect(() => { load(); }, []);
+
+    // Seed draft names whenever groups load / reload
+    useEffect(() => {
+        const seed = {};
+        groups.forEach(g => { seed[g.test_group_id] = g.display_name ?? ''; });
+        setDraftNames(seed);
+    }, [groups]);
 
     async function load() {
         setLoading(true);
@@ -62,6 +72,27 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
             setError('Delete failed: ' + e.message);
         } finally {
             setDeleting(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
+        }
+    }
+
+    async function handleDisplayNameSave(group) {
+        const draft = (draftNames[group.test_group_id] ?? '').trim();
+        const current = group.display_name ?? '';
+        if (draft === current) return; // no change
+        setSavingName(prev => new Set(prev).add(group.test_group_id));
+        try {
+            await updateEpaTestGroup?.(group.test_group_id, { display_name: draft || null });
+            setGroups(prev => prev.map(g =>
+                g.test_group_id === group.test_group_id
+                    ? { ...g, display_name: draft || null }
+                    : g
+            ));
+        } catch (e) {
+            setError('Save failed: ' + e.message);
+            // Revert draft
+            setDraftNames(prev => ({ ...prev, [group.test_group_id]: current }));
+        } finally {
+            setSavingName(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
         }
     }
 
@@ -147,6 +178,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                     <table className="w-full text-xs">
                         <thead>
                             <tr className="border-b bg-gray-50 dark:bg-slate-800/50 text-left">
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Display Name</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Vehicle Config ID</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
@@ -166,6 +198,27 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                         key={g.test_group_id}
                                         className={`transition hover:bg-gray-50/50 dark:hover:bg-slate-800/30 ${isDel ? 'opacity-40 pointer-events-none' : ''}`}
                                     >
+                                        {/* Display name — inline editable, save on blur or Enter */}
+                                        <td className="px-3 py-2 min-w-[160px]">
+                                            <input
+                                                type="text"
+                                                value={draftNames[g.test_group_id] ?? g.display_name ?? ''}
+                                                placeholder={g.epa_carline_name}
+                                                disabled={isDel || savingName.has(g.test_group_id)}
+                                                onChange={e => setDraftNames(prev => ({ ...prev, [g.test_group_id]: e.target.value }))}
+                                                onBlur={() => handleDisplayNameSave(g)}
+                                                onKeyDown={e => {
+                                                    if (e.key === 'Enter') { e.target.blur(); }
+                                                    if (e.key === 'Escape') {
+                                                        setDraftNames(prev => ({ ...prev, [g.test_group_id]: g.display_name ?? '' }));
+                                                        e.target.blur();
+                                                    }
+                                                }}
+                                                className="form-input text-xs py-0.5 w-full disabled:opacity-50 placeholder:text-gray-300 dark:placeholder:text-slate-600 placeholder:italic"
+                                                title="Friendly name used in charts. Leave blank to use the EPA carline name."
+                                            />
+                                        </td>
+
                                         {/* Vehicle config ID + family ID */}
                                         <td className="px-3 py-2 font-mono">
                                             <div className="text-gray-700 dark:text-slate-300">{g.test_group_id}</div>

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -1,0 +1,238 @@
+/**
+ * Admin panel card — lists all imported EPA test groups with filter + delete.
+ *
+ * Filter is client-side (the full list loads once on mount) and matches on
+ * make, carline name, vehicle config ID, EPA family ID, and linked vehicle
+ * names — the same fields visible in the table.
+ *
+ * Delete removes the vehicle mapping(s) first (no CASCADE on the FK) then the
+ * test group row, and shows a confirmation that names any linked vehicles.
+ */
+import { useState, useEffect } from 'react';
+
+const CONFIDENCE_COLORS = {
+    verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
+    likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
+    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+};
+
+export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup }) {
+    const [groups,   setGroups]   = useState([]);
+    const [loading,  setLoading]  = useState(true);
+    const [query,    setQuery]    = useState('');
+    const [deleting, setDeleting] = useState(new Set()); // set of test_group_ids in-flight
+    const [error,    setError]    = useState(null);
+
+    useEffect(() => { load(); }, []);
+
+    async function load() {
+        setLoading(true);
+        setError(null);
+        try {
+            setGroups(await getEpaTestGroupsAdmin());
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function handleDelete(group) {
+        const linked = (group.epa_vehicle_mappings || [])
+            .map(m => m.vehicles?.name).filter(Boolean);
+        const suffix = linked.length
+            ? `\n\nThis will also unlink it from: ${linked.join(', ')}.`
+            : '';
+        if (!window.confirm(`Delete "${group.epa_carline_name}" (${group.test_group_id})?${suffix}`)) return;
+
+        setDeleting(prev => new Set(prev).add(group.test_group_id));
+        try {
+            await deleteEpaTestGroup(group.test_group_id);
+            setGroups(prev => prev.filter(g => g.test_group_id !== group.test_group_id));
+        } catch (e) {
+            setError('Delete failed: ' + e.message);
+        } finally {
+            setDeleting(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
+        }
+    }
+
+    // ── Client-side filter ────────────────────────────────────────────────────
+
+    const q = query.trim().toLowerCase();
+    const filtered = q
+        ? groups.filter(g =>
+            g.make?.toLowerCase().includes(q) ||
+            g.epa_carline_name?.toLowerCase().includes(q) ||
+            g.test_group_id?.toLowerCase().includes(q) ||
+            g.epa_test_family_id?.toLowerCase().includes(q) ||
+            (g.epa_vehicle_mappings || []).some(m => m.vehicles?.name?.toLowerCase().includes(q))
+          )
+        : groups;
+
+    const linkedCount = groups.filter(g => g.epa_vehicle_mappings?.length > 0).length;
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    return (
+        <div className="card p-0 overflow-hidden mt-6">
+
+            {/* Header */}
+            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b">
+                <div>
+                    <h3 className="font-semibold text-sm">EPA Test Groups</h3>
+                    <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                        {loading ? 'Loading…' : `${groups.length} imported · ${linkedCount} linked to vehicles`}
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <input
+                        type="text"
+                        placeholder="Filter by make, carline, ID, vehicle…"
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        className="form-input text-sm py-1.5 w-64"
+                    />
+                    <button
+                        onClick={load}
+                        disabled={loading}
+                        className="btn btn-secondary text-xs py-1.5 px-3"
+                        title="Refresh"
+                    >
+                        {loading ? '…' : '↻ Refresh'}
+                    </button>
+                </div>
+            </div>
+
+            {/* Error */}
+            {error && (
+                <div className="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-700 text-red-800 dark:text-red-300 text-xs">
+                    ⚠️ {error}
+                </div>
+            )}
+
+            {/* Body */}
+            {loading ? (
+                <div className="px-4 py-8 text-center text-sm text-gray-400">Loading…</div>
+            ) : filtered.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-gray-400">
+                    {q ? 'No test groups match that filter.' : 'No EPA test groups imported yet. Use Import → EPA Test Car Data to add some.'}
+                </div>
+            ) : (
+                <div className="overflow-x-auto">
+                    <table className="w-full text-xs">
+                        <thead>
+                            <tr className="border-b bg-gray-50 dark:bg-slate-800/50 text-left">
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Vehicle Config ID</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold text-center whitespace-nowrap">A/B/C</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Label</th>
+                                <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
+                                <th className="px-3 py-2" />
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y">
+                            {filtered.map(g => {
+                                const mappings = g.epa_vehicle_mappings || [];
+                                const isDel = deleting.has(g.test_group_id);
+                                return (
+                                    <tr
+                                        key={g.test_group_id}
+                                        className={`transition hover:bg-gray-50/50 dark:hover:bg-slate-800/30 ${isDel ? 'opacity-40 pointer-events-none' : ''}`}
+                                    >
+                                        {/* Vehicle config ID + family ID */}
+                                        <td className="px-3 py-2 font-mono">
+                                            <div className="text-gray-700 dark:text-slate-300">{g.test_group_id}</div>
+                                            {g.epa_test_family_id && g.epa_test_family_id !== g.test_group_id && (
+                                                <div className="text-[10px] text-gray-400 dark:text-slate-500 mt-0.5">
+                                                    fam: {g.epa_test_family_id}
+                                                </div>
+                                            )}
+                                        </td>
+
+                                        {/* Year / Make / Carline */}
+                                        <td className="px-3 py-2">
+                                            <div
+                                                className="font-medium text-gray-700 dark:text-slate-300 max-w-[220px] truncate"
+                                                title={g.epa_carline_name}
+                                            >
+                                                {g.epa_carline_name}
+                                            </div>
+                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5">
+                                                {g.model_year}{g.make ? ` · ${g.make}` : ''}
+                                            </div>
+                                        </td>
+
+                                        {/* Drive / ETW */}
+                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
+                                            <div>{g.drive || '—'}</div>
+                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5">
+                                                {g.equiv_test_weight_lbs != null
+                                                    ? `${Number(g.equiv_test_weight_lbs).toLocaleString()} lbs`
+                                                    : '—'}
+                                            </div>
+                                        </td>
+
+                                        {/* Has road-load coefficients? */}
+                                        <td className="px-3 py-2 text-center">
+                                            {g.target_a != null || g.set_a != null
+                                                ? <span className="text-green-600 dark:text-green-400 font-medium">✓</span>
+                                                : <span className="text-gray-300 dark:text-slate-600">—</span>
+                                            }
+                                        </td>
+
+                                        {/* Label MPGe */}
+                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
+                                            {g.label_combined_mpge != null
+                                                ? `${g.label_combined_mpge} MPGe`
+                                                : <span className="text-gray-300 dark:text-slate-600">—</span>
+                                            }
+                                        </td>
+
+                                        {/* Linked vehicles with confidence badges */}
+                                        <td className="px-3 py-2">
+                                            {mappings.length === 0 ? (
+                                                <span className="text-gray-300 dark:text-slate-600 italic">none</span>
+                                            ) : (
+                                                <div className="flex flex-wrap gap-1">
+                                                    {mappings.map(m => (
+                                                        <span
+                                                            key={m.id}
+                                                            className={`px-1.5 py-0.5 rounded border font-medium ${CONFIDENCE_COLORS[m.confidence] ?? CONFIDENCE_COLORS.inferred}`}
+                                                        >
+                                                            {m.vehicles?.name || '?'}
+                                                            {m.vehicles?.year ? ` (${m.vehicles.year})` : ''}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </td>
+
+                                        {/* Delete */}
+                                        <td className="px-3 py-2">
+                                            <button
+                                                type="button"
+                                                disabled={isDel}
+                                                onClick={() => handleDelete(g)}
+                                                className="btn btn-secondary text-xs py-0.5 px-2 text-red-600 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-900/30 disabled:opacity-40"
+                                            >
+                                                {isDel ? '…' : 'Delete'}
+                                            </button>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {/* Footer: source file info when filtering is active */}
+            {!loading && groups.length > 0 && q && filtered.length !== groups.length && (
+                <div className="px-4 py-2 border-t text-xs text-gray-400 dark:text-slate-500">
+                    Showing {filtered.length} of {groups.length} test groups
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/EpaImportModal.jsx
+++ b/src/components/EpaImportModal.jsx
@@ -1,0 +1,309 @@
+import { useState, useRef } from 'react';
+import { parseEpaTestCarSheet, summariseEpaGroups } from '../utils/parseEpaTestCarSheet';
+
+/**
+ * Admin-only modal for importing EPA Test Car List data.
+ *
+ * Workflow:
+ *  1. Upload a pre-filtered EPA testcar TSV
+ *  2. Parser groups rows → one record per test group
+ *  3. User optionally links each test group to a vehicle via a pick list
+ *  4. "Import" upserts epa_test_groups + creates epa_vehicle_mappings
+ */
+export default function EpaImportModal({ vehicles, onImport, onClose }) {
+    const [step, setStep]           = useState('upload'); // 'upload' | 'map' | 'done'
+    const [parsed, setParsed]       = useState([]);
+    const [fileName, setFileName]   = useState('');
+    // Set of test_group_ids to include in the import (all checked by default)
+    const [selected, setSelected]   = useState(new Set());
+    // Map: test_group_id → vehicle id (string) for the link
+    const [linkMap, setLinkMap]     = useState({});
+    const [importing, setImporting] = useState(false);
+    const [result, setResult]       = useState(null);
+    const [error, setError]         = useState(null);
+    const [dragOver, setDragOver]   = useState(false);
+    const fileRef = useRef();
+
+    // ── File handling ─────────────────────────────────────────────────────────
+
+    const processFile = (file) => {
+        if (!file) return;
+        setFileName(file.name);
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            const groups = parseEpaTestCarSheet(e.target.result, file.name);
+            setParsed(groups);
+            setSelected(new Set(groups.map(g => g.test_group_id)));
+            setLinkMap({});
+            setError(null);
+            setStep('map');
+        };
+        reader.onerror = () => setError('Could not read file.');
+        reader.readAsText(file);
+    };
+
+    const handleFilePick   = (e) => processFile(e.target.files[0]);
+    const handleDrop       = (e) => { e.preventDefault(); setDragOver(false); processFile(e.dataTransfer.files[0]); };
+    const handleDragOver   = (e) => { e.preventDefault(); setDragOver(true); };
+    const handleDragLeave  = () => setDragOver(false);
+
+    // ── Pick-list helpers ─────────────────────────────────────────────────────
+
+    const toggleAll = (checked) =>
+        setSelected(checked ? new Set(parsed.map(g => g.test_group_id)) : new Set());
+
+    const toggleOne = (id, checked) =>
+        setSelected(prev => { const s = new Set(prev); checked ? s.add(id) : s.delete(id); return s; });
+
+    const setVehicleLink = (testGroupId, vehicleId) =>
+        setLinkMap(prev => ({ ...prev, [testGroupId]: vehicleId }));
+
+    // ── Import ────────────────────────────────────────────────────────────────
+
+    const handleImport = async () => {
+        const toImport = parsed.filter(g => selected.has(g.test_group_id));
+        const mappings = Object.entries(linkMap)
+            .filter(([tgid, vid]) => selected.has(tgid) && vid)
+            .map(([testGroupId, vehicleId]) => ({ vehicleId: parseInt(vehicleId, 10), testGroupId }));
+
+        setImporting(true);
+        setError(null);
+        try {
+            const res = await onImport(toImport, mappings);
+            setResult(res);
+            setStep('done');
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setImporting(false);
+        }
+    };
+
+    // ── Derived state ─────────────────────────────────────────────────────────
+
+    const summary = parsed.length ? summariseEpaGroups(parsed) : null;
+    const selectedCount = selected.size;
+    const linkedCount   = Object.entries(linkMap).filter(([tgid, vid]) => selected.has(tgid) && vid).length;
+
+    // Vehicles sorted for the dropdown
+    const sortedVehicles = [...vehicles].sort((a, b) => a.name.localeCompare(b.name));
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    return (
+        <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+            <div className="modal-panel" style={{ maxWidth: '900px', width: '96vw', maxHeight: '90vh', display: 'flex', flexDirection: 'column' }}>
+
+                {/* Header */}
+                <div className="modal-header flex items-center justify-between">
+                    <div>
+                        <h2 className="text-lg font-semibold">Import EPA Test Car Data</h2>
+                        <p className="text-sm text-gray-500 mt-0.5">
+                            Upload a pre-filtered EPA testcar sheet (TSV) to add road-load coefficients.
+                        </p>
+                    </div>
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none ml-4">&times;</button>
+                </div>
+
+                {/* Body — scrollable */}
+                <div className="overflow-y-auto flex-1 p-6">
+
+                    {/* ── Step 1: Upload ─────────────────────────────────── */}
+                    {step === 'upload' && (
+                        <div className="flex flex-col items-center">
+                            <div
+                                className={`w-full border-2 border-dashed rounded-xl p-12 text-center cursor-pointer transition
+                                    ${dragOver ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-gray-300 dark:border-slate-600 hover:border-indigo-400'}`}
+                                onClick={() => fileRef.current?.click()}
+                                onDrop={handleDrop}
+                                onDragOver={handleDragOver}
+                                onDragLeave={handleDragLeave}
+                            >
+                                <div className="text-4xl mb-3">📂</div>
+                                <p className="font-medium text-gray-700 dark:text-slate-300">Drop the EPA testcar TSV here, or click to browse</p>
+                                <p className="text-sm text-gray-400 mt-1">Accepts .txt / .tsv / .csv · Tab-separated · Pre-filter to your vehicles of interest</p>
+                                <input ref={fileRef} type="file" accept=".txt,.tsv,.csv" className="hidden" onChange={handleFilePick} />
+                            </div>
+                            {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+
+                            <div className="mt-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg text-sm text-amber-800 dark:text-amber-300 max-w-lg">
+                                <p className="font-semibold mb-1">How to prepare the file</p>
+                                <ol className="list-decimal list-inside space-y-1 text-xs">
+                                    <li>Download the EPA Test Car List (testcar_yymmdd.txt) from <span className="font-mono">epa.gov</span></li>
+                                    <li>Open in Excel and filter to the manufacturers and models you care about</li>
+                                    <li>Save As → Tab-delimited text (.txt or .tsv)</li>
+                                    <li>Upload here — the app will group rows by test group and show a pick list</li>
+                                </ol>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* ── Step 2: Map to vehicles ─────────────────────────── */}
+                    {step === 'map' && summary && (
+                        <>
+                            {/* Summary banner */}
+                            <div className="flex flex-wrap gap-4 mb-4 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700 rounded-lg text-sm">
+                                <span><strong>{summary.total}</strong> test group{summary.total !== 1 ? 's' : ''} found</span>
+                                {summary.yearMin && <span>MY {summary.yearMin}{summary.yearMax !== summary.yearMin ? `–${summary.yearMax}` : ''}</span>}
+                                <span>{summary.makes.join(', ')}</span>
+                                <span className="text-gray-400">·</span>
+                                <span>{summary.withCoeffs} with A/B/C coefficients</span>
+                                <span>{summary.withMpge} with combined MPGe</span>
+                                <span className="text-gray-400">·</span>
+                                <span>File: <span className="font-mono text-xs">{fileName}</span></span>
+                            </div>
+
+                            {error && (
+                                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-800 text-sm">⚠️ {error}</div>
+                            )}
+
+                            {/* Table */}
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-xs">
+                                    <thead>
+                                        <tr className="border-b text-left">
+                                            <th className="pb-2 pr-2">
+                                                <input type="checkbox"
+                                                    checked={selectedCount === parsed.length && parsed.length > 0}
+                                                    onChange={e => toggleAll(e.target.checked)}
+                                                />
+                                            </th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Test Group</th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">A / B / C</th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Combined</th>
+                                            <th className="pb-2 text-gray-500 font-semibold">Link to Vehicle</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y">
+                                        {parsed.map(g => {
+                                            const isSelected = selected.has(g.test_group_id);
+                                            const linkedVid  = linkMap[g.test_group_id] || '';
+                                            // Prefer set coefficients; fall back to target
+                                            const a = g.set_a ?? g.target_a;
+                                            const b = g.set_b ?? g.target_b;
+                                            const c = g.set_c ?? g.target_c;
+                                            return (
+                                                <tr key={g.test_group_id} className={`transition ${isSelected ? '' : 'opacity-40'}`}>
+                                                    <td className="py-2 pr-2">
+                                                        <input type="checkbox" checked={isSelected}
+                                                            onChange={e => toggleOne(g.test_group_id, e.target.checked)} />
+                                                    </td>
+                                                    <td className="py-2 pr-3 font-mono text-gray-600 dark:text-slate-400 whitespace-nowrap">
+                                                        {g.test_group_id}
+                                                    </td>
+                                                    <td className="py-2 pr-3">
+                                                        <span className="font-medium">{g.model_year}</span>
+                                                        <span className="text-gray-400 mx-1">·</span>
+                                                        <span>{g.make}</span>
+                                                        <div className="text-gray-500 mt-0.5 max-w-[200px] truncate" title={g.epa_carline_name}>
+                                                            {g.epa_carline_name}
+                                                        </div>
+                                                    </td>
+                                                    <td className="py-2 pr-3 whitespace-nowrap">
+                                                        <div>{g.drive ?? '—'}</div>
+                                                        <div className="text-gray-400">{g.equiv_test_weight_lbs != null ? `${g.equiv_test_weight_lbs.toLocaleString()} lbs` : '—'}</div>
+                                                    </td>
+                                                    <td className="py-2 pr-3 font-mono whitespace-nowrap">
+                                                        {a != null ? (
+                                                            <div>
+                                                                <span className={g.set_a != null ? '' : 'text-gray-400'}>{a?.toFixed(2)}</span>
+                                                                <span className="text-gray-300 mx-1">/</span>
+                                                                <span className={g.set_b != null ? '' : 'text-gray-400'}>{b?.toFixed(4)}</span>
+                                                                <span className="text-gray-300 mx-1">/</span>
+                                                                <span className={g.set_c != null ? '' : 'text-gray-400'}>{c?.toFixed(5)}</span>
+                                                            </div>
+                                                        ) : <span className="text-gray-300">—</span>}
+                                                        {g.set_a == null && a != null && (
+                                                            <div className="text-amber-500 text-[10px]">target only</div>
+                                                        )}
+                                                    </td>
+                                                    <td className="py-2 pr-3 whitespace-nowrap">
+                                                        {g.label_combined_mpge != null ? (
+                                                            <span>{g.label_combined_mpge} MPGe</span>
+                                                        ) : <span className="text-gray-300">—</span>}
+                                                    </td>
+                                                    <td className="py-2">
+                                                        <select
+                                                            value={linkedVid}
+                                                            onChange={e => setVehicleLink(g.test_group_id, e.target.value)}
+                                                            disabled={!isSelected}
+                                                            className="form-input text-xs py-1 w-52"
+                                                        >
+                                                            <option value="">— Not linked —</option>
+                                                            {sortedVehicles.map(v => (
+                                                                <option key={v.id} value={v.id}>{v.name}</option>
+                                                            ))}
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </>
+                    )}
+
+                    {/* ── Step 3: Done ─────────────────────────────────────── */}
+                    {step === 'done' && result && (
+                        <div className="flex flex-col items-center py-8 text-center">
+                            <div className="text-5xl mb-4">✅</div>
+                            <p className="text-lg font-semibold mb-2">Import complete</p>
+                            <p className="text-gray-600">
+                                <strong>{result.testGroupsCount}</strong> test group{result.testGroupsCount !== 1 ? 's' : ''} upserted
+                                {result.mappingsCount > 0 && <>, <strong>{result.mappingsCount}</strong> vehicle link{result.mappingsCount !== 1 ? 's' : ''} created</>}
+                            </p>
+                            <p className="text-sm text-gray-400 mt-2">
+                                Vehicles with new EPA data will show a dashed curve on the EPA Curves chart tab.
+                                Confidence is set to "likely" — update it to "verified" via the vehicle edit form if confirmed.
+                            </p>
+                        </div>
+                    )}
+
+                </div>
+
+                {/* Footer */}
+                <div className="modal-footer flex justify-between items-center">
+                    <div className="text-sm text-gray-500">
+                        {step === 'map' && (
+                            <span>
+                                {selectedCount} of {parsed.length} selected
+                                {linkedCount > 0 && ` · ${linkedCount} linked to vehicles`}
+                            </span>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        {step === 'map' && (
+                            <button
+                                type="button"
+                                onClick={() => setStep('upload')}
+                                className="btn btn-secondary text-sm"
+                                disabled={importing}
+                            >
+                                ← Back
+                            </button>
+                        )}
+                        {step === 'upload' && (
+                            <button type="button" onClick={onClose} className="btn btn-secondary text-sm">Cancel</button>
+                        )}
+                        {step === 'map' && (
+                            <button
+                                type="button"
+                                onClick={handleImport}
+                                disabled={importing || selectedCount === 0}
+                                className="btn btn-primary text-sm disabled:opacity-40"
+                            >
+                                {importing ? 'Importing…' : `Import ${selectedCount} test group${selectedCount !== 1 ? 's' : ''}${linkedCount > 0 ? ` + ${linkedCount} link${linkedCount !== 1 ? 's' : ''}` : ''}`}
+                            </button>
+                        )}
+                        {step === 'done' && (
+                            <button type="button" onClick={onClose} className="btn btn-primary text-sm">Done</button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/EpaImportModal.jsx
+++ b/src/components/EpaImportModal.jsx
@@ -121,7 +121,7 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                             >
                                 <div className="text-4xl mb-3">📂</div>
                                 <p className="font-medium text-gray-700 dark:text-slate-300">Drop the EPA testcar TSV here, or click to browse</p>
-                                <p className="text-sm text-gray-400 mt-1">Accepts .txt / .tsv / .csv · Tab-separated · Pre-filter to your vehicles of interest</p>
+                                <p className="text-sm text-gray-400 mt-1">Accepts .csv (Excel) or .txt / .tsv (tab-separated) · Pre-filter to your vehicles of interest</p>
                                 <input ref={fileRef} type="file" accept=".txt,.tsv,.csv" className="hidden" onChange={handleFilePick} />
                             </div>
                             {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
@@ -131,7 +131,7 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                 <ol className="list-decimal list-inside space-y-1 text-xs">
                                     <li>Download the EPA Test Car List (testcar_yymmdd.txt) from <span className="font-mono">epa.gov</span></li>
                                     <li>Open in Excel and filter to the manufacturers and models you care about</li>
-                                    <li>Save As → Tab-delimited text (.txt or .tsv)</li>
+                                    <li>Save As → CSV (.csv) or Tab-delimited text (.txt / .tsv)</li>
                                     <li>Upload here — the app will group rows by test group and show a pick list</li>
                                 </ol>
                             </div>

--- a/src/components/EpaImportModal.jsx
+++ b/src/components/EpaImportModal.jsx
@@ -18,6 +18,9 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
     const [selected, setSelected]   = useState(new Set());
     // Map: test_group_id → vehicle id (string) for the link
     const [linkMap, setLinkMap]     = useState({});
+    // Map: test_group_id → 'mpge' when the user has flipped a row's unit assumption.
+    // Default (absent key) means 'kwh' — RND_ADJ_FE treated as kWh/100mi.
+    const [unitOverrides, setUnitOverrides] = useState({});
     const [importing, setImporting] = useState(false);
     const [result, setResult]       = useState(null);
     const [error, setError]         = useState(null);
@@ -35,6 +38,7 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
             setParsed(groups);
             setSelected(new Set(groups.map(g => g.test_group_id)));
             setLinkMap({});
+            setUnitOverrides({});
             setError(null);
             setStep('map');
         };
@@ -58,10 +62,57 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
     const setVehicleLink = (testGroupId, vehicleId) =>
         setLinkMap(prev => ({ ...prev, [testGroupId]: vehicleId }));
 
+    // ── Unit-override helpers ─────────────────────────────────────────────────
+
+    const MPG_E_CONV = 33.705;
+
+    /**
+     * Effective label MPGe for a group given the current unit-override state.
+     * In 'kwh' mode the parser already computed label_combined_mpge correctly.
+     * In 'mpge' mode the raw MCT value IS the MPGe, so use it directly.
+     */
+    const effectiveMpge = (g) => {
+        if (unitOverrides[g.test_group_id] === 'mpge') {
+            const raw = g._raw?.combined;
+            return (raw != null && raw > 0 && raw < 999) ? raw : null;
+        }
+        return g.label_combined_mpge;
+    };
+
+    /**
+     * Apply the user's unit-mode choice to a parsed group before DB upsert.
+     * Strips the _raw helper object (not a DB column).
+     * In 'mpge' mode: raw values are MPGe → re-derive kWh/100mi for per-cycle fields.
+     */
+    const applyUnitOverride = (g) => {
+        const { _raw, ...rest } = g;
+        if (unitOverrides[g.test_group_id] !== 'mpge' || !_raw) return rest;
+        const toKwh = (mpge) => (mpge != null && mpge > 0 && mpge < 999)
+            ? parseFloat((MPG_E_CONV * 100 / mpge).toFixed(4))
+            : null;
+        return {
+            ...rest,
+            label_combined_mpge:    (_raw.combined != null && _raw.combined > 0 && _raw.combined < 999) ? _raw.combined : rest.label_combined_mpge,
+            hwfet_adj_kwh_100mi:    toKwh(_raw.hwfet),
+            udds_adj_kwh_100mi:     toKwh(_raw.udds),
+            us06_adj_kwh_100mi:     toKwh(_raw.us06),
+            sc03_adj_kwh_100mi:     toKwh(_raw.sc03),
+            cold_ftp_adj_kwh_100mi: toKwh(_raw.cold_ftp),
+        };
+    };
+
+    const toggleUnitOverride = (testGroupId) =>
+        setUnitOverrides(prev => ({
+            ...prev,
+            [testGroupId]: prev[testGroupId] === 'mpge' ? undefined : 'mpge',
+        }));
+
     // ── Import ────────────────────────────────────────────────────────────────
 
     const handleImport = async () => {
-        const toImport = parsed.filter(g => selected.has(g.test_group_id));
+        const toImport = parsed
+            .filter(g => selected.has(g.test_group_id))
+            .map(applyUnitOverride); // apply unit overrides + strip _raw
         const mappings = Object.entries(linkMap)
             .filter(([tgid, vid]) => selected.has(tgid) && vid)
             .map(([testGroupId, vehicleId]) => ({ vehicleId: parseInt(vehicleId, 10), testGroupId }));
@@ -172,7 +223,7 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                             <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
                                             <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
                                             <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">A / B / C</th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Combined</th>
+                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Combined MPGe</th>
                                             <th className="pb-2 text-gray-500 font-semibold">Link to Vehicle</th>
                                         </tr>
                                     </thead>
@@ -220,9 +271,43 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                                         )}
                                                     </td>
                                                     <td className="py-2 pr-3 whitespace-nowrap">
-                                                        {g.label_combined_mpge != null ? (
-                                                            <span>{g.label_combined_mpge} MPGe</span>
-                                                        ) : <span className="text-gray-300">—</span>}
+                                                        {(() => {
+                                                            const mpge = effectiveMpge(g);
+                                                            const isMpgeMode = unitOverrides[g.test_group_id] === 'mpge';
+                                                            // Flag when converted label is suspiciously low —
+                                                            // likely the column was already in MPGe, not kWh/100mi
+                                                            const suspect = !isMpgeMode && mpge != null && mpge < 60;
+                                                            return (
+                                                                <div className="flex items-center gap-1.5">
+                                                                    {mpge != null ? (
+                                                                        <span className={suspect ? 'text-amber-600 dark:text-amber-400 font-medium' : ''}>
+                                                                            {suspect && '⚠ '}{mpge.toFixed(1)} MPGe
+                                                                        </span>
+                                                                    ) : (
+                                                                        <span className="text-gray-300">—</span>
+                                                                    )}
+                                                                    {/* Only show toggle when we have a raw value to flip */}
+                                                                    {g._raw?.combined != null && (
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => toggleUnitOverride(g.test_group_id)}
+                                                                            title={isMpgeMode
+                                                                                ? `Treating as MPGe (raw: ${g._raw.combined}). Click to treat as kWh/100mi.`
+                                                                                : `Treating as kWh/100mi (raw: ${g._raw.combined}). Click to treat as MPGe.`}
+                                                                            className={`text-[10px] px-1.5 py-0.5 rounded border leading-none ${
+                                                                                isMpgeMode
+                                                                                    ? 'border-indigo-400 text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30'
+                                                                                    : suspect
+                                                                                        ? 'border-amber-400 text-amber-600 dark:text-amber-400 hover:bg-amber-50'
+                                                                                        : 'border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400'
+                                                                            }`}
+                                                                        >
+                                                                            {isMpgeMode ? 'MPGe' : 'kWh'}
+                                                                        </button>
+                                                                    )}
+                                                                </div>
+                                                            );
+                                                        })()}
                                                     </td>
                                                     <td className="py-2">
                                                         <select

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -197,6 +197,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
     const [query, setQuery]               = useState('');
     const [results, setResults]           = useState([]);
     const [searching, setSearching]       = useState(false);
+    const [searchError, setSearchError]   = useState(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [linking, setLinking]           = useState(false);
     const debounceRef = useRef(null);
@@ -207,14 +208,19 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
         const q = e.target.value;
         setQuery(q);
         setShowDropdown(true);
+        setSearchError(null);
         if (debounceRef.current) clearTimeout(debounceRef.current);
         if (!q.trim()) { setResults([]); return; }
         debounceRef.current = setTimeout(async () => {
             setSearching(true);
             try {
-                const year = vehicle?.year ? parseInt(vehicle.year, 10) : null;
-                const rows = await searchEpaTestGroups?.(q.trim(), year);
+                // No year filter — EPA model years often differ from the vehicle's model year
+                // by 1–2 years; the year is shown in dropdown results for manual verification.
+                const rows = await searchEpaTestGroups?.(q.trim());
                 setResults(rows || []);
+            } catch (err) {
+                setSearchError(err?.message || 'Search failed');
+                setResults([]);
             } finally {
                 setSearching(false);
             }
@@ -278,10 +284,13 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         {linking && (
                             <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">Linking…</span>
                         )}
-                        {showDropdown && (results.length > 0 || searching) && (
+                        {showDropdown && (results.length > 0 || searching || searchError) && (
                             <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
                                 {searching && (
                                     <li className="px-3 py-2 text-sm text-gray-400 italic">Searching…</li>
+                                )}
+                                {!searching && searchError && (
+                                    <li className="px-3 py-2 text-sm text-red-500">Error: {searchError}</li>
                                 )}
                                 {!searching && results.map(g => (
                                     <li
@@ -295,7 +304,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                         </span>
                                     </li>
                                 ))}
-                                {!searching && results.length === 0 && query.trim() && (
+                                {!searching && !searchError && results.length === 0 && query.trim() && (
                                     <li className="px-3 py-2 text-sm text-gray-400 italic">No results</li>
                                 )}
                             </ul>

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -65,7 +65,12 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
                         {g.model_year}{g.make ? ` · ${g.make}` : ''}{g.drive ? ` · ${g.drive}` : ''}
                         {g.transmission ? ` · ${g.transmission}` : ''}
                     </div>
-                    <div className="font-mono text-xs text-gray-400 mt-0.5">{g.test_group_id}</div>
+                    <div className="font-mono text-xs text-gray-400 mt-0.5">
+                        {g.test_group_id}
+                        {g.epa_test_family_id && g.epa_test_family_id !== g.test_group_id && (
+                            <span className="ml-1 text-gray-300 dark:text-slate-600">· family: {g.epa_test_family_id}</span>
+                        )}
+                    </div>
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0">
                     {canEdit ? (

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -36,14 +36,15 @@ function DataRow({ label, value, muted }) {
 }
 
 /** Card displaying the data for one EPA test group mapping. */
-function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
-    const [unlinking, setUnlinking] = useState(false);
+function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
+    const [unlinking,    setUnlinking]    = useState(false);
     const [updatingConf, setUpdatingConf] = useState(false);
+    const [draftName,    setDraftName]    = useState(null); // null = not editing
+    const [savingName,   setSavingName]   = useState(false);
     const g = mapping.epaGroup;
     if (!g) return null;
 
     const fmt = (n, dp = 4) => n != null ? n.toFixed(dp) : null;
-    const mpge = (kwh) => kwh != null ? (33705 / kwh).toFixed(1) : null; // kWh/100mi → MPGe
 
     const handleUnlink = async () => {
         setUnlinking(true);
@@ -55,15 +56,56 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
         try { await onUpdateConfidence(mapping.id, e.target.value); } finally { setUpdatingConf(false); }
     };
 
+    const handleNameFocus = () => {
+        if (!canEdit) return;
+        setDraftName(g.display_name ?? '');
+    };
+
+    const handleNameSave = async () => {
+        if (draftName === null) return;
+        const trimmed = draftName.trim();
+        const current = g.display_name ?? '';
+        setDraftName(null);
+        if (trimmed === current) return;
+        setSavingName(true);
+        try {
+            await onUpdateDisplayName?.(g.test_group_id, trimmed || null);
+        } finally {
+            setSavingName(false);
+        }
+    };
+
+    const handleNameKeyDown = (e) => {
+        if (e.key === 'Enter')  { e.target.blur(); }
+        if (e.key === 'Escape') { setDraftName(null); }
+    };
+
     return (
         <div className="card p-4 mb-3">
             {/* Card header */}
             <div className="flex items-start justify-between gap-3 mb-3">
-                <div className="min-w-0">
-                    <div className="font-semibold text-sm truncate">
-                        {g.display_name || g.epa_carline_name}
-                    </div>
-                    {g.display_name && (
+                <div className="min-w-0 flex-1">
+                    {/* Display name — editable when canEdit */}
+                    {canEdit ? (
+                        <input
+                            type="text"
+                            value={draftName !== null ? draftName : (g.display_name ?? '')}
+                            placeholder={g.epa_carline_name}
+                            disabled={savingName}
+                            onFocus={handleNameFocus}
+                            onChange={e => setDraftName(e.target.value)}
+                            onBlur={handleNameSave}
+                            onKeyDown={handleNameKeyDown}
+                            className="form-input text-sm font-semibold py-0.5 w-full disabled:opacity-50 placeholder:text-gray-400 dark:placeholder:text-slate-500 placeholder:font-normal placeholder:italic"
+                            title="Friendly display name used in charts. Leave blank to use the EPA carline name."
+                        />
+                    ) : (
+                        <div className="font-semibold text-sm truncate">
+                            {g.display_name || g.epa_carline_name}
+                        </div>
+                    )}
+                    {/* Show raw EPA name as subtitle when a display name is set or being edited */}
+                    {(g.display_name || draftName !== null) && (
                         <div className="text-xs text-gray-400 dark:text-slate-500 italic truncate mt-0.5">{g.epa_carline_name}</div>
                     )}
                     <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
@@ -207,7 +249,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onUnlink, onUpdateConfidence }) {
+export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
     const [query, setQuery]               = useState('');
     const [results, setResults]           = useState([]);
     const [searching, setSearching]       = useState(false);
@@ -277,6 +319,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         canEdit={canEdit}
                         onUnlink={onUnlink}
                         onUpdateConfidence={onUpdateConfidence}
+                        onUpdateDisplayName={onUpdateDisplayName}
                     />
                 ))
             )}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -60,7 +60,12 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
             {/* Card header */}
             <div className="flex items-start justify-between gap-3 mb-3">
                 <div className="min-w-0">
-                    <div className="font-semibold text-sm truncate">{g.epa_carline_name}</div>
+                    <div className="font-semibold text-sm truncate">
+                        {g.display_name || g.epa_carline_name}
+                    </div>
+                    {g.display_name && (
+                        <div className="text-xs text-gray-400 dark:text-slate-500 italic truncate mt-0.5">{g.epa_carline_name}</div>
+                    )}
                     <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
                         {g.model_year}{g.make ? ` · ${g.make}` : ''}{g.drive ? ` · ${g.drive}` : ''}
                         {g.transmission ? ` · ${g.transmission}` : ''}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -1,0 +1,311 @@
+/**
+ * EPA testing data section — shown in the Tests & Data (RunsView) per-vehicle panel.
+ *
+ * Shows:
+ *   • A card for each linked EPA test group (coefficients, cycle results, label values)
+ *   • An "Assign EPA Testing Data" combobox for linking additional test groups
+ *   • Unlink controls (contributor+)
+ */
+import { useState, useRef } from 'react';
+import InfoIcon from './InfoIcon';
+import { EPA_EXPLAINERS } from '../utils/epaExplainers';
+
+const CONFIDENCE_COLORS = {
+    verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
+    likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
+    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+};
+
+function ConfidenceBadge({ confidence }) {
+    return (
+        <span className={`text-xs px-1.5 py-0.5 rounded border font-medium ${CONFIDENCE_COLORS[confidence] ?? CONFIDENCE_COLORS.inferred}`}>
+            {confidence}
+        </span>
+    );
+}
+
+/** One row of a label/value table inside the card. */
+function DataRow({ label, value, muted }) {
+    if (value == null) return null;
+    return (
+        <div className="flex justify-between gap-4 py-0.5">
+            <span className="text-gray-500 dark:text-slate-400 shrink-0">{label}</span>
+            <span className={`font-mono text-right ${muted ? 'text-gray-400 dark:text-slate-500' : ''}`}>{value}</span>
+        </div>
+    );
+}
+
+/** Card displaying the data for one EPA test group mapping. */
+function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
+    const [unlinking, setUnlinking] = useState(false);
+    const [updatingConf, setUpdatingConf] = useState(false);
+    const g = mapping.epaGroup;
+    if (!g) return null;
+
+    const fmt = (n, dp = 4) => n != null ? n.toFixed(dp) : null;
+    const mpge = (kwh) => kwh != null ? (33705 / kwh).toFixed(1) : null; // kWh/100mi → MPGe
+
+    const handleUnlink = async () => {
+        setUnlinking(true);
+        try { await onUnlink(mapping.id); } finally { setUnlinking(false); }
+    };
+
+    const handleConfidence = async (e) => {
+        setUpdatingConf(true);
+        try { await onUpdateConfidence(mapping.id, e.target.value); } finally { setUpdatingConf(false); }
+    };
+
+    return (
+        <div className="card p-4 mb-3">
+            {/* Card header */}
+            <div className="flex items-start justify-between gap-3 mb-3">
+                <div className="min-w-0">
+                    <div className="font-semibold text-sm truncate">{g.epa_carline_name}</div>
+                    <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                        {g.model_year}{g.make ? ` · ${g.make}` : ''}{g.drive ? ` · ${g.drive}` : ''}
+                        {g.transmission ? ` · ${g.transmission}` : ''}
+                    </div>
+                    <div className="font-mono text-xs text-gray-400 mt-0.5">{g.test_group_id}</div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                    {canEdit ? (
+                        <select
+                            value={mapping.confidence}
+                            onChange={handleConfidence}
+                            disabled={updatingConf}
+                            className="form-input text-xs py-0.5 w-28"
+                        >
+                            <option value="verified">Verified</option>
+                            <option value="likely">Likely</option>
+                            <option value="inferred">Inferred</option>
+                        </select>
+                    ) : (
+                        <ConfidenceBadge confidence={mapping.confidence} />
+                    )}
+                    {canEdit && (
+                        <button
+                            type="button"
+                            disabled={unlinking}
+                            onClick={handleUnlink}
+                            className="btn btn-secondary text-xs py-0.5 px-2 disabled:opacity-40"
+                        >
+                            {unlinking ? '…' : 'Unlink'}
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-1 text-xs">
+
+                {/* Physical */}
+                <div>
+                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                        Test Setup
+                    </div>
+                    <DataRow label="Test weight" value={g.equiv_test_weight_lbs != null ? g.equiv_test_weight_lbs.toLocaleString() + ' lbs' : null} />
+                    <DataRow label="Fuel type" value={g.fuel_type} />
+                </div>
+
+                {/* Road-load coefficients */}
+                <div>
+                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
+                        Road-Load Coefficients
+                        <InfoIcon text={EPA_EXPLAINERS.roadLoad} position="right" />
+                    </div>
+                    {g.target_a != null && (
+                        <>
+                            <DataRow label="Target A" value={fmt(g.target_a, 3) + ' lbf'} />
+                            <DataRow label="Target B" value={fmt(g.target_b, 5) + ' lbf/mph'} />
+                            <DataRow label="Target C" value={fmt(g.target_c, 6) + ' lbf/mph²'} />
+                        </>
+                    )}
+                    {g.set_a != null && (
+                        <>
+                            <DataRow label="Set A" value={fmt(g.set_a, 3) + ' lbf'} muted />
+                            <DataRow label="Set B" value={fmt(g.set_b, 5) + ' lbf/mph'} muted />
+                            <DataRow label="Set C" value={fmt(g.set_c, 6) + ' lbf/mph²'} muted />
+                        </>
+                    )}
+                </div>
+
+                {/* Cycle results */}
+                <div>
+                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
+                        Cycle Results
+                        <InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} position="right" />
+                    </div>
+                    {(g.udds_adj_kwh_100mi != null || g.udds_unadj_kwh_100mi != null) && (
+                        <DataRow
+                            label="UDDS (city)"
+                            value={(g.udds_adj_kwh_100mi ?? g.udds_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
+                        />
+                    )}
+                    {(g.hwfet_adj_kwh_100mi != null || g.hwfet_unadj_kwh_100mi != null) && (
+                        <DataRow
+                            label="HWFET (hwy)"
+                            value={(g.hwfet_adj_kwh_100mi ?? g.hwfet_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
+                        />
+                    )}
+                    {(g.us06_adj_kwh_100mi != null || g.us06_unadj_kwh_100mi != null) && (
+                        <DataRow
+                            label="US06"
+                            value={(g.us06_adj_kwh_100mi ?? g.us06_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
+                        />
+                    )}
+                    {(g.sc03_adj_kwh_100mi != null || g.sc03_unadj_kwh_100mi != null) && (
+                        <DataRow
+                            label="SC03 (AC)"
+                            value={(g.sc03_adj_kwh_100mi ?? g.sc03_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
+                        />
+                    )}
+                    {(g.cold_ftp_adj_kwh_100mi != null || g.cold_ftp_unadj_kwh_100mi != null) && (
+                        <DataRow
+                            label="Cold FTP"
+                            value={(g.cold_ftp_adj_kwh_100mi ?? g.cold_ftp_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
+                        />
+                    )}
+                    {/* Label values */}
+                    {g.label_combined_mpge != null && (
+                        <DataRow label="Label combined" value={g.label_combined_mpge.toFixed(1) + ' MPGe'} />
+                    )}
+                    {g.label_hwy_mpge != null && (
+                        <DataRow label="Label highway" value={g.label_hwy_mpge.toFixed(1) + ' MPGe'} />
+                    )}
+                    {g.label_city_mpge != null && (
+                        <DataRow label="Label city" value={g.label_city_mpge.toFixed(1) + ' MPGe'} />
+                    )}
+                    {g.label_combined_mi != null && (
+                        <DataRow label="Label range" value={g.label_combined_mi.toFixed(0) + ' mi'} />
+                    )}
+                    {/* No cycle data at all */}
+                    {g.label_combined_mpge == null && g.hwfet_adj_kwh_100mi == null && g.hwfet_unadj_kwh_100mi == null && (
+                        <p className="text-gray-400 text-[10px] italic">No cycle data in this record</p>
+                    )}
+                </div>
+            </div>
+
+            {mapping.notes && (
+                <p className="mt-2 text-xs text-gray-500 dark:text-slate-400 italic border-t pt-2">{mapping.notes}</p>
+            )}
+        </div>
+    );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onUnlink, onUpdateConfidence }) {
+    const [query, setQuery]               = useState('');
+    const [results, setResults]           = useState([]);
+    const [searching, setSearching]       = useState(false);
+    const [showDropdown, setShowDropdown] = useState(false);
+    const [linking, setLinking]           = useState(false);
+    const debounceRef = useRef(null);
+
+    const mappings = vehicle?.epa_mappings ?? [];
+
+    const handleQueryChange = (e) => {
+        const q = e.target.value;
+        setQuery(q);
+        setShowDropdown(true);
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        if (!q.trim()) { setResults([]); return; }
+        debounceRef.current = setTimeout(async () => {
+            setSearching(true);
+            try {
+                const year = vehicle?.year ? parseInt(vehicle.year, 10) : null;
+                const rows = await searchEpaTestGroups?.(q.trim(), year);
+                setResults(rows || []);
+            } finally {
+                setSearching(false);
+            }
+        }, 300);
+    };
+
+    const handleSelect = async (group) => {
+        setShowDropdown(false);
+        setQuery('');
+        setResults([]);
+        if (!vehicle?.id || !onLink) return;
+        setLinking(true);
+        try {
+            await onLink(vehicle.id, group.test_group_id, 'inferred', null);
+        } finally {
+            setLinking(false);
+        }
+    };
+
+    return (
+        <div className="mt-6">
+            <div className="flex items-center gap-2 mb-3">
+                <h3 className="section-title">
+                    EPA Testing Data
+                    <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
+                </h3>
+            </div>
+
+            {/* Existing mappings */}
+            {mappings.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">
+                    No EPA test group linked yet.
+                    {canEdit && ' Use the search below to assign one.'}
+                </p>
+            ) : (
+                mappings.map(m => (
+                    <EpaGroupCard
+                        key={m.id}
+                        mapping={m}
+                        canEdit={canEdit}
+                        onUnlink={onUnlink}
+                        onUpdateConfidence={onUpdateConfidence}
+                    />
+                ))
+            )}
+
+            {/* Link combobox — contributors only */}
+            {canEdit && (
+                <div className="mt-2">
+                    <div className="relative">
+                        <input
+                            type="text"
+                            placeholder="Assign EPA testing data — search by make or carline…"
+                            value={query}
+                            onChange={handleQueryChange}
+                            onFocus={() => query && setShowDropdown(true)}
+                            onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+                            disabled={linking}
+                            className="form-input text-sm w-full"
+                        />
+                        {linking && (
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">Linking…</span>
+                        )}
+                        {showDropdown && (results.length > 0 || searching) && (
+                            <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
+                                {searching && (
+                                    <li className="px-3 py-2 text-sm text-gray-400 italic">Searching…</li>
+                                )}
+                                {!searching && results.map(g => (
+                                    <li
+                                        key={g.test_group_id}
+                                        className="px-3 py-2 text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-indigo-900"
+                                        onMouseDown={e => { e.preventDefault(); handleSelect(g); }}
+                                    >
+                                        <span className="font-medium">{g.make} · {g.epa_carline_name}</span>
+                                        <span className="text-gray-400 ml-2 text-xs">
+                                            {g.model_year}{g.drive ? ` · ${g.drive}` : ''} · {g.test_group_id}
+                                        </span>
+                                    </li>
+                                ))}
+                                {!searching && results.length === 0 && query.trim() && (
+                                    <li className="px-3 py-2 text-sm text-gray-400 italic">No results</li>
+                                )}
+                            </ul>
+                        )}
+                    </div>
+                    <p className="text-xs text-gray-400 mt-1">
+                        Results filtered by vehicle year when available. Import test groups via Admin → Import → EPA Test Car Data.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -183,6 +183,9 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
                     {g.label_combined_mi != null && (
                         <DataRow label="Label range" value={g.label_combined_mi.toFixed(0) + ' mi'} />
                     )}
+                    {g.label_method && (
+                        <DataRow label="Label method" value={g.label_method} />
+                    )}
                     {/* No cycle data at all */}
                     {g.label_combined_mpge == null && g.hwfet_adj_kwh_100mi == null && g.hwfet_unadj_kwh_100mi == null && (
                         <p className="text-gray-400 text-[10px] italic">No cycle data in this record</p>

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -169,14 +169,15 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence }) {
                             value={(g.cold_ftp_adj_kwh_100mi ?? g.cold_ftp_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
                         />
                     )}
-                    {/* Label values */}
-                    {g.label_combined_mpge != null && (
+                    {/* Label values — suppress 999/sentinel placeholders used by EPA
+                        for records where the label has not yet been finalized */}
+                    {g.label_combined_mpge != null && g.label_combined_mpge < 500 && (
                         <DataRow label="Label combined" value={g.label_combined_mpge.toFixed(1) + ' MPGe'} />
                     )}
-                    {g.label_hwy_mpge != null && (
+                    {g.label_hwy_mpge != null && g.label_hwy_mpge < 500 && (
                         <DataRow label="Label highway" value={g.label_hwy_mpge.toFixed(1) + ' MPGe'} />
                     )}
-                    {g.label_city_mpge != null && (
+                    {g.label_city_mpge != null && g.label_city_mpge < 500 && (
                         <DataRow label="Label city" value={g.label_city_mpge.toFixed(1) + ' MPGe'} />
                     )}
                     {g.label_combined_mi != null && (

--- a/src/components/InfoIcon.jsx
+++ b/src/components/InfoIcon.jsx
@@ -1,0 +1,22 @@
+/**
+ * InfoIcon — a small ⓘ glyph with a CSS-only hover tooltip.
+ *
+ * No JavaScript, no library, no new npm packages. The tooltip is positioned
+ * via a sibling element inside a `position: relative` wrapper; visibility is
+ * toggled by the `.info-icon:hover .info-icon-tooltip` CSS rule in index.css.
+ *
+ * Props:
+ *   text      {string}  — tooltip text (plain string; no HTML)
+ *   position  {'above'|'below'|'right'}  — tooltip placement (default: 'above')
+ *   className {string}  — extra classes on the wrapper span
+ */
+export default function InfoIcon({ text, position = 'above', className = '' }) {
+    return (
+        <span className={`info-icon ${className}`} aria-label={text} role="img">
+            <span className="info-icon-glyph">ⓘ</span>
+            <span className={`info-icon-tooltip info-icon-tooltip--${position}`}>
+                {text}
+            </span>
+        </span>
+    );
+}

--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -2,6 +2,7 @@ import ChargingView from './ChargingView';
 import ChargeCompareView from './ChargeCompareView';
 import RoadTripView from './RoadTripView';
 import SpecsChartView from './SpecsChartView';
+import EpaCurvesView from './EpaCurvesView';
 
 /**
  * Minimal fullscreen chart-only view rendered in the pop-out tab.
@@ -10,7 +11,7 @@ import SpecsChartView from './SpecsChartView';
  */
 export default function PopoutView({
     vehicles, selectedVehicles, chartMode, chartConfig,
-    setChartConfig, compareConfig, roadTripConfig, onUpdateRunColor,
+    setChartConfig, compareConfig, roadTripConfig, epaConfig, onUpdateRunColor,
 }) {
     return (
         <div className="popout-root">
@@ -58,6 +59,16 @@ export default function PopoutView({
                     xMinutes={compareConfig.xMinutes}
                     mMiles={compareConfig.mMiles}
                     startSoc={compareConfig.startSoc}
+                    presentationMode
+                />
+            )}
+
+            {chartMode === 'epacurves' && (
+                <EpaCurvesView
+                    vehicles={vehicles}
+                    selectedVehicleIds={selectedVehicles}
+                    epaConfig={epaConfig || { yAxis: 'kwh100mi' }}
+                    setEpaConfig={() => {}}
                     presentationMode
                 />
             )}

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -594,15 +594,13 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                     </button>
                 </div>
             </div>
-            {/* ── Axis scale controls card ── */}
-            <div className="card mb-4">
-                <AxisScaleControls
-                    xMin={xMin} xMax={xMax}
-                    yMin={yMin} yMax={yMax}
-                    onChange={handleScaleChange}
-                    showX={CHART_TYPES.find(t => t.key === chartType)?.kind === 'line'}
-                />
-            </div>
+            {/* ── Axis scale controls (card provided by AxisScaleControls) ── */}
+            <AxisScaleControls
+                xMin={xMin} xMax={xMax}
+                yMin={yMin} yMax={yMax}
+                onChange={handleScaleChange}
+                showX={CHART_TYPES.find(t => t.key === chartType)?.kind === 'line'}
+            />
         </div>
     );
 }

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1529,19 +1529,17 @@ export default function RoadTripView({
                 </div>
             )}
 
-            {/* ── Axis Scale Controls ────────────────────────────────────── */}
+            {/* ── Axis Scale Controls (card provided by AxisScaleControls) ─ */}
             {!loading && (simResults.some(Boolean) || speedSweepResults?.length > 0 || distSweepResults?.length > 0) && !presentationMode && (
-                <div className="card mb-6">
-                    <AxisScaleControls
-                        xMin={axisScale.xMin} xMax={axisScale.xMax}
-                        yMin={axisScale.yMin} yMax={axisScale.yMax}
-                        onChange={onAxisChange}
-                        showX={true}
-                        showY2={false}
-                        xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : isTripDistMode ? `X-Axis Scale (${dl})` : 'X-Axis Scale (hrs)'}
-                        yAxisLabel={isSweepMode ? 'Y-Axis Scale (hrs)' : 'Left Axis Scale'}
-                    />
-                </div>
+                <AxisScaleControls
+                    xMin={axisScale.xMin} xMax={axisScale.xMax}
+                    yMin={axisScale.yMin} yMax={axisScale.yMax}
+                    onChange={onAxisChange}
+                    showX={true}
+                    showY2={false}
+                    xAxisLabel={isSpeedMode ? `X-Axis Scale (${sl})` : isTripDistMode ? `X-Axis Scale (${dl})` : 'X-Axis Scale (hrs)'}
+                    yAxisLabel={isSweepMode ? 'Y-Axis Scale (hrs)' : 'Left Axis Scale'}
+                />
             )}
 
             {/* ── Summary Table ─────────────────────────────────────────── */}

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -278,7 +278,7 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2378,6 +2378,9 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 onLink={linkEpaTestGroup}
                 onUnlink={unlinkEpaTestGroup}
                 onUpdateConfidence={updateEpaMapping}
+                onUpdateDisplayName={(testGroupId, name) =>
+                    updateEpaTestGroup(testGroupId, { display_name: name || null })
+                }
             />
         </div>
     );

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -10,6 +10,7 @@ import EditVehicleForm from './EditVehicleForm';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 import { RunVoteButtons } from './VoteButtons';
+import EpaVehicleSection from './EpaVehicleSection';
 import { estimateChargingTimes } from '../utils/estimateChargingTimes';
 
 // ── Data-type flag definitions ────────────────────────────────────────────────
@@ -277,7 +278,7 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2368,6 +2369,16 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                     </div>
                 </div>
             )}
+
+            {/* ── EPA Testing Data ──────────────────────────────────────────── */}
+            <EpaVehicleSection
+                vehicle={vehicle}
+                canEdit={isContributor && canEdit(vehicle)}
+                searchEpaTestGroups={searchEpaTestGroups}
+                onLink={linkEpaTestGroup}
+                onUnlink={unlinkEpaTestGroup}
+                onUpdateConfidence={updateEpaMapping}
+            />
         </div>
     );
 }

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -74,7 +74,10 @@ export default function VehiclesView({
         return () => { onSaveState?.(persistableState.current); };
     }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentional: fire only on unmount
 
-    const { units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink, user } = useAppContext();
+    const {
+        units, manufacturers, addManufacturer, isContributor, addSpecLink, deleteSpecLink, user,
+        searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup,
+    } = useAppContext();
 
     const {
         pendingDeletes, committedDeletes, undoState, secondsLeft,
@@ -383,6 +386,13 @@ export default function VehiclesView({
         // Manufacturer
         manufacturers,
         onAddManufacturer: addManufacturer,
+        // EPA linking (contributor+)
+        ...(isContributor ? {
+            searchEpaTestGroups,
+            onLinkEpaTestGroup:   linkEpaTestGroup,
+            onUpdateEpaMapping:   updateEpaMapping,
+            onUnlinkEpaTestGroup: unlinkEpaTestGroup,
+        } : {}),
     };
 
     const handleMoveVehicle = (vehicleId, direction) => {

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -768,6 +768,22 @@ export function AppProvider({ children }) {
         }
     };
 
+    /** Pass-through: fetch all test groups with linked vehicles for admin panel. */
+    const getEpaTestGroupsAdmin = () => dataService.getEpaTestGroupsAdmin();
+
+    /** Delete an EPA test group and its vehicle mappings, then refresh vehicles. */
+    const deleteEpaTestGroup = async (testGroupId) => {
+        try {
+            await dataService.deleteEpaTestGroup(testGroupId);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('EPA test group deleted.');
+        } catch (error) {
+            showError('Delete failed: ' + error.message);
+            throw error;
+        }
+    };
+
     /**
      * Bulk-import EPA test groups from the parsed testcar sheet, then create
      * vehicle mappings for any test groups the user linked to a vehicle.
@@ -888,6 +904,8 @@ export function AppProvider({ children }) {
         updateEpaMapping,
         unlinkEpaTestGroup,
         importEpaTestGroups,
+        getEpaTestGroupsAdmin,
+        deleteEpaTestGroup,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -730,6 +730,44 @@ export function AppProvider({ children }) {
         }
     };
 
+    // ── EPA test group linking ────────────────────────────────────────────────
+
+    /** Pass-through: server-side search used by the linking combobox. */
+    const searchEpaTestGroups = (query, year) => dataService.searchEpaTestGroups(query, year);
+
+    const linkEpaTestGroup = async (vehicleId, groupId, confidence, notes) => {
+        try {
+            await dataService.linkEpaTestGroup(vehicleId, groupId, confidence, notes);
+            // Re-fetch vehicles so epa_mappings reflects the new link immediately.
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('EPA test group linked.');
+        } catch (error) {
+            showError('Error linking EPA test group: ' + error.message);
+        }
+    };
+
+    const updateEpaMapping = async (mappingId, updates) => {
+        try {
+            await dataService.updateEpaMapping(mappingId, updates);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+        } catch (error) {
+            showError('Error updating EPA mapping: ' + error.message);
+        }
+    };
+
+    const unlinkEpaTestGroup = async (mappingId) => {
+        try {
+            await dataService.unlinkEpaTestGroup(mappingId);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('EPA test group unlinked.');
+        } catch (error) {
+            showError('Error unlinking EPA test group: ' + error.message);
+        }
+    };
+
     // ── Admin actions ─────────────────────────────────────────────────────────
     const getUsersForAdmin = async () => {
         // Let the error propagate to AdminView so it can show it inline.
@@ -817,6 +855,10 @@ export function AppProvider({ children }) {
         updateSpecLink,
         deleteSpecLink,
         clearDefaultRun,
+        searchEpaTestGroups,
+        linkEpaTestGroup,
+        updateEpaMapping,
+        unlinkEpaTestGroup,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -772,11 +772,13 @@ export function AppProvider({ children }) {
     const getEpaTestGroupsAdmin = () => dataService.getEpaTestGroupsAdmin();
 
     /**
-     * Update editable fields on an EPA test group (admin only).
+     * Update editable fields on an EPA test group.
      * Accepts any subset of: { label_method, display_name }.
+     * Soft-refreshes vehicles so chart labels and vehicle cards reflect the change.
      */
     const updateEpaTestGroup = async (testGroupId, updates) => {
         await dataService.updateEpaTestGroup(testGroupId, updates);
+        softRefreshVehicles();
     };
 
     /** Convenience alias: update only label_method. */

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -768,6 +768,34 @@ export function AppProvider({ children }) {
         }
     };
 
+    /**
+     * Bulk-import EPA test groups from the parsed testcar sheet, then create
+     * vehicle mappings for any test groups the user linked to a vehicle.
+     *
+     * @param {Array<Object>} testGroups  Rows for epa_test_groups upsert
+     * @param {Array<{vehicleId, testGroupId}>} mappings  Vehicle → test group links to create
+     */
+    const importEpaTestGroups = async (testGroups, mappings) => {
+        try {
+            await dataService.bulkUpsertEpaTestGroups(testGroups);
+            // Create mappings sequentially; skip if already linked (upsert would conflict)
+            for (const { vehicleId, testGroupId } of mappings) {
+                try {
+                    await dataService.linkEpaTestGroup(vehicleId, testGroupId, 'likely', null);
+                } catch {
+                    // Ignore duplicate-link errors (UNIQUE constraint) — mapping already exists
+                }
+            }
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess(`Imported ${testGroups.length} EPA test group(s), linked ${mappings.length}.`);
+            return { testGroupsCount: testGroups.length, mappingsCount: mappings.length };
+        } catch (error) {
+            showError('EPA import failed: ' + error.message);
+            throw error;
+        }
+    };
+
     // ── Admin actions ─────────────────────────────────────────────────────────
     const getUsersForAdmin = async () => {
         // Let the error propagate to AdminView so it can show it inline.
@@ -859,6 +887,7 @@ export function AppProvider({ children }) {
         linkEpaTestGroup,
         updateEpaMapping,
         unlinkEpaTestGroup,
+        importEpaTestGroups,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -771,7 +771,15 @@ export function AppProvider({ children }) {
     /** Pass-through: fetch all test groups with linked vehicles for admin panel. */
     const getEpaTestGroupsAdmin = () => dataService.getEpaTestGroupsAdmin();
 
-    /** Update the label_method field on an EPA test group (admin only). */
+    /**
+     * Update editable fields on an EPA test group (admin only).
+     * Accepts any subset of: { label_method, display_name }.
+     */
+    const updateEpaTestGroup = async (testGroupId, updates) => {
+        await dataService.updateEpaTestGroup(testGroupId, updates);
+    };
+
+    /** Convenience alias: update only label_method. */
     const updateEpaLabelMethod = async (testGroupId, method) => {
         await dataService.updateEpaLabelMethod(testGroupId, method);
     };
@@ -912,6 +920,7 @@ export function AppProvider({ children }) {
         getEpaTestGroupsAdmin,
         deleteEpaTestGroup,
         updateEpaLabelMethod,
+        updateEpaTestGroup,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -771,6 +771,11 @@ export function AppProvider({ children }) {
     /** Pass-through: fetch all test groups with linked vehicles for admin panel. */
     const getEpaTestGroupsAdmin = () => dataService.getEpaTestGroupsAdmin();
 
+    /** Update the label_method field on an EPA test group (admin only). */
+    const updateEpaLabelMethod = async (testGroupId, method) => {
+        await dataService.updateEpaLabelMethod(testGroupId, method);
+    };
+
     /** Delete an EPA test group and its vehicle mappings, then refresh vehicles. */
     const deleteEpaTestGroup = async (testGroupId) => {
         try {
@@ -906,6 +911,7 @@ export function AppProvider({ children }) {
         importEpaTestGroups,
         getEpaTestGroupsAdmin,
         deleteEpaTestGroup,
+        updateEpaLabelMethod,
     };
 
     return (

--- a/src/hooks/useChartSync.js
+++ b/src/hooks/useChartSync.js
@@ -10,8 +10,8 @@ const CHANNEL = 'evbench-chart-sync';
  * Pop-out tab: sends 'request-state' on mount + focus, applies received state.
  */
 export function useChartSync({
-    chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig,
-    setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig,
+    chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig,
+    setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig,
 }) {
     const isPopout = useRef(
         new URLSearchParams(window.location.search).get('popout') === '1'
@@ -20,9 +20,9 @@ export function useChartSync({
     const channelRef = useRef(null);
 
     // Keep a ref of current state so the onmessage handler never closes over stale values
-    const stateRef = useRef({ chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig });
+    const stateRef = useRef({ chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig });
     useEffect(() => {
-        stateRef.current = { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig };
+        stateRef.current = { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig };
     });
 
     useEffect(() => {
@@ -40,6 +40,7 @@ export function useChartSync({
                 setVehicleSelection(data.selectedVehicleIds);
                 if (data.compareConfig)  setCompareConfig(data.compareConfig);
                 if (data.roadTripConfig) setRoadTripConfig(data.roadTripConfig);
+                if (data.epaConfig)      setEpaConfig(data.epaConfig);
             };
             // Request current state on mount and whenever the tab regains focus
             // (covers the case where the main tab refreshed while this was in the background)
@@ -54,7 +55,7 @@ export function useChartSync({
             // Main tab: respond to state requests from pop-outs
             channel.onmessage = ({ data }) => {
                 if (data?.type !== 'request-state') return;
-                const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig } = stateRef.current;
+                const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig } = stateRef.current;
                 channel.postMessage({
                     type: 'chart-state',
                     chartMode,
@@ -62,6 +63,7 @@ export function useChartSync({
                     selectedVehicleIds: selectedVehicles,
                     compareConfig,
                     roadTripConfig,
+                    epaConfig,
                 });
             };
             return () => channel.close();
@@ -71,7 +73,7 @@ export function useChartSync({
     /** Called by App.jsx whenever chart state changes (main tab only). */
     const sendState = useCallback(() => {
         if (isPopout || !channelRef.current) return;
-        const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig } = stateRef.current;
+        const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig } = stateRef.current;
         channelRef.current.postMessage({
             type: 'chart-state',
             chartMode,
@@ -79,6 +81,7 @@ export function useChartSync({
             selectedVehicleIds: selectedVehicles,
             compareConfig,
             roadTripConfig,
+            epaConfig,
         });
     }, [isPopout]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -957,6 +957,72 @@ body {
     @apply inline-flex items-center;
 }
 
+/* ── InfoIcon — ⓘ glyph with CSS-only hover tooltip ─────────────────────────── */
+
+.info-icon {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: help;
+    margin-left: 0.25rem;
+}
+
+.info-icon-glyph {
+    font-size: 0.75em;
+    line-height: 1;
+    opacity: 0.5;
+    transition: opacity 0.15s;
+    color: var(--color-text-secondary);
+    user-select: none;
+}
+
+.info-icon:hover .info-icon-glyph {
+    opacity: 0.9;
+}
+
+.info-icon-tooltip {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    z-index: 100;
+    width: 240px;
+    padding: 0.5rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    border-radius: 0.375rem;
+    pointer-events: none;
+    transition: opacity 0.15s;
+    background-color: var(--color-surface-sunken);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    white-space: normal;
+}
+
+.info-icon:hover .info-icon-tooltip {
+    visibility: visible;
+    opacity: 1;
+}
+
+/* Tooltip placement variants */
+.info-icon-tooltip--above {
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.info-icon-tooltip--below {
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.info-icon-tooltip--right {
+    left: calc(100% + 6px);
+    top: 50%;
+    transform: translateY(-50%);
+}
+
 /* ── Specs comparison chart ──────────────────────────────────────────────────── */
 
 .specs-chart-card {

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1133,7 +1133,9 @@ class DataService {
       .select(`
         test_group_id, epa_test_family_id,
         model_year, make, epa_carline_name, drive, transmission,
-        equiv_test_weight_lbs, target_a, set_a,
+        equiv_test_weight_lbs,
+        target_a, target_b, target_c,
+        set_a, set_b, set_c,
         label_combined_mpge, source_file, ingested_at,
         epa_vehicle_mappings(
           id, confidence,

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1121,6 +1121,50 @@ class DataService {
       .upsert(rows, { onConflict: 'test_group_id', ignoreDuplicates: false });
     if (error) throw error;
   }
+
+  /**
+   * Fetch all EPA test groups for the admin panel, including which vehicles
+   * each group is currently linked to via epa_vehicle_mappings.
+   */
+  async getEpaTestGroupsAdmin() {
+    if (!this.useSupabase) return [];
+    const { data, error } = await getSupabase()
+      .from('epa_test_groups')
+      .select(`
+        test_group_id, epa_test_family_id,
+        model_year, make, epa_carline_name, drive, transmission,
+        equiv_test_weight_lbs, target_a, set_a,
+        label_combined_mpge, source_file, ingested_at,
+        epa_vehicle_mappings(
+          id, confidence,
+          vehicles(id, name, year)
+        )
+      `)
+      .order('make')
+      .order('epa_carline_name');
+    if (error) throw error;
+    return data || [];
+  }
+
+  /**
+   * Delete an EPA test group and all its vehicle mappings.
+   * The epa_vehicle_mappings FK has no CASCADE so mappings must be deleted first.
+   */
+  async deleteEpaTestGroup(testGroupId) {
+    if (!this.useSupabase) return;
+    // Step 1: remove all vehicle→group mappings
+    const { error: mapErr } = await getSupabase()
+      .from('epa_vehicle_mappings')
+      .delete()
+      .eq('epa_test_group_id', testGroupId);
+    if (mapErr) throw mapErr;
+    // Step 2: remove the group itself
+    const { error } = await getSupabase()
+      .from('epa_test_groups')
+      .delete()
+      .eq('test_group_id', testGroupId);
+    if (error) throw error;
+  }
 }
 
 export const dataService = new DataService();

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1136,7 +1136,8 @@ class DataService {
         equiv_test_weight_lbs,
         target_a, target_b, target_c,
         set_a, set_b, set_c,
-        label_combined_mpge, source_file, ingested_at,
+        label_combined_mpge, label_method,
+        source_file, ingested_at,
         epa_vehicle_mappings(
           id, confidence,
           vehicles(id, name, year)
@@ -1146,6 +1147,16 @@ class DataService {
       .order('epa_carline_name');
     if (error) throw error;
     return data || [];
+  }
+
+  /** Update the label_method field on a single EPA test group. */
+  async updateEpaLabelMethod(testGroupId, method) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_test_groups')
+      .update({ label_method: method || null })
+      .eq('test_group_id', testGroupId);
+    if (error) throw error;
   }
 
   /**

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color)`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, model_year, make, epa_carline_name, drive, transmission, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs, hwfet_unadj_kwh_100mi, hwfet_adj_kwh_100mi, udds_unadj_kwh_100mi, range_city_mi, range_hwy_mi, range_combined_mi, useable_kwh, label_combined_mpge, label_combined_mi, label_hwy_mpge, label_city_mpge, label_hwy_mi, label_city_mi, label_method))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -128,6 +128,12 @@ class DataService {
         ...v,
         manufacturer,                    // { id, name, country } or null
         spec_links: v.spec_links || [],  // raw link rows (kept for admin UI)
+        epa_mappings: (v.epa_vehicle_mappings || []).map(m => ({
+          id:        m.id,
+          confidence: m.confidence,
+          notes:     m.notes,
+          epaGroup:  m.epa_test_groups,
+        })),
         tags:  (v.vehicle_tags || []).map(vt => vt.tags).filter(Boolean),
         runs:  (v.runs || []).map(r => ({
           ...r,
@@ -1027,6 +1033,74 @@ class DataService {
       p_vehicle_id: vehicleId,
       p_field_key: fieldKey,
     });
+    if (error) throw error;
+  }
+
+  // ── EPA Test Groups ───────────────────────────────────────────────────────
+
+  /**
+   * Search epa_test_groups for the vehicle-linking combobox.
+   * Filters by free-text (matched against make + epa_carline_name) and optional
+   * model year. Returns at most 50 results, ordered by make and carline name.
+   *
+   * @param {string} query — free text search string
+   * @param {number|null} year — exact model year filter (optional)
+   */
+  async searchEpaTestGroups(query, year = null) {
+    if (!this.useSupabase) return [];
+    let q = getSupabase()
+      .from('epa_test_groups')
+      .select('test_group_id, model_year, make, epa_carline_name, transmission, drive, fuel_type')
+      .order('make')
+      .order('epa_carline_name')
+      .limit(50);
+    if (year) q = q.eq('model_year', year);
+    if (query?.trim()) {
+      const escaped = query.trim().replace(/[%_]/g, '\\$&');
+      q = q.or(`make.ilike.%${escaped}%,epa_carline_name.ilike.%${escaped}%`);
+    }
+    const { data, error } = await q;
+    if (error) throw error;
+    return data || [];
+  }
+
+  /**
+   * Link a vehicle to an EPA test group.
+   * Contributor-level permission enforced by RLS on epa_vehicle_mappings.
+   */
+  async linkEpaTestGroup(vehicleId, epaTestGroupId, confidence = 'inferred', notes = '') {
+    if (!this.useSupabase) return null;
+    const { data, error } = await getSupabase()
+      .from('epa_vehicle_mappings')
+      .insert({ vehicle_id: vehicleId, epa_test_group_id: epaTestGroupId, confidence, notes: notes || null })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  /**
+   * Update the confidence or notes on an existing vehicle → EPA test group mapping.
+   */
+  async updateEpaMapping(mappingId, updates) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_vehicle_mappings')
+      .update(updates)
+      .eq('id', mappingId);
+    if (error) throw error;
+  }
+
+  /**
+   * Remove a vehicle → EPA test group mapping.
+   * Admin permission enforced by RLS.
+   */
+  async unlinkEpaTestGroup(mappingId) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_vehicle_mappings')
+      .delete()
+      .eq('id', mappingId);
     if (error) throw error;
   }
 }

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs, hwfet_unadj_kwh_100mi, hwfet_adj_kwh_100mi, udds_unadj_kwh_100mi, us06_adj_kwh_100mi, sc03_adj_kwh_100mi, cold_ftp_adj_kwh_100mi, range_city_mi, range_hwy_mi, range_combined_mi, useable_kwh, label_combined_mpge, label_combined_mi, label_hwy_mpge, label_city_mpge, label_hwy_mi, label_city_mi, label_method))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs, hwfet_unadj_kwh_100mi, hwfet_adj_kwh_100mi, udds_unadj_kwh_100mi, us06_adj_kwh_100mi, sc03_adj_kwh_100mi, cold_ftp_adj_kwh_100mi, range_city_mi, range_hwy_mi, range_combined_mi, useable_kwh, label_combined_mpge, label_combined_mi, label_hwy_mpge, label_city_mpge, label_hwy_mi, label_city_mi, label_method, display_name))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -1136,7 +1136,7 @@ class DataService {
         equiv_test_weight_lbs,
         target_a, target_b, target_c,
         set_a, set_b, set_c,
-        label_combined_mpge, label_method,
+        label_combined_mpge, label_method, display_name,
         source_file, ingested_at,
         epa_vehicle_mappings(
           id, confidence,
@@ -1149,14 +1149,22 @@ class DataService {
     return data || [];
   }
 
-  /** Update the label_method field on a single EPA test group. */
-  async updateEpaLabelMethod(testGroupId, method) {
+  /**
+   * Update one or more fields on an EPA test group.
+   * Accepts any subset of: { label_method, display_name }.
+   */
+  async updateEpaTestGroup(testGroupId, updates) {
     if (!this.useSupabase) return;
     const { error } = await getSupabase()
       .from('epa_test_groups')
-      .update({ label_method: method || null })
+      .update(updates)
       .eq('test_group_id', testGroupId);
     if (error) throw error;
+  }
+
+  /** Convenience alias kept for back-compat. */
+  async updateEpaLabelMethod(testGroupId, method) {
+    return this.updateEpaTestGroup(testGroupId, { label_method: method || null });
   }
 
   /**

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, model_year, make, epa_carline_name, drive, transmission, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs, hwfet_unadj_kwh_100mi, hwfet_adj_kwh_100mi, udds_unadj_kwh_100mi, range_city_mi, range_hwy_mi, range_combined_mi, useable_kwh, label_combined_mpge, label_combined_mi, label_hwy_mpge, label_city_mpge, label_hwy_mi, label_city_mi, label_method))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs, hwfet_unadj_kwh_100mi, hwfet_adj_kwh_100mi, udds_unadj_kwh_100mi, us06_adj_kwh_100mi, sc03_adj_kwh_100mi, cold_ftp_adj_kwh_100mi, range_city_mi, range_hwy_mi, range_combined_mi, useable_kwh, label_combined_mpge, label_combined_mi, label_hwy_mpge, label_city_mpge, label_hwy_mi, label_city_mi, label_method))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -1050,14 +1050,19 @@ class DataService {
     if (!this.useSupabase) return [];
     let q = getSupabase()
       .from('epa_test_groups')
-      .select('test_group_id, model_year, make, epa_carline_name, transmission, drive, fuel_type')
+      .select('test_group_id, epa_test_family_id, model_year, make, epa_carline_name, transmission, drive, fuel_type')
       .order('make')
       .order('epa_carline_name')
       .limit(50);
     if (year) q = q.eq('model_year', year);
     if (query?.trim()) {
       const escaped = query.trim().replace(/[%_]/g, '\\$&');
-      q = q.or(`make.ilike.%${escaped}%,epa_carline_name.ilike.%${escaped}%`);
+      // Also search test_group_id and epa_test_family_id so users can look up
+      // by vehicle config code (e.g. "R1S247") or EPA family ID
+      q = q.or(
+        `make.ilike.%${escaped}%,epa_carline_name.ilike.%${escaped}%,` +
+        `test_group_id.ilike.%${escaped}%,epa_test_family_id.ilike.%${escaped}%`
+      );
     }
     const { data, error } = await q;
     if (error) throw error;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1103,6 +1103,19 @@ class DataService {
       .eq('id', mappingId);
     if (error) throw error;
   }
+
+  /**
+   * Bulk upsert EPA test group rows (keyed on test_group_id).
+   * Existing rows are updated; new rows are inserted.
+   * @param {Array<Object>} rows  Shaped like epa_test_groups columns
+   */
+  async bulkUpsertEpaTestGroups(rows) {
+    if (!this.useSupabase || !rows.length) return;
+    const { error } = await getSupabase()
+      .from('epa_test_groups')
+      .upsert(rows, { onConflict: 'test_group_id', ignoreDuplicates: false });
+    if (error) throw error;
+  }
 }
 
 export const dataService = new DataService();

--- a/src/utils/epaExplainers.js
+++ b/src/utils/epaExplainers.js
@@ -1,0 +1,62 @@
+/**
+ * Centralized tooltip explainer text for EPA-related concepts.
+ *
+ * All InfoIcon tooltips in the EPA Curves feature reference this map by key
+ * so the text is maintained in one place.
+ *
+ * Tone: factual, dense, no hedging, no marketing language.
+ */
+
+export const EPA_EXPLAINERS = {
+
+    // ── Road-load physics ─────────────────────────────────────────────────────
+
+    roadLoad:
+        'Road-load force F = A + B·v + C·v² describes the total resistance the drivetrain must overcome at constant speed. A captures rolling resistance; B·v captures speed-proportional losses (bearing drag, tire flexing); C·v² captures aerodynamic drag. Measured by EPA coast-down testing on a flat road.',
+
+    targetVsSet:
+        'Target coefficients are the EPA-certified values used to compute label MPGe. Set coefficients are what was actually programmed on the dynamometer for testing — they usually match the target but may differ slightly. This chart uses set values when available, falling back to target.',
+
+    equivTestWeight:
+        'Equivalent Test Weight (ETW) is the vehicle\'s curb weight plus 300 lbs (representing passengers and cargo), rounded to the nearest 125-lb increment. It determines how much inertia the dynamometer simulates during acceleration phases. May differ from the spec sheet curb weight by up to ~60 lbs.',
+
+    steadyStateCurve:
+        'This curve is theoretical, not measured. It assumes constant speed on flat ground with no wind, a fixed 0.3 kW accessory load, and a single composite drivetrain efficiency back-solved from the HWFET measurement. It does not capture grade, wind, HVAC transients, or stop-and-go losses.',
+
+    hwfetCalibration:
+        'Drivetrain efficiency η is back-solved by finding the value that makes the steady-state formula reproduce the HWFET unadjusted measurement at 48.3 mph average. This ensures the curve is internally consistent with EPA\'s own highway data for each specific vehicle.',
+
+    accessoryLoad:
+        'A constant 0.3 kW accessory load (HVAC, lighting, electronics) is added at all speeds. At low speeds this term dominates; at highway speeds it becomes a small fraction of total consumption.',
+
+    // ── Drive cycles ──────────────────────────────────────────────────────────
+
+    hwfetCycle:
+        'HWFET (Highway Fuel Economy Test): 765 seconds, 10.26 miles, 48.3 mph average. Steady-speed highway driving with gradual speed changes. The reference vertical line marks this average. This cycle is the basis for the EPA highway label.',
+
+    udssCycle:
+        'UDDS (Urban Dynamometer Driving Schedule): city cycle, 1369 seconds, 7.45 miles, 19.6 mph average. Frequent stops and low speeds. Favors EVs due to heavy regenerative braking. Basis for the city label.',
+
+    us06Cycle:
+        'US06 (Supplemental FTP): aggressive driving with rapid acceleration and speeds up to 80 mph; 48.4 mph average. Despite the similar average speed to HWFET, US06 is substantially harder — the transients and high-speed portions impose much greater peak power demands. Included in the 5-cycle method.',
+
+    sc03Cycle:
+        'SC03: same speed profile as UDDS but run at 95°F ambient temperature with the air conditioning on. Captures the range penalty of cooling. Included in the 5-cycle method.',
+
+    coldFtpCycle:
+        'Cold FTP: UDDS drive schedule run at 20°F ambient (engine/battery cold-start). Captures the efficiency penalty of low-temperature battery chemistry and cabin heating. Included in the 5-cycle method.',
+
+    // ── Adjusted vs unadjusted ────────────────────────────────────────────────
+
+    unadjVsAdj:
+        'Unadjusted kWh/100mi is the raw dynamometer measurement. Adjusted applies EPA correction factors that account for the gap between lab conditions and real-world driving variability. The label MPGe and label range are derived from the adjusted values.',
+
+    labelMethod:
+        '2-cycle: label is computed from UDDS and HWFET only. 5-cycle: adds US06, SC03, and Cold FTP for a more realistic estimate. Vehicle-specific: manufacturer submitted actual 5-cycle test data. MPG-based adjustment: older method using a statistical correction rather than additional test cycles.',
+
+    // ── Mapping confidence ────────────────────────────────────────────────────
+
+    confidenceBadge:
+        'Confidence indicates how certain the link between this vehicle and the EPA test group is. Verified: a contributor confirmed the test group ID against the EPA certification document. Likely: matched by make, model, and year with high confidence but not manually verified. Inferred: matched automatically; may not be exact, especially for multi-trim submissions.',
+
+};

--- a/src/utils/epaPhysics.js
+++ b/src/utils/epaPhysics.js
@@ -1,0 +1,204 @@
+/**
+ * EPA Road-Load Physics
+ *
+ * Pure functions for computing theoretical steady-state efficiency vs speed
+ * curves from EPA road-load coefficients (A, B, C).
+ *
+ * All physics is done in imperial units (lbf, mph, kWh) matching EPA data.
+ * Unit conversion for display (metric, MPGe) happens in the calling component.
+ *
+ * Key formula derivation:
+ *   Road-load force:  F(v) = A + B·v + C·v²   [lbf, v in mph]
+ *   Wheel power:      P_wheel = F(v) · v / 375 · 0.7457   [kW]
+ *                     (375 lbf·mph/hp; 1 hp = 0.7457 kW)
+ *   Wheel energy:     E_wheel = P_wheel / v = F(v) · 0.001989   [kWh/mile]
+ *                     (0.001989 = 4.44822 N/lbf × 1609.34 m/mi / 3,600,000 J/kWh)
+ *   Battery energy:   E_bat = E_wheel / η_eff + P_acc / v   [kWh/mile]
+ *
+ * η_eff is back-solved from the HWFET unadjusted measurement using the HWFET
+ * average speed (48.3 mph) as a proxy for the full 765-point drive cycle.
+ * This is an intentional approximation that makes the curve pass exactly
+ * through the EPA's own highway data point without embedding the drive trace.
+ */
+
+// ── Physical constants ────────────────────────────────────────────────────────
+
+/** Average speed of the HWFET (Highway Fuel Economy Test) drive cycle, mph. */
+export const HWFET_AVG_MPH = 48.3;
+
+/** Average speed of the US06 (Supplemental Federal Test Procedure) cycle, mph.
+ *  Note: US06 includes aggressive transients up to 80+ mph; the 48.4 avg understates peak loads. */
+export const US06_AVG_MPH = 48.4;
+
+/** Speed band considered "real highway" for reference overlay on the chart. */
+export const HIGHWAY_BAND_MPH = [65, 75];
+
+/** Constant accessory load assumed for all EVs (HVAC, lighting, electronics). kW. */
+export const ACCESSORY_LOAD_KW = 0.3;
+
+/** EPA's kWh-per-gallon-of-gasoline-equivalent constant, used to compute MPGe. */
+export const MPG_E_CONVERSION = 33.705;
+
+/** Unit conversion: lbf-force × 1 mile of travel → kWh of energy.
+ *  Derivation: 4.44822 N/lbf × 1609.34 m/mi / 3,600,000 J/kWh = 0.001989. */
+const LBF_MILE_TO_KWH = 0.001989;
+
+/** Fallback drivetrain efficiency when HWFET data is absent. */
+const DEFAULT_ETA = 0.88;
+
+/** Speed range for the curve, mph, inclusive. */
+export const CURVE_SPEED_RANGE = [5, 120];
+
+// ── Coefficient resolution ────────────────────────────────────────────────────
+
+/**
+ * Select which set of road-load coefficients to use.
+ *
+ * Preference order:
+ *   1. set_a/b/c — values actually programmed on the dynamometer (what was tested)
+ *   2. target_a/b/c — EPA-certified values (what the label is based on)
+ *
+ * They usually match. When they differ, set values reflect actual test conditions;
+ * target values reflect what was certified. For a curve calibrated to match the
+ * measured HWFET result, set values are slightly more internally consistent.
+ *
+ * @param {object} epaGroup — row from epa_test_groups
+ * @returns {{ a: number, b: number, c: number }}
+ */
+export function resolveCoeffs(epaGroup) {
+    const hasSet =
+        epaGroup.set_a != null &&
+        epaGroup.set_b != null &&
+        epaGroup.set_c != null;
+
+    if (hasSet) {
+        return { a: epaGroup.set_a, b: epaGroup.set_b, c: epaGroup.set_c };
+    }
+    return { a: epaGroup.target_a, b: epaGroup.target_b, c: epaGroup.target_c };
+}
+
+// ── Core physics ──────────────────────────────────────────────────────────────
+
+/**
+ * Road-load force at a given speed.
+ * F(v) = A + B·v + C·v²
+ *
+ * @param {number} v — speed in mph
+ * @param {number} a — lbf (rolling resistance + constant losses)
+ * @param {number} b — lbf/mph (speed-proportional losses)
+ * @param {number} c — lbf/mph² (aerodynamic drag)
+ * @returns {number} force in lbf
+ */
+function roadLoadForce(v, a, b, c) {
+    return a + b * v + c * v * v;
+}
+
+/**
+ * Back-solve effective drivetrain efficiency η_eff from the HWFET unadjusted
+ * measurement (battery-side kWh, pre-correction-factor).
+ *
+ * At the HWFET average speed (48.3 mph), steady-state consumption should equal
+ * the measured value. Solving for η:
+ *   hwfetUnadj = F(48.3) × 0.1989 / η + P_acc × 100 / 48.3   [kWh/100mi]
+ *   η = F(48.3) × 0.1989 / (hwfetUnadj - P_acc × 100 / 48.3)
+ *
+ * η_eff lumps motor inverter losses, gearbox losses, and the net benefit of
+ * regenerative braking into a single composite factor. Typical EVs: 0.80–0.95.
+ *
+ * Fallback to DEFAULT_ETA (0.88) when HWFET data is absent.
+ * Clamped to [0.60, 0.98] to reject physically implausible back-solves.
+ *
+ * @param {number} a — road-load A coefficient (lbf)
+ * @param {number} b — road-load B coefficient (lbf/mph)
+ * @param {number} c — road-load C coefficient (lbf/mph²)
+ * @param {number|null} hwfetUnadjKwh100mi
+ * @returns {number} η_eff (dimensionless, 0–1)
+ */
+export function calibrateEfficiency(a, b, c, hwfetUnadjKwh100mi) {
+    if (!hwfetUnadjKwh100mi || hwfetUnadjKwh100mi <= 0) return DEFAULT_ETA;
+
+    const fAtHwfet = roadLoadForce(HWFET_AVG_MPH, a, b, c);
+    const eWheelKwh100mi = fAtHwfet * LBF_MILE_TO_KWH * 100;
+    const eAccKwh100mi   = ACCESSORY_LOAD_KW * 100 / HWFET_AVG_MPH;
+    const denominator    = hwfetUnadjKwh100mi - eAccKwh100mi;
+
+    if (denominator <= 0) return DEFAULT_ETA;
+
+    const eta = eWheelKwh100mi / denominator;
+    return Math.max(0.60, Math.min(0.98, eta));
+}
+
+/**
+ * Battery-side energy consumption at a single steady-state speed.
+ *
+ * @param {number} speedMph
+ * @param {number} a
+ * @param {number} b
+ * @param {number} c
+ * @param {number} etaEff — from calibrateEfficiency()
+ * @returns {number} kWh/100mi
+ */
+export function batteryKwh100mi(speedMph, a, b, c, etaEff) {
+    if (speedMph <= 0) return null;
+    const f = roadLoadForce(speedMph, a, b, c);
+    const eWheel = f * LBF_MILE_TO_KWH * 100;        // kWh/100mi wheel
+    const eAcc   = ACCESSORY_LOAD_KW * 100 / speedMph; // kWh/100mi accessories
+    return eWheel / etaEff + eAcc;
+}
+
+// ── Curve builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the full steady-state curve from CURVE_SPEED_RANGE[0] to [1] mph
+ * at 1-mph intervals.
+ *
+ * @param {object} epaGroup — row from epa_test_groups
+ * @param {number|null} useableKwh — battery capacity for range calculation
+ * @returns {Array<{ mph, kwh100mi, miPerKwh, mpge, rangeMi }>}
+ *   rangeMi is null when useableKwh is null/zero.
+ */
+export function buildEpaCurve(epaGroup, useableKwh) {
+    const { a, b, c } = resolveCoeffs(epaGroup);
+    if (a == null || b == null || c == null) return [];
+
+    const eta = calibrateEfficiency(a, b, c, epaGroup.hwfet_unadj_kwh_100mi);
+    const results = [];
+    const [vMin, vMax] = CURVE_SPEED_RANGE;
+
+    for (let v = vMin; v <= vMax; v++) {
+        const kwh100mi = batteryKwh100mi(v, a, b, c, eta);
+        if (kwh100mi == null || kwh100mi <= 0) continue;
+
+        const miPerKwh = 100 / kwh100mi;
+        const mpge     = miPerKwh * MPG_E_CONVERSION;
+        const rangeMi  = useableKwh > 0 ? useableKwh / (kwh100mi / 100) : null;
+
+        results.push({ mph: v, kwh100mi, miPerKwh, mpge, rangeMi });
+    }
+
+    return results;
+}
+
+// ── Useable kWh resolution ────────────────────────────────────────────────────
+
+/**
+ * Resolve the best available useable battery capacity estimate (kWh).
+ *
+ * Priority:
+ *   1. epa_test_groups.useable_kwh  — EPA's own reported value (often absent)
+ *   2. vehicle.specs.charging.battery_usable_kwh — contributor-entered spec
+ *   3. vehicle.battery × 0.93  — gross battery × typical usable fraction (estimate)
+ *
+ * Returns null when none of the above yield a positive number.
+ *
+ * @param {object} epaGroup — row from epa_test_groups
+ * @param {object} vehicle  — app vehicle object
+ * @returns {number|null}
+ */
+export function resolveUseableKwh(epaGroup, vehicle) {
+    if (epaGroup?.useable_kwh > 0) return epaGroup.useable_kwh;
+    const specUsable = vehicle?.specs?.charging?.battery_usable_kwh;
+    if (specUsable > 0) return specUsable;
+    if (vehicle?.battery > 0) return vehicle.battery * 0.93;
+    return null;
+}

--- a/src/utils/epaPhysics.js
+++ b/src/utils/epaPhysics.js
@@ -194,12 +194,12 @@ export function buildEpaCurve(epaGroup, useableKwh) {
 // ── Useable kWh resolution ────────────────────────────────────────────────────
 
 /**
- * Resolve the best available useable battery capacity estimate (kWh).
+ * Resolve the best available useable battery capacity (kWh).
  *
  * Priority:
- *   1. epa_test_groups.useable_kwh  — EPA's own reported value (often absent)
+ *   1. epa_test_groups.useable_kwh          — EPA's own reported value (often absent)
  *   2. vehicle.specs.charging.battery_usable_kwh — contributor-entered spec
- *   3. vehicle.battery × 0.93  — gross battery × typical usable fraction (estimate)
+ *   3. vehicle.battery                       — gross capacity as-is
  *
  * Returns null when none of the above yield a positive number.
  *
@@ -211,6 +211,20 @@ export function resolveUseableKwh(epaGroup, vehicle) {
     if (epaGroup?.useable_kwh > 0) return epaGroup.useable_kwh;
     const specUsable = vehicle?.specs?.charging?.battery_usable_kwh;
     if (specUsable > 0) return specUsable;
-    if (vehicle?.battery > 0) return vehicle.battery * 0.93;
+    if (vehicle?.battery > 0) return vehicle.battery;
+    return null;
+}
+
+/**
+ * Return a short label describing which source resolveUseableKwh() used.
+ * Matches the priority order exactly.
+ *
+ * @returns {'EPA'|'spec'|'gross'|null}
+ */
+export function resolveUseableKwhSource(epaGroup, vehicle) {
+    if (epaGroup?.useable_kwh > 0) return 'EPA';
+    const specUsable = vehicle?.specs?.charging?.battery_usable_kwh;
+    if (specUsable > 0) return 'spec';
+    if (vehicle?.battery > 0) return 'gross';
     return null;
 }

--- a/src/utils/epaPhysics.js
+++ b/src/utils/epaPhysics.js
@@ -55,26 +55,33 @@ export const CURVE_SPEED_RANGE = [5, 120];
  * Select which set of road-load coefficients to use.
  *
  * Preference order:
- *   1. set_a/b/c — values actually programmed on the dynamometer (what was tested)
- *   2. target_a/b/c — EPA-certified values (what the label is based on)
+ *   1. target_a/b/c — EPA-certified road load (what the vehicle experiences on the road)
+ *   2. set_a/b/c    — dyno-programmed load (fallback when target is absent)
  *
- * They usually match. When they differ, set values reflect actual test conditions;
- * target values reflect what was certified. For a curve calibrated to match the
- * measured HWFET result, set values are slightly more internally consistent.
+ * WHY target is preferred:
+ *   The "target" coefficients come from the vehicle's coast-down test and represent
+ *   the true aerodynamic and rolling-resistance forces the vehicle must overcome on
+ *   the road. The "set" (programmed) coefficients are what gets sent to the chassis
+ *   dynamometer controller. Because the dyno drums have their own tire-contact
+ *   friction, the programmed values are adjusted downward (often giving a negative A)
+ *   so that:
+ *       F_set(v)  +  F_drum_friction(v)  =  F_target(v)
+ *   Using set alone would dramatically understate road load at highway speeds
+ *   (30–55 % for heavy vehicles), producing falsely optimistic efficiency curves.
  *
  * @param {object} epaGroup — row from epa_test_groups
  * @returns {{ a: number, b: number, c: number }}
  */
 export function resolveCoeffs(epaGroup) {
-    const hasSet =
-        epaGroup.set_a != null &&
-        epaGroup.set_b != null &&
-        epaGroup.set_c != null;
+    const hasTarget =
+        epaGroup.target_a != null &&
+        epaGroup.target_b != null &&
+        epaGroup.target_c != null;
 
-    if (hasSet) {
-        return { a: epaGroup.set_a, b: epaGroup.set_b, c: epaGroup.set_c };
+    if (hasTarget) {
+        return { a: epaGroup.target_a, b: epaGroup.target_b, c: epaGroup.target_c };
     }
-    return { a: epaGroup.target_a, b: epaGroup.target_b, c: epaGroup.target_c };
+    return { a: epaGroup.set_a, b: epaGroup.set_b, c: epaGroup.set_c };
 }
 
 // ── Core physics ──────────────────────────────────────────────────────────────

--- a/src/utils/epaPhysics.js
+++ b/src/utils/epaPhysics.js
@@ -168,7 +168,12 @@ export function buildEpaCurve(epaGroup, useableKwh) {
     const { a, b, c } = resolveCoeffs(epaGroup);
     if (a == null || b == null || c == null) return [];
 
-    const eta = calibrateEfficiency(a, b, c, epaGroup.hwfet_unadj_kwh_100mi);
+    // Prefer unadjusted HWFET (raw dyno value) for calibration; fall back to
+    // adjusted (RND_ADJ_FE kWh/100mi from the test car sheet). Unadj is rarely
+    // present in the test car list; adj is populated for every HWFE/HWY row and
+    // is accurate enough for the steady-state comparative curve.
+    const hwfetKwh = epaGroup.hwfet_unadj_kwh_100mi ?? epaGroup.hwfet_adj_kwh_100mi;
+    const eta = calibrateEfficiency(a, b, c, hwfetKwh);
     const results = [];
     const [vMin, vMax] = CURVE_SPEED_RANGE;
 

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -103,13 +103,21 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
         const fuelCd = get(row, 'Test Fuel Type Cd');
         if (fuelCd !== '62') continue; // 62 = Electricity
 
-        const testGroupId = get(row, 'Actual Tested Testgroup');
+        // ── Unique key: Test Vehicle ID is specific per configuration (e.g.
+        //    R1S247XR20 = 20in wheels, R1S247XR22 = 22in wheels).
+        //    "Actual Tested Testgroup" is a test-family ID shared across
+        //    multiple configurations — using it would merge the 20in and 22in
+        //    variants into one record, discarding the different A/B/C values.
+        const testVehicleId  = get(row, 'Test Vehicle ID');
+        const testFamilyId   = get(row, 'Actual Tested Testgroup');
+        const testGroupId    = testVehicleId || testFamilyId;
         if (!testGroupId) continue;
 
         // ── Initialise group on first encounter ─────────────────────────────
         if (!groups.has(testGroupId)) {
             groups.set(testGroupId, {
-                test_group_id: testGroupId,
+                test_group_id:      testGroupId,      // Test Vehicle ID (preferred)
+                epa_test_family_id: testFamilyId || null, // Actual Tested Testgroup
                 model_year: getNum(row, 'Model Year'),
                 make: get(row, 'Represented Test Veh Make') || get(row, 'Vehicle Manufacturer Name') || null,
                 epa_carline_name: get(row, 'Represented Test Veh Model') || null,
@@ -124,6 +132,9 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
                 set_a:    null, set_b:    null, set_c:    null,
 
                 // Per-cycle kWh/100mi (adj = adjusted label values)
+                // Note: only RND_ADJ_FE is used; FE Bag columns are NOT MPGe
+                // for BEVs — their values can be negative (US06) which proves
+                // they are internal test-accounting deltas, not fuel economy.
                 udds_unadj_kwh_100mi:     null,
                 udds_adj_kwh_100mi:       null,
                 hwfet_unadj_kwh_100mi:    null,
@@ -164,45 +175,43 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
         if (g.set_b === null && sb !== null) g.set_b = sb;
         if (g.set_c === null && sc !== null) g.set_c = sc;
 
-        // ── Per-cycle FE (RND_ADJ_FE = cycle-adjusted MPGe) ────────────────
-        const category = get(row, 'Test Category').toUpperCase();
-        const fe = getNum(row, 'RND_ADJ_FE');
-        // Bag 1 = phase 1, Bag 2 = phase 2 (for FTP: Bag1=cold, Bag2=transient, Bag3=hot)
-        const bag1 = getNum(row, 'FE Bag 1');
-        const bag2 = getNum(row, 'FE Bag 2');
-        const bag3 = getNum(row, 'FE Bag 3');
+        // ── Per-cycle FE ─────────────────────────────────────────────────────
+        // Only RND_ADJ_FE is a reliable MPGe value. FE Bag 1/2/3 are NOT MPGe
+        // for BEVs — they appear to be internal EPA test-accounting corrections
+        // (evidenced by negative values in US06/SC03 rows). Do not use them.
+        const category     = get(row, 'Test Category').toUpperCase();
+        const testProcCd   = get(row, 'Test Procedure Cd');
+        const fe           = getNum(row, 'RND_ADJ_FE');
 
-        switch (category) {
-            case 'CD':   // charge-depleting combined — MCT summary row
-            case 'MCT':
-                if (fe != null) g.label_combined_mpge = fe;
-                break;
-            case 'FTP':
-                // FTP = UDDS city cycle; bags = Bag1 cold + Bag2 transient + Bag3 hot
-                if (fe  != null) g.udds_adj_kwh_100mi  = mpgeToKwh100mi(fe);
-                // Unadjusted: bag values are raw dyno phases; combined unadj ≈ bag average
-                // (only assign if we can get a meaningful value — bags are often blank for BEVs)
-                if (bag1 != null && bag1 > 1) g.udds_unadj_kwh_100mi = mpgeToKwh100mi(bag1);
-                break;
-            case 'HWY':
-            case 'HWFE':
-                if (fe   != null) g.hwfet_adj_kwh_100mi  = mpgeToKwh100mi(fe);
-                if (bag1 != null && bag1 > 1) g.hwfet_unadj_kwh_100mi = mpgeToKwh100mi(bag1);
-                break;
-            case 'US06':
-                if (fe   != null) g.us06_adj_kwh_100mi   = mpgeToKwh100mi(fe);
-                if (bag1 != null && bag1 > 1) g.us06_unadj_kwh_100mi  = mpgeToKwh100mi(bag1);
-                break;
-            case 'SC03':
-                if (fe   != null) g.sc03_adj_kwh_100mi   = mpgeToKwh100mi(fe);
-                break;
-            case 'COLD':
-            case 'FTP COLD':
-            case 'COLD FTP':
-                if (fe   != null) g.cold_ftp_adj_kwh_100mi = mpgeToKwh100mi(fe);
-                break;
-            default:
-                break;
+        // Cold-FTP: Test Procedure Cd 86 shares Test Category "CD" with MCT.
+        // Detect it by procedure code before falling through to the CD/MCT case.
+        const isColdFtp = testProcCd === '86' ||
+            category === 'COLD' || category === 'FTP COLD' || category === 'COLD FTP';
+
+        if (isColdFtp) {
+            if (fe != null) g.cold_ftp_adj_kwh_100mi = mpgeToKwh100mi(fe);
+        } else {
+            switch (category) {
+                case 'CD':   // charge-depleting combined — MCT summary row
+                case 'MCT':
+                    if (fe != null) g.label_combined_mpge = fe;
+                    break;
+                case 'FTP':
+                    if (fe != null) g.udds_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    break;
+                case 'HWY':
+                case 'HWFE':
+                    if (fe != null) g.hwfet_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    break;
+                case 'US06':
+                    if (fe != null) g.us06_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    break;
+                case 'SC03':
+                    if (fe != null) g.sc03_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    break;
+                default:
+                    break;
+            }
         }
     }
 

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -31,14 +31,55 @@ function mpgeToKwh100mi(mpge) {
  * @param {string} [sourceFileName]  Stored in source_file field
  * @returns {Array<Object>}
  */
+/**
+ * Split one line into fields, respecting RFC 4180 CSV quoting rules.
+ * For TSV (sep='\t') no quoting is expected so we just split.
+ * For CSV, fields may be wrapped in double-quotes, and "" inside a quoted
+ * field represents a literal double-quote.
+ */
+function splitLine(line, sep) {
+    if (sep === '\t') return line.split('\t');
+
+    const fields = [];
+    let cur = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (inQuotes) {
+            if (ch === '"') {
+                if (i + 1 < line.length && line[i + 1] === '"') {
+                    cur += '"'; // escaped quote
+                    i++;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                cur += ch;
+            }
+        } else {
+            if (ch === '"') {
+                inQuotes = true;
+            } else if (ch === sep) {
+                fields.push(cur);
+                cur = '';
+            } else {
+                cur += ch;
+            }
+        }
+    }
+    fields.push(cur);
+    return fields;
+}
+
 export function parseEpaTestCarSheet(text, sourceFileName = null) {
     // Normalise line endings
     const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
     if (lines.length < 2) return [];
 
-    // Detect separator
+    // Detect separator: prefer tab; fall back to comma (Excel CSV)
     const sep = lines[0].includes('\t') ? '\t' : ',';
-    const headers = lines[0].split(sep).map(h => h.trim());
+    const headers = splitLine(lines[0], sep).map(h => h.trim());
 
     // Build a lookup from header name → column index
     const colIdx = {};
@@ -56,7 +97,7 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
     for (let i = 1; i < lines.length; i++) {
         const line = lines[i];
         if (!line.trim()) continue;
-        const row = line.split(sep);
+        const row = splitLine(line, sep);
 
         // ── Fuel type filter ────────────────────────────────────────────────
         const fuelCd = get(row, 'Test Fuel Type Cd');

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -20,10 +20,19 @@ function numOrNull(str) {
     return isNaN(n) ? null : n;
 }
 
-/** Convert MPGe → kWh/100mi (rounded to 4 decimal places). */
-function mpgeToKwh100mi(mpge) {
-    if (!mpge || mpge <= 0) return null;
-    return Math.round((MPG_E_CONVERSION * 100 / mpge) * 10000) / 10000;
+/**
+ * Convert kWh/100mi → MPGe (rounded to 1 decimal place).
+ *
+ * Despite being named "FE" (fuel economy), the RND_ADJ_FE column in the EPA
+ * Test Car List stores energy *consumption* in kWh/100mi, not MPGe. This
+ * function applies the correct formula: MPGe = (33.705 × 100) / kWh/100mi.
+ *
+ * Values ≥ 500 kWh/100mi are EPA sentinel placeholders (e.g. 999 = "label
+ * not yet finalized") and are treated as null.
+ */
+function kwh100miToMpge(kwh100mi) {
+    if (kwh100mi == null || kwh100mi <= 0 || kwh100mi >= 500) return null;
+    return Math.round((MPG_E_CONVERSION * 100 / kwh100mi) * 10) / 10;
 }
 
 /**
@@ -175,13 +184,16 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
         if (g.set_b === null && sb !== null) g.set_b = sb;
         if (g.set_c === null && sc !== null) g.set_c = sc;
 
-        // ── Per-cycle FE ─────────────────────────────────────────────────────
-        // Only RND_ADJ_FE is a reliable MPGe value. FE Bag 1/2/3 are NOT MPGe
-        // for BEVs — they appear to be internal EPA test-accounting corrections
-        // (evidenced by negative values in US06/SC03 rows). Do not use them.
-        const category     = get(row, 'Test Category').toUpperCase();
-        const testProcCd   = get(row, 'Test Procedure Cd');
-        const fe           = getNum(row, 'RND_ADJ_FE');
+        // ── Per-cycle energy consumption ──────────────────────────────────────
+        // RND_ADJ_FE is kWh/100mi (not MPGe — see kwh100miToMpge comment above).
+        // FE Bag 1/2/3 are internal EPA test-accounting corrections (can be
+        // negative for US06/SC03) and are not usable as consumption values.
+        const category   = get(row, 'Test Category').toUpperCase();
+        const testProcCd = get(row, 'Test Procedure Cd');
+        const feKwh      = getNum(row, 'RND_ADJ_FE'); // kWh/100mi; null if blank or sentinel
+
+        // Plausibility guard: values ≥ 500 are sentinel placeholders (e.g. 999)
+        const feKwh100mi = (feKwh != null && feKwh > 0 && feKwh < 500) ? feKwh : null;
 
         // Cold-FTP: Test Procedure Cd 86 shares Test Category "CD" with MCT.
         // Detect it by procedure code before falling through to the CD/MCT case.
@@ -189,25 +201,27 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
             category === 'COLD' || category === 'FTP COLD' || category === 'COLD FTP';
 
         if (isColdFtp) {
-            if (fe != null) g.cold_ftp_adj_kwh_100mi = mpgeToKwh100mi(fe);
+            if (feKwh100mi != null) g.cold_ftp_adj_kwh_100mi = feKwh100mi;
         } else {
             switch (category) {
                 case 'CD':   // charge-depleting combined — MCT summary row
                 case 'MCT':
-                    if (fe != null) g.label_combined_mpge = fe;
+                    // Convert kWh/100mi → MPGe for the label field
+                    if (feKwh100mi != null) g.label_combined_mpge = kwh100miToMpge(feKwh100mi);
                     break;
                 case 'FTP':
-                    if (fe != null) g.udds_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    // Already kWh/100mi — store directly, no conversion needed
+                    if (feKwh100mi != null) g.udds_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'HWY':
                 case 'HWFE':
-                    if (fe != null) g.hwfet_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    if (feKwh100mi != null) g.hwfet_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'US06':
-                    if (fe != null) g.us06_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    if (feKwh100mi != null) g.us06_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'SC03':
-                    if (fe != null) g.sc03_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                    if (feKwh100mi != null) g.sc03_adj_kwh_100mi = feKwh100mi;
                     break;
                 default:
                     break;

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -1,0 +1,186 @@
+/**
+ * Parse an EPA Test Car List TSV (tab-separated) or CSV file.
+ *
+ * The EPA file has one row per *test run* — a single vehicle configuration
+ * (test group) produces multiple rows: MCT/CD (combined label), FTP (city),
+ * HWY (highway), US06, SC03, and optionally Cold-FTP. This parser groups
+ * those rows back into one record per test group and extracts per-cycle
+ * fuel economy values where available.
+ *
+ * Filter: only rows with Test Fuel Type Cd = 62 (Electricity) are kept.
+ *
+ * Returns: Array of objects shaped like the epa_test_groups table row.
+ */
+
+const MPG_E_CONVERSION = 33.705; // kWh per gallon gasoline equivalent
+
+function numOrNull(str) {
+    if (!str || !str.trim()) return null;
+    const n = parseFloat(str.trim());
+    return isNaN(n) ? null : n;
+}
+
+/** Convert MPGe → kWh/100mi (rounded to 4 decimal places). */
+function mpgeToKwh100mi(mpge) {
+    if (!mpge || mpge <= 0) return null;
+    return Math.round((MPG_E_CONVERSION * 100 / mpge) * 10000) / 10000;
+}
+
+/**
+ * @param {string} text  Raw file text (UTF-8)
+ * @param {string} [sourceFileName]  Stored in source_file field
+ * @returns {Array<Object>}
+ */
+export function parseEpaTestCarSheet(text, sourceFileName = null) {
+    // Normalise line endings
+    const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    if (lines.length < 2) return [];
+
+    // Detect separator
+    const sep = lines[0].includes('\t') ? '\t' : ',';
+    const headers = lines[0].split(sep).map(h => h.trim());
+
+    // Build a lookup from header name → column index
+    const colIdx = {};
+    headers.forEach((h, i) => { colIdx[h] = i; });
+
+    // Helper: get a cell by column name (returns '' if not found)
+    const get = (row, col) => {
+        const i = colIdx[col];
+        return i !== undefined ? (row[i] ?? '').trim() : '';
+    };
+    const getNum = (row, col) => numOrNull(get(row, col));
+
+    const groups = new Map();
+
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) continue;
+        const row = line.split(sep);
+
+        // ── Fuel type filter ────────────────────────────────────────────────
+        const fuelCd = get(row, 'Test Fuel Type Cd');
+        if (fuelCd !== '62') continue; // 62 = Electricity
+
+        const testGroupId = get(row, 'Actual Tested Testgroup');
+        if (!testGroupId) continue;
+
+        // ── Initialise group on first encounter ─────────────────────────────
+        if (!groups.has(testGroupId)) {
+            groups.set(testGroupId, {
+                test_group_id: testGroupId,
+                model_year: getNum(row, 'Model Year'),
+                make: get(row, 'Represented Test Veh Make') || get(row, 'Vehicle Manufacturer Name') || null,
+                epa_carline_name: get(row, 'Represented Test Veh Model') || null,
+                transmission: get(row, 'Tested Transmission Type') || null,
+                drive: get(row, 'Drive System Description') || null,
+                fuel_type: get(row, 'Test Fuel Type Description') || 'BEV',
+
+                equiv_test_weight_lbs: getNum(row, 'Equivalent Test Weight (lbs.)'),
+
+                // Coefficients — same across all rows; filled below
+                target_a: null, target_b: null, target_c: null,
+                set_a:    null, set_b:    null, set_c:    null,
+
+                // Per-cycle kWh/100mi (adj = adjusted label values)
+                udds_unadj_kwh_100mi:     null,
+                udds_adj_kwh_100mi:       null,
+                hwfet_unadj_kwh_100mi:    null,
+                hwfet_adj_kwh_100mi:      null,
+                us06_unadj_kwh_100mi:     null,
+                us06_adj_kwh_100mi:       null,
+                sc03_unadj_kwh_100mi:     null,
+                sc03_adj_kwh_100mi:       null,
+                cold_ftp_unadj_kwh_100mi: null,
+                cold_ftp_adj_kwh_100mi:   null,
+
+                // Label values
+                label_combined_mpge: null,
+                label_city_mpge:     null,
+                label_hwy_mpge:      null,
+                label_combined_mi:   null,
+                label_city_mi:       null,
+                label_hwy_mi:        null,
+
+                source_file:  sourceFileName,
+                ingested_at:  new Date().toISOString(),
+            });
+        }
+
+        const g = groups.get(testGroupId);
+
+        // ── Road-load coefficients (same for all rows; take first non-null) ──
+        const ta = getNum(row, 'Target Coef A (lbf)');
+        const tb = getNum(row, 'Target Coef B (lbf/mph)');
+        const tc = getNum(row, 'Target Coef C (lbf/mph**2)');
+        const sa = getNum(row, 'Set Coef A (lbf)');
+        const sb = getNum(row, 'Set Coef B (lbf/mph)');
+        const sc = getNum(row, 'Set Coef C (lbf/mph**2)');
+        if (g.target_a === null && ta !== null) g.target_a = ta;
+        if (g.target_b === null && tb !== null) g.target_b = tb;
+        if (g.target_c === null && tc !== null) g.target_c = tc;
+        if (g.set_a === null && sa !== null) g.set_a = sa;
+        if (g.set_b === null && sb !== null) g.set_b = sb;
+        if (g.set_c === null && sc !== null) g.set_c = sc;
+
+        // ── Per-cycle FE (RND_ADJ_FE = cycle-adjusted MPGe) ────────────────
+        const category = get(row, 'Test Category').toUpperCase();
+        const fe = getNum(row, 'RND_ADJ_FE');
+        // Bag 1 = phase 1, Bag 2 = phase 2 (for FTP: Bag1=cold, Bag2=transient, Bag3=hot)
+        const bag1 = getNum(row, 'FE Bag 1');
+        const bag2 = getNum(row, 'FE Bag 2');
+        const bag3 = getNum(row, 'FE Bag 3');
+
+        switch (category) {
+            case 'CD':   // charge-depleting combined — MCT summary row
+            case 'MCT':
+                if (fe != null) g.label_combined_mpge = fe;
+                break;
+            case 'FTP':
+                // FTP = UDDS city cycle; bags = Bag1 cold + Bag2 transient + Bag3 hot
+                if (fe  != null) g.udds_adj_kwh_100mi  = mpgeToKwh100mi(fe);
+                // Unadjusted: bag values are raw dyno phases; combined unadj ≈ bag average
+                // (only assign if we can get a meaningful value — bags are often blank for BEVs)
+                if (bag1 != null && bag1 > 1) g.udds_unadj_kwh_100mi = mpgeToKwh100mi(bag1);
+                break;
+            case 'HWY':
+            case 'HWFE':
+                if (fe   != null) g.hwfet_adj_kwh_100mi  = mpgeToKwh100mi(fe);
+                if (bag1 != null && bag1 > 1) g.hwfet_unadj_kwh_100mi = mpgeToKwh100mi(bag1);
+                break;
+            case 'US06':
+                if (fe   != null) g.us06_adj_kwh_100mi   = mpgeToKwh100mi(fe);
+                if (bag1 != null && bag1 > 1) g.us06_unadj_kwh_100mi  = mpgeToKwh100mi(bag1);
+                break;
+            case 'SC03':
+                if (fe   != null) g.sc03_adj_kwh_100mi   = mpgeToKwh100mi(fe);
+                break;
+            case 'COLD':
+            case 'FTP COLD':
+            case 'COLD FTP':
+                if (fe   != null) g.cold_ftp_adj_kwh_100mi = mpgeToKwh100mi(fe);
+                break;
+            default:
+                break;
+        }
+    }
+
+    return Array.from(groups.values());
+}
+
+/**
+ * Summarise what was parsed (for UI display).
+ * @param {Array} groups  Output of parseEpaTestCarSheet
+ */
+export function summariseEpaGroups(groups) {
+    const makes = [...new Set(groups.map(g => g.make).filter(Boolean))].sort();
+    const years = groups.map(g => g.model_year).filter(Boolean);
+    return {
+        total: groups.length,
+        makes,
+        yearMin: years.length ? Math.min(...years) : null,
+        yearMax: years.length ? Math.max(...years) : null,
+        withCoeffs: groups.filter(g => g.set_a !== null || g.target_a !== null).length,
+        withMpge: groups.filter(g => g.label_combined_mpge !== null).length,
+    };
+}

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -165,6 +165,12 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
 
                 source_file:  sourceFileName,
                 ingested_at:  new Date().toISOString(),
+
+                // Raw RND_ADJ_FE column values before our kWh/100mi interpretation.
+                // NOT sent to the database — used only by the import UI so the user
+                // can detect and flip records where the column is actually in MPGe.
+                // Stripped by applyUnitOverride() before the DB upsert.
+                _raw: { combined: null, hwfet: null, udds: null, us06: null, sc03: null, cold_ftp: null },
             });
         }
 
@@ -201,26 +207,32 @@ export function parseEpaTestCarSheet(text, sourceFileName = null) {
             category === 'COLD' || category === 'FTP COLD' || category === 'COLD FTP';
 
         if (isColdFtp) {
+            g._raw.cold_ftp = feKwh;  // store raw (pre-sentinel-filter) for unit-flip UI
             if (feKwh100mi != null) g.cold_ftp_adj_kwh_100mi = feKwh100mi;
         } else {
             switch (category) {
                 case 'CD':   // charge-depleting combined — MCT summary row
                 case 'MCT':
+                    g._raw.combined = feKwh;
                     // Convert kWh/100mi → MPGe for the label field
                     if (feKwh100mi != null) g.label_combined_mpge = kwh100miToMpge(feKwh100mi);
                     break;
                 case 'FTP':
+                    g._raw.udds = feKwh;
                     // Already kWh/100mi — store directly, no conversion needed
                     if (feKwh100mi != null) g.udds_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'HWY':
                 case 'HWFE':
+                    g._raw.hwfet = feKwh;
                     if (feKwh100mi != null) g.hwfet_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'US06':
+                    g._raw.us06 = feKwh;
                     if (feKwh100mi != null) g.us06_adj_kwh_100mi = feKwh100mi;
                     break;
                 case 'SC03':
+                    g._raw.sc03 = feKwh;
                     if (feKwh100mi != null) g.sc03_adj_kwh_100mi = feKwh100mi;
                     break;
                 default:

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -89,6 +89,22 @@ export function formatSpecValue(value, unitGroup, sys) {
     }
 }
 
+// ── MPGe (Miles Per Gallon equivalent) ───────────────────────────────────────
+
+/** EPA's kWh per gallon of gasoline equivalent (used to compute MPGe). */
+export const MPG_E_CONVERSION = 33.705;
+
+/**
+ * Convert mi/kWh to MPGe (Miles Per Gallon equivalent).
+ * MPGe = (mi/kWh) × 33.705 kWh/gal
+ * @param {number|null} miPerKwh
+ * @returns {number|null}
+ */
+export function miKwhToMpge(miPerKwh) {
+    if (miPerKwh == null) return null;
+    return Math.round(miPerKwh * MPG_E_CONVERSION * 10) / 10;
+}
+
 // ── Rounding ──────────────────────────────────────────────────────────────────
 
 /** Round to a given number of decimal places. Returns null for null/NaN input. */

--- a/supabase/migrations/020_epa_curves.sql
+++ b/supabase/migrations/020_epa_curves.sql
@@ -1,0 +1,120 @@
+-- Migration 020: EPA Road-Load Curves
+--
+-- Adds two tables:
+--   epa_test_groups     — one row per EPA test group (reference data, admin-write-only)
+--   epa_vehicle_mappings — links app vehicles to EPA test groups (contributor-writable)
+--
+-- EPA records are inserted directly via the database; the app only reads and visualises them.
+
+-- ── epa_test_groups ──────────────────────────────────────────────────────────
+
+CREATE TABLE epa_test_groups (
+    -- Identity
+    test_group_id         text        PRIMARY KEY,  -- EPA's verbatim text ID
+    model_year            integer     NOT NULL,
+    make                  text        NOT NULL,
+    epa_carline_name      text        NOT NULL,     -- EPA name, preserved verbatim
+    transmission          text,
+    drive                 text,                     -- FWD / RWD / AWD / 4WD
+    fuel_type             text,                     -- BEV, PHEV, HEV, gas, …
+
+    -- Road load (physics layer)
+    -- Coefficients in EPA standard units: A [lbf], B [lbf/mph], C [lbf/mph²]
+    equiv_test_weight_lbs numeric(10,2),
+    target_a              numeric(10,4),            -- EPA-accepted (certified) value
+    target_b              numeric(10,6),
+    target_c              numeric(10,8),
+    set_a                 numeric(10,4),            -- value actually programmed on dyno
+    set_b                 numeric(10,6),
+    set_c                 numeric(10,8),
+
+    -- Per-cycle results  (NULL = cycle was not run — this is meaningful, not missing data)
+    -- Unadjusted = raw dyno measurement; adjusted = post-correction-factor (label basis)
+    udds_unadj_kwh_100mi      numeric(8,4),
+    udds_adj_kwh_100mi        numeric(8,4),
+    hwfet_unadj_kwh_100mi     numeric(8,4),
+    hwfet_adj_kwh_100mi       numeric(8,4),
+    us06_unadj_kwh_100mi      numeric(8,4),
+    us06_adj_kwh_100mi        numeric(8,4),
+    sc03_unadj_kwh_100mi      numeric(8,4),
+    sc03_adj_kwh_100mi        numeric(8,4),
+    cold_ftp_unadj_kwh_100mi  numeric(8,4),
+    cold_ftp_adj_kwh_100mi    numeric(8,4),
+
+    -- EV-specific label / range fields
+    range_city_mi         numeric(8,2),
+    range_hwy_mi          numeric(8,2),
+    range_combined_mi     numeric(8,2),
+    useable_kwh           numeric(8,3),            -- often absent from EPA data; nullable
+
+    -- Label derivation
+    label_method          text
+                              CHECK (label_method IN
+                                  ('2-cycle','5-cycle','vehicle-specific','mpg-based')),
+    label_city_mpge       numeric(8,2),
+    label_hwy_mpge        numeric(8,2),
+    label_combined_mpge   numeric(8,2),
+    label_city_mi         numeric(8,2),
+    label_hwy_mi          numeric(8,2),
+    label_combined_mi     numeric(8,2),
+
+    -- Provenance
+    source_file           text,
+    ingested_at           timestamptz,
+    created_at            timestamptz DEFAULT now()
+);
+
+ALTER TABLE epa_test_groups ENABLE ROW LEVEL SECURITY;
+
+-- Reference data — anyone can read
+CREATE POLICY "Public read epa_test_groups"
+    ON epa_test_groups FOR SELECT USING (true);
+
+-- Data originates from EPA bulk files processed outside the app; only admins write
+CREATE POLICY "Admins insert epa_test_groups"
+    ON epa_test_groups FOR INSERT
+    WITH CHECK (current_user_role() = 'admin');
+
+CREATE POLICY "Admins update epa_test_groups"
+    ON epa_test_groups FOR UPDATE
+    USING (current_user_role() = 'admin');
+
+CREATE POLICY "Admins delete epa_test_groups"
+    ON epa_test_groups FOR DELETE
+    USING (current_user_role() = 'admin');
+
+
+-- ── epa_vehicle_mappings ──────────────────────────────────────────────────────
+
+CREATE TABLE epa_vehicle_mappings (
+    id                  bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    vehicle_id          bigint NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    epa_test_group_id   text   NOT NULL REFERENCES epa_test_groups(test_group_id) ON DELETE CASCADE,
+    -- confidence: how certain we are that this vehicle matches this EPA test group
+    confidence          text   NOT NULL DEFAULT 'inferred'
+                            CHECK (confidence IN ('verified','likely','inferred')),
+    notes               text,
+    created_by          uuid REFERENCES auth.users(id),
+    created_at          timestamptz DEFAULT now(),
+    UNIQUE (vehicle_id, epa_test_group_id)
+);
+
+ALTER TABLE epa_vehicle_mappings ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX idx_epa_mappings_vehicle ON epa_vehicle_mappings(vehicle_id);
+
+CREATE POLICY "Public read epa_vehicle_mappings"
+    ON epa_vehicle_mappings FOR SELECT USING (true);
+
+-- Contributors link vehicles to test groups via the in-app UI
+CREATE POLICY "Contributors insert epa_vehicle_mappings"
+    ON epa_vehicle_mappings FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Contributors update epa_vehicle_mappings"
+    ON epa_vehicle_mappings FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Admins delete epa_vehicle_mappings"
+    ON epa_vehicle_mappings FOR DELETE
+    USING (current_user_role() = 'admin');

--- a/supabase/migrations/021_epa_test_vehicle_id.sql
+++ b/supabase/migrations/021_epa_test_vehicle_id.sql
@@ -1,0 +1,22 @@
+-- Migration 021: EPA test group key fix
+--
+-- Background:
+--   The original schema stored "Actual Tested Testgroup" (e.g. SRIVT00.0SEP)
+--   as test_group_id. This is an EPA test-family ID shared by multiple vehicle
+--   configurations (e.g. 20in and 22in wheel variants of the same model), which
+--   caused the importer to collapse distinct configurations into one record.
+--
+--   The correct unique key per configuration is the EPA "Test Vehicle ID"
+--   (e.g. R1S247XR20 / R1S247XR22). New imports use that value as test_group_id.
+--   This migration adds epa_test_family_id to store the family ID separately.
+--
+-- For records imported before this fix, epa_test_family_id will be NULL
+-- (they used the family ID as test_group_id, which cannot be reversed safely).
+
+ALTER TABLE epa_test_groups
+    ADD COLUMN IF NOT EXISTS epa_test_family_id text;
+
+COMMENT ON COLUMN epa_test_groups.epa_test_family_id IS
+    'EPA "Actual Tested Testgroup" — the certification family ID shared by '
+    'multiple vehicle configurations. Populated by imports after migration 021. '
+    'test_group_id now stores the more specific "Test Vehicle ID".';

--- a/supabase/migrations/022_epa_display_name.sql
+++ b/supabase/migrations/022_epa_display_name.sql
@@ -1,0 +1,11 @@
+-- Add a user-facing display name to EPA test groups.
+--
+-- EPA carline names (epa_carline_name) are verbatim from the test sheet and
+-- are intentionally preserved unchanged for traceability. display_name is an
+-- optional override used in chart legends and UI wherever the raw EPA name
+-- would be clunky or duplicative (e.g. "20-inch wheels" vs
+-- "RIVIAN R1S PERFORMANCE DUAL-MOTOR MAX PACK R1S247XR20").
+--
+-- NULL means "use epa_carline_name as-is".
+ALTER TABLE epa_test_groups
+    ADD COLUMN IF NOT EXISTS display_name text;


### PR DESCRIPTION
## Summary

- **New "EPA Curves" chart sub-tab** plots steady-state battery consumption vs speed derived from EPA dyno A/B/C road-load coefficients — lets users compare vehicles on a physics-equal basis and see where label range values come from
- **Physics engine** (`epaPhysics.js`): F(v) = A + Bv + Cv², back-solves drivetrain efficiency η from the HWFET unadjusted measurement at 48.3 mph average, builds 5–120 mph curves at 1 mph intervals
- **Y-axis toggle**: kWh/100mi · mi/kWh · MPGe · Range (mi), with metric unit support
- **Reference markers**: shaded highway band (65–75 mph), HWFET avg (48.3 mph) and US06 avg (48.4 mph) dashed lines — all drawn via a custom `afterDraw` plugin, no new npm packages
- **EPA test group linking UI** in EditVehicleForm (contributor+): searchable combobox debounced 300ms, confidence badge (Verified / Likely / Inferred), inline confidence selector, unlink button
- **Tooltip explainer system**: `epaExplainers.js` centralizes all tooltip text; `InfoIcon.jsx` renders CSS-only hover tooltips throughout the form and chart
- **Popout / BroadcastChannel sync**: `epaConfig` (yAxis + axis bounds) syncs to presentation window like compareConfig and roadTripConfig
- **URL persistence**: `epa_ya` query param restores selected Y axis on page load

## Database

Run `supabase/migrations/020_epa_curves.sql` in the Supabase SQL editor before deploying. Creates:
- `epa_test_groups` — one row per EPA test group (road-load coefficients, cycle results, label values); public read, admin write
- `epa_vehicle_mappings` — links vehicles to test groups with confidence level; public read, contributor insert/update

EPA test group records are inserted directly into the DB (no admin UI for bulk import — data volume and sourcing make that out of scope).

## Test plan

- [ ] Run migration in Supabase SQL editor; seed 2–3 rows from the EPA test data spreadsheet + one `epa_vehicle_mappings` row linking to a vehicle
- [ ] Vehicle with mapping: open edit form → EPA Test Group section shows; search returns results; select one → mapping row appears with confidence badge; change confidence dropdown → badge updates; Unlink removes row
- [ ] Navigate to Charts → EPA Curves sub-tab → dashed curve renders for vehicle with mapping; empty-state list shows vehicle without mapping
- [ ] Y-axis toggle: kWh/100mi → mi/kWh → MPGe → Range → labels and scale update
- [ ] Highway band (65–75 mph) visible as shaded rect; HWFET and US06 dashed reference lines labeled
- [ ] Dark mode: reference lines and shading adapt
- [ ] Metric mode: x-axis in km/h, range in km
- [ ] Pop-out window: syncs within ~1 s when main tab changes Y axis or selected vehicle
- [ ] URL: `?epa_ya=mi_kwh` restores Y axis on reload
- [ ] Copy PNG button produces a correctly composited image

🤖 Generated with [Claude Code](https://claude.com/claude-code)