### PR TITLE
Replace 'Tests: N' with typed pills on vehicle cards

### DIFF
--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -21,7 +21,8 @@ function TestCountPills({ vehicle }) {
     if (!chargingCount && !rangeCount && !epaCount) return null;
 
     return (
-        <div className="flex flex-wrap items-center gap-1">
+        <div className="flex flex-wrap items-center gap-1 mt-2">
+            <span className="text-xs text-gray-500 dark:text-slate-400 mr-0.5">Tests:</span>
             {chargingCount > 0 && <span className="pill-test-charging">Charging ({chargingCount})</span>}
             {rangeCount    > 0 && <span className="pill-test-range">Range ({rangeCount})</span>}
             {epaCount      > 0 && <span className="pill-test-epa">EPA ({epaCount})</span>}
@@ -785,6 +786,7 @@ export default function VehiclesView({
                                                     {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                                     {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                                 </div>
+                                                <TestCountPills vehicle={vehicle} />
                                                 {vehicle.tags?.length > 0 && (
                                                     <div className="mt-2">
                                                         <TagPills vehicle={vehicle} />
@@ -802,10 +804,9 @@ export default function VehiclesView({
                                         <div className="mt-auto pt-3" onClick={e => e.stopPropagation()}>
                                             <button
                                                 onClick={() => onViewRuns(vehicle)}
-                                                className="w-full px-3 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition flex flex-col items-start gap-1.5"
+                                                className="w-full px-3 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition"
                                             >
-                                                <span>View Tests &amp; Data →</span>
-                                                <TestCountPills vehicle={vehicle} />
+                                                View Tests &amp; Data →
                                             </button>
                                         </div>
                                     </div>
@@ -895,15 +896,15 @@ export default function VehiclesView({
                                         {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                         {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                         {vehicle.power && <p>Power: {vehicle.power} kW</p>}
+                                        <TestCountPills vehicle={vehicle} />
                                     </div>
 
                                     {/* View Tests & Data — dedicated column */}
                                     <button
                                         onClick={(e) => { e.stopPropagation(); onViewRuns(vehicle); }}
-                                        className="px-4 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition flex-shrink-0 flex flex-col items-start gap-1.5"
+                                        className="px-4 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 transition flex-shrink-0"
                                     >
-                                        <span>View Tests &amp; Data →</span>
-                                        <TestCountPills vehicle={vehicle} />
+                                        View Tests &amp; Data →
                                     </button>
 
                                     {/* Action column: Visibility → Edit → Copy → Delete */}

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -7,11 +7,12 @@ import EditVehicleForm from './EditVehicleForm';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 
-// ── Test-count pills ──────────────────────────────────────────────────────────
+// ── Test-count row ────────────────────────────────────────────────────────────
 
 /**
- * Renders coloured pills showing how many charging runs, range runs, and EPA
- * test groups a vehicle has. Omits any category whose count is zero.
+ * Renders a "Tests: Charging (n) Range (n) EPA (n)" line that matches the
+ * styling of Battery/Range rows. "Tests:" inherits the parent's text-sm color;
+ * the type names are 1pt smaller and colored. Zero-count categories omitted.
  */
 function TestCountPills({ vehicle }) {
     const chargingCount = vehicle.runs?.filter(r => r.has_charging).length ?? 0;
@@ -21,12 +22,12 @@ function TestCountPills({ vehicle }) {
     if (!chargingCount && !rangeCount && !epaCount) return null;
 
     return (
-        <div className="flex flex-wrap items-center gap-1 mt-2">
-            <span className="text-xs text-gray-500 dark:text-slate-400 mr-0.5">Tests:</span>
-            {chargingCount > 0 && <span className="pill-test-charging">Charging ({chargingCount})</span>}
-            {rangeCount    > 0 && <span className="pill-test-range">Range ({rangeCount})</span>}
-            {epaCount      > 0 && <span className="pill-test-epa">EPA ({epaCount})</span>}
-        </div>
+        <p className="flex flex-wrap items-baseline gap-x-1.5">
+            <span>Tests:</span>
+            {chargingCount > 0 && <span className="text-[13px] font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
+            {rangeCount    > 0 && <span className="text-[13px] font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
+            {epaCount      > 0 && <span className="text-[13px] font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
+        </p>
     );
 }
 
@@ -785,8 +786,8 @@ export default function VehiclesView({
                                                 <div className="text-sm text-gray-700 dark:text-slate-200 space-y-1">
                                                     {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                                     {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
+                                                    <TestCountPills vehicle={vehicle} />
                                                 </div>
-                                                <TestCountPills vehicle={vehicle} />
                                                 {vehicle.tags?.length > 0 && (
                                                     <div className="mt-2">
                                                         <TagPills vehicle={vehicle} />

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -7,6 +7,29 @@ import EditVehicleForm from './EditVehicleForm';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 
+// ── Test-count pills ──────────────────────────────────────────────────────────
+
+/**
+ * Renders coloured pills showing how many charging runs, range runs, and EPA
+ * test groups a vehicle has. Omits any category whose count is zero.
+ */
+function TestCountPills({ vehicle }) {
+    const chargingCount = vehicle.runs?.filter(r => r.has_charging).length ?? 0;
+    const rangeCount    = vehicle.runs?.filter(r => r.has_range).length    ?? 0;
+    const epaCount      = vehicle.epa_mappings?.length                     ?? 0;
+
+    if (!chargingCount && !rangeCount && !epaCount) return null;
+
+    return (
+        <div className="flex flex-wrap items-center gap-1 mt-2">
+            <span className="text-xs text-gray-500 dark:text-slate-400 mr-0.5">Tests:</span>
+            {chargingCount > 0 && <span className="pill-test-charging">Charging ({chargingCount})</span>}
+            {rangeCount    > 0 && <span className="pill-test-range">Range ({rangeCount})</span>}
+            {epaCount      > 0 && <span className="pill-test-epa">EPA ({epaCount})</span>}
+        </div>
+    );
+}
+
 // Icons for view toggle
 const CardViewIcon = () => (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -763,7 +786,7 @@ export default function VehiclesView({
                                                     {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                                     {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                                 </div>
-                                                <p className="text-sm font-semibold mt-2">Tests: {vehicle.runs?.length || 0}</p>
+                                                <TestCountPills vehicle={vehicle} />
                                                 {vehicle.tags?.length > 0 && (
                                                     <div className="mt-2">
                                                         <TagPills vehicle={vehicle} />
@@ -873,7 +896,7 @@ export default function VehiclesView({
                                         {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                         {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                         {vehicle.power && <p>Power: {vehicle.power} kW</p>}
-                                        <p className="font-medium">Tests: {vehicle.runs?.length || 0}</p>
+                                        <TestCountPills vehicle={vehicle} />
                                     </div>
 
                                     {/* View Tests & Data — dedicated column */}

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -21,8 +21,7 @@ function TestCountPills({ vehicle }) {
     if (!chargingCount && !rangeCount && !epaCount) return null;
 
     return (
-        <div className="flex flex-wrap items-center gap-1 mt-2">
-            <span className="text-xs text-gray-500 dark:text-slate-400 mr-0.5">Tests:</span>
+        <div className="flex flex-wrap items-center gap-1">
             {chargingCount > 0 && <span className="pill-test-charging">Charging ({chargingCount})</span>}
             {rangeCount    > 0 && <span className="pill-test-range">Range ({rangeCount})</span>}
             {epaCount      > 0 && <span className="pill-test-epa">EPA ({epaCount})</span>}
@@ -786,7 +785,6 @@ export default function VehiclesView({
                                                     {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                                     {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                                 </div>
-                                                <TestCountPills vehicle={vehicle} />
                                                 {vehicle.tags?.length > 0 && (
                                                     <div className="mt-2">
                                                         <TagPills vehicle={vehicle} />
@@ -804,9 +802,10 @@ export default function VehiclesView({
                                         <div className="mt-auto pt-3" onClick={e => e.stopPropagation()}>
                                             <button
                                                 onClick={() => onViewRuns(vehicle)}
-                                                className="w-full px-3 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition"
+                                                className="w-full px-3 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition flex flex-col items-start gap-1.5"
                                             >
-                                                View Tests &amp; Data →
+                                                <span>View Tests &amp; Data →</span>
+                                                <TestCountPills vehicle={vehicle} />
                                             </button>
                                         </div>
                                     </div>
@@ -896,15 +895,15 @@ export default function VehiclesView({
                                         {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                         {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                         {vehicle.power && <p>Power: {vehicle.power} kW</p>}
-                                        <TestCountPills vehicle={vehicle} />
                                     </div>
 
                                     {/* View Tests & Data — dedicated column */}
                                     <button
                                         onClick={(e) => { e.stopPropagation(); onViewRuns(vehicle); }}
-                                        className="px-4 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 transition flex-shrink-0"
+                                        className="px-4 py-2 rounded-md text-sm font-medium bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-900/50 transition flex-shrink-0 flex flex-col items-start gap-1.5"
                                     >
-                                        View Tests &amp; Data →
+                                        <span>View Tests &amp; Data →</span>
+                                        <TestCountPills vehicle={vehicle} />
                                     </button>
 
                                     {/* Action column: Visibility → Edit → Copy → Delete */}

--- a/src/index.css
+++ b/src/index.css
@@ -491,6 +491,38 @@ body {
     @apply text-xs px-1.5 py-0.5 rounded-full border;
 }
 
+/* ── Test-count pills (vehicle cards) ──────────────────────────────────────── */
+
+/* Charging: green */
+.pill-test-charging {
+    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-green-100 text-green-700 border-green-200;
+}
+[data-theme="dark"] .pill-test-charging {
+    background-color: rgba(34, 197, 94, 0.15);
+    color: rgb(134, 239, 172);
+    border-color: rgba(34, 197, 94, 0.3);
+}
+
+/* Range: amber/yellow */
+.pill-test-range {
+    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-yellow-100 text-yellow-700 border-yellow-200;
+}
+[data-theme="dark"] .pill-test-range {
+    background-color: rgba(234, 179, 8, 0.15);
+    color: rgb(253, 224, 71);
+    border-color: rgba(234, 179, 8, 0.3);
+}
+
+/* EPA curves: blue */
+.pill-test-epa {
+    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-blue-100 text-blue-700 border-blue-200;
+}
+[data-theme="dark"] .pill-test-epa {
+    background-color: rgba(59, 130, 246, 0.15);
+    color: rgb(147, 197, 253);
+    border-color: rgba(59, 130, 246, 0.3);
+}
+
 
 /* ── Navigation (App.jsx) ───────────────────────────────────────────────────── */
 

--- a/src/index.css
+++ b/src/index.css
@@ -491,39 +491,6 @@ body {
     @apply text-xs px-1.5 py-0.5 rounded-full border;
 }
 
-/* ── Test-count pills (vehicle cards) ──────────────────────────────────────── */
-
-/* Charging: green */
-.pill-test-charging {
-    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-green-100 text-green-700 border-green-200;
-}
-[data-theme="dark"] .pill-test-charging {
-    background-color: rgba(34, 197, 94, 0.15);
-    color: rgb(134, 239, 172);
-    border-color: rgba(34, 197, 94, 0.3);
-}
-
-/* Range: amber/yellow */
-.pill-test-range {
-    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-yellow-100 text-yellow-700 border-yellow-200;
-}
-[data-theme="dark"] .pill-test-range {
-    background-color: rgba(234, 179, 8, 0.15);
-    color: rgb(253, 224, 71);
-    border-color: rgba(234, 179, 8, 0.3);
-}
-
-/* EPA curves: blue */
-.pill-test-epa {
-    @apply px-2 py-0.5 rounded-full text-xs font-medium border bg-blue-100 text-blue-700 border-blue-200;
-}
-[data-theme="dark"] .pill-test-epa {
-    background-color: rgba(59, 130, 246, 0.15);
-    color: rgb(147, 197, 253);
-    border-color: rgba(59, 130, 246, 0.3);
-}
-
-
 /* ── Navigation (App.jsx) ───────────────────────────────────────────────────── */
 
 /* Tab button group in the main nav bar */


### PR DESCRIPTION
Charging (green), Range (amber), EPA (blue) pills show per-type counts. Zero-count categories are omitted. Pills are light/dark-mode aware via [data-theme="dark"] overrides in index.css.