### PR TITLE
Fix trim field missing from vehicle edit form in Tests & Data tab

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -285,7 +285,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     const [showEditSpecs, setShowEditSpecs] = useState(false);
     const [showViewSpecs, setShowViewSpecs] = useState(false);
     const [vehicleFormData, setVehicleFormData] = useState({
-        name: '', make: '', model: '', year: '', battery: '', range: '', manufacturer_id: null,
+        name: '', make: '', model: '', trim: '', year: '', battery: '', range: '', manufacturer_id: null,
     });
     const [vehicleFormTags, setVehicleFormTags] = useState([]);
     const [vehicleNewTagName, setVehicleNewTagName] = useState('');
@@ -296,6 +296,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             name: vehicle.name,
             make: vehicle.make || '',
             model: vehicle.model || '',
+            trim: vehicle.trim || '',
             year: vehicle.year || '',
             battery: vehicle.battery || '',
             range: vehicle.range || '',


### PR DESCRIPTION
openEditVehicle() and its initial state both omitted trim, so the field showed blank and changes were not saved. Matches the pattern already used in VehiclesView.