### PR TITLE
Add RLS violation access logging

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -28,6 +28,24 @@ export function AppProvider({ children }) {
     const showSuccess = (message) => setAppNotification({ message, type: 'success' });
     const clearNotification = () => setAppNotification(null);
 
+    // ── Access logging helpers ────────────────────────────────────────────────
+    const isRlsViolation = (err) =>
+        err?.message?.includes('row-level security') ||
+        err?.code === 'PGRST301' ||
+        err?.code === '42501';
+
+    const logIfUnauthorized = (operation, resourceType, resourceId, err) => {
+        if (isRlsViolation(err)) {
+            dataService.logAccessAttempt({
+                operation,
+                resourceType,
+                resourceId: String(resourceId ?? ''),
+                errorCode:    err.code,
+                errorMessage: err.message,
+            });
+        }
+    };
+
     useEffect(() => {
         initializeApp();
     }, []);
@@ -110,6 +128,7 @@ export function AppProvider({ children }) {
             }
             setVehicles(prev => [...prev, newVehicle]);
         } catch (error) {
+            logIfUnauthorized('add_vehicle', 'vehicle', null, error);
             showError('Error adding vehicle: ' + error.message);
         }
     };
@@ -128,6 +147,7 @@ export function AppProvider({ children }) {
                 return updated;
             }));
         } catch (error) {
+            logIfUnauthorized('update_vehicle', 'vehicle', vehicleId, error);
             showError('Error updating vehicle: ' + error.message);
         }
     };
@@ -140,6 +160,7 @@ export function AppProvider({ children }) {
                 return u ? { ...v, sort_order: u.sort_order } : v;
             }));
         } catch (error) {
+            logIfUnauthorized('reorder_vehicles', 'vehicle', null, error);
             showError('Error reordering vehicles: ' + error.message);
         }
     };
@@ -162,6 +183,7 @@ export function AppProvider({ children }) {
             setVehicles(prev => prev.filter(v => v.id !== vehicleId));
             setSelectedVehicles(prev => prev.filter(id => id !== vehicleId));
         } catch (error) {
+            logIfUnauthorized('delete_vehicle', 'vehicle', vehicleId, error);
             showError('Error deleting vehicle: ' + error.message);
         }
     };
@@ -178,6 +200,7 @@ export function AppProvider({ children }) {
             ));
             showSuccess(`Test copied to ${vehicles.find(v => v.id === targetVehicleId)?.name || 'vehicle'}`);
         } catch (error) {
+            logIfUnauthorized('copy_run', 'run', null, error);
             showError('Error copying test: ' + error.message);
         }
     };
@@ -194,6 +217,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('duplicate_run', 'run', runId, error);
             showError('Error duplicating run: ' + error.message);
         }
     };
@@ -208,6 +232,7 @@ export function AppProvider({ children }) {
             ));
             return vehicleId;
         } catch (error) {
+            logIfUnauthorized('add_run', 'run', null, error);
             showError('Error adding run: ' + error.message);
         }
     };
@@ -241,6 +266,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('update_run', 'run', runId, error);
             showError('Error updating run: ' + error.message);
         }
     };
@@ -254,6 +280,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('clear_default_run', 'run', null, error);
             showError('Error clearing default run: ' + error.message);
         }
     };
@@ -273,6 +300,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('set_default_run', 'run', runId, error);
             showError('Error setting default run: ' + error.message);
         }
     };
@@ -300,6 +328,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('update_run_color', 'run', runId, error);
             showError('Error updating run color: ' + error.message);
         }
     };
@@ -313,6 +342,7 @@ export function AppProvider({ children }) {
                     : v
             ));
         } catch (error) {
+            logIfUnauthorized('delete_run', 'run', runId, error);
             showError('Error deleting run: ' + error.message);
         }
     };
@@ -330,6 +360,7 @@ export function AppProvider({ children }) {
             ));
             return result;
         } catch (error) {
+            logIfUnauthorized('save_run_data', 'run', runId, error);
             showError('Error saving data: ' + error.message);
             throw error;
         }
@@ -350,6 +381,7 @@ export function AppProvider({ children }) {
             }
             return result;
         } catch (error) {
+            logIfUnauthorized('merge_run_data', 'run', runId, error);
             showError('Error updating run data: ' + error.message);
             throw error; // re-throw so the caller knows it failed
         }
@@ -451,6 +483,7 @@ export function AppProvider({ children }) {
             setTags(prev => [...prev, tag].sort((a, b) => a.name.localeCompare(b.name)));
             return tag;
         } catch (error) {
+            logIfUnauthorized('create_tag', 'tag', null, error);
             const message = error.message?.includes('row-level security')
                 ? 'Only vehicle owners can create tags.'
                 : 'Error creating tag: ' + error.message;
@@ -464,6 +497,7 @@ export function AppProvider({ children }) {
             const vehicleTags = tags.filter(t => tagIds.includes(t.id));
             setVehicles(prev => prev.map(v => v.id === vehicleId ? { ...v, tags: vehicleTags } : v));
         } catch (error) {
+            logIfUnauthorized('sync_tags', 'vehicle', vehicleId, error);
             showError('Error updating tags: ' + error.message);
         }
     };
@@ -491,6 +525,7 @@ export function AppProvider({ children }) {
                 return next;
             });
         } catch (error) {
+            logIfUnauthorized('update_specs', 'vehicle', vehicleId, error);
             showError('Error updating specs: ' + error.message);
         }
     };
@@ -511,6 +546,7 @@ export function AppProvider({ children }) {
             // Only update UI after confirmed DB write
             setVehicles(prev => prev.map(v => v.id === vehicleId ? { ...v, visibility: newVisibility } : v));
         } catch (error) {
+            logIfUnauthorized('update_visibility', 'vehicle', vehicleId, error);
             showError('Error updating visibility: ' + error.message);
             // Re-sync from DB so the UI doesn't show stale state
             await initializeApp();
@@ -545,6 +581,7 @@ export function AppProvider({ children }) {
             setManufacturers(prev => [...prev, mfg].sort((a, b) => a.name.localeCompare(b.name)));
             return mfg;
         } catch (error) {
+            logIfUnauthorized('add_manufacturer', 'manufacturer', null, error);
             showError('Error adding manufacturer: ' + error.message);
         }
     };
@@ -563,6 +600,7 @@ export function AppProvider({ children }) {
                 ));
             }
         } catch (error) {
+            logIfUnauthorized('update_manufacturer', 'manufacturer', id, error);
             showError('Error updating manufacturer: ' + error.message);
         }
     };
@@ -572,6 +610,7 @@ export function AppProvider({ children }) {
             await dataService.deleteManufacturer(id);
             setManufacturers(prev => prev.filter(m => m.id !== id));
         } catch (error) {
+            logIfUnauthorized('delete_manufacturer', 'manufacturer', id, error);
             showError('Error deleting manufacturer: ' + error.message);
         }
     };
@@ -585,6 +624,7 @@ export function AppProvider({ children }) {
             await dataService.addSpecLink({ targetVehicleId, sourceRunId, scalingFactor, notes });
             await softRefreshVehicles();
         } catch (error) {
+            logIfUnauthorized('add_spec_link', 'spec_link', null, error);
             showError('Error adding spec link: ' + error.message);
             throw error;
         }
@@ -595,6 +635,7 @@ export function AppProvider({ children }) {
             await dataService.updateSpecLink(linkId, changes, targetVehicleId);
             await softRefreshVehicles();
         } catch (error) {
+            logIfUnauthorized('update_spec_link', 'spec_link', linkId, error);
             showError('Error updating spec link: ' + error.message);
             throw error;
         }
@@ -605,6 +646,7 @@ export function AppProvider({ children }) {
             await dataService.deleteSpecLink(linkId);
             await softRefreshVehicles();
         } catch (error) {
+            logIfUnauthorized('delete_spec_link', 'spec_link', linkId, error);
             showError('Error removing spec link: ' + error.message);
         }
     };

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1186,6 +1186,33 @@ class DataService {
       .eq('test_group_id', testGroupId);
     if (error) throw error;
   }
+
+  // ── Access logging ──────────────────────────────────────────────────────────
+
+  /**
+   * Record an unauthorised access attempt (RLS violation or permission error).
+   * Writes via a SECURITY DEFINER RPC so anonymous callers can always insert.
+   * Errors are silently swallowed — logging must never surface to the user.
+   *
+   * @param {{ operation, resourceType, resourceId, errorCode, errorMessage }} opts
+   */
+  async logAccessAttempt({ operation, resourceType, resourceId, errorCode, errorMessage }) {
+    if (!this.useSupabase) return;
+    try {
+      await getSupabase().rpc('log_access_attempt', {
+        p_user_id:       this.user?.id        ?? null,
+        p_user_email:    this.user?.email      ?? null,
+        p_operation:     operation,
+        p_resource_type: resourceType          ?? null,
+        p_resource_id:   String(resourceId ?? ''),
+        p_error_code:    errorCode             ?? null,
+        p_error_message: errorMessage          ?? null,
+        p_user_agent:    navigator.userAgent,
+      });
+    } catch {
+      // Intentionally swallowed — logging failures are invisible to the user.
+    }
+  }
 }
 
 export const dataService = new DataService();

--- a/supabase/migrations/023_access_logs.sql
+++ b/supabase/migrations/023_access_logs.sql
@@ -1,0 +1,61 @@
+-- ── Access logs ────────────────────────────────────────────────────────────
+-- Captures RLS violations and other unauthorised write attempts so we can
+-- distinguish genuine attacks from UI bugs showing actions to the wrong users.
+--
+-- Rows are written via a SECURITY DEFINER function so anonymous sessions can
+-- record attempts without direct table access. Admins can query via dashboard.
+
+CREATE TABLE IF NOT EXISTS access_logs (
+    id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id       uuid,           -- null = anonymous / unauthenticated
+    user_email    text,           -- denormalised for readability in dashboard
+    operation     text NOT NULL,  -- e.g. 'delete_run', 'update_vehicle'
+    resource_type text,           -- e.g. 'run', 'vehicle', 'tag'
+    resource_id   text,           -- stringified resource id
+    error_code    text,           -- PostgREST / Supabase error code
+    error_message text,           -- raw error message
+    user_agent    text,           -- navigator.userAgent from client
+    created_at    timestamptz DEFAULT now()
+);
+
+ALTER TABLE access_logs ENABLE ROW LEVEL SECURITY;
+
+-- No direct INSERT or SELECT — all writes go through the SECURITY DEFINER fn.
+CREATE POLICY "access_logs: no direct access"
+    ON access_logs USING (false) WITH CHECK (false);
+
+-- Admins can read logs via the dashboard or direct query.
+CREATE POLICY "access_logs: admin read"
+    ON access_logs FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM profiles
+            WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+        )
+    );
+
+-- SECURITY DEFINER so any caller (including anonymous) can write a log row.
+-- The function itself validates nothing sensitive — it just records what happened.
+CREATE OR REPLACE FUNCTION log_access_attempt(
+    p_user_id       uuid,
+    p_user_email    text,
+    p_operation     text,
+    p_resource_type text,
+    p_resource_id   text,
+    p_error_code    text,
+    p_error_message text,
+    p_user_agent    text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO access_logs
+        (user_id, user_email, operation, resource_type, resource_id,
+         error_code, error_message, user_agent)
+    VALUES
+        (p_user_id, p_user_email, p_operation, p_resource_type, p_resource_id,
+         p_error_code, p_error_message, p_user_agent);
+END;
+$$;


### PR DESCRIPTION
## Summary
- New `access_logs` table + `log_access_attempt()` SECURITY DEFINER function (migration 023) captures unauthorized write attempts without exposing the table to direct access
- `DataService.logAccessAttempt()` calls the RPC — fire-and-forget, errors swallowed so logging never surfaces to users
- `logIfUnauthorized` helper in `AppContext` wired into all 24 write-operation catch blocks (vehicles, runs, tags, specs, manufacturers, spec links)

## Test plan
- [x] Apply migration 023 in Supabase SQL editor
- [ ] Sign out; attempt to delete or update a run → confirm a row appears in `access_logs` via Supabase dashboard query; no toast/banner about the log write
- [ ] Sign in as a normal user; attempt to edit another user's vehicle → confirm row logged
- [ ] Normal operations while signed in produce no spurious log rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)