### PR TITLE
UI polish: compact header, button dimming, remove chart headings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -395,55 +395,70 @@ export default function App() {
             )}
             <div className="min-h-screen">
                 {/* ── Header ── */}
-                <header className="relative text-white shadow-lg overflow-hidden">
-                    {/* Full-width base colour — always fills edge to edge.
-                        In dark mode use the page background so the header blends into
-                        the dark navy layout instead of showing a bright blue strip. */}
-                    <div
-                        className="absolute inset-0"
-                        style={{ backgroundColor: isDark ? 'var(--color-background)' : 'var(--color-primary)' }}
-                    />
-                    {/* Image + overlay are both capped to page width (max-w-7xl) so on very
-                        wide monitors the image stays aligned with the content column and more
-                        of it is visible rather than being stretched thin across the viewport */}
-                    {headerImageUrl && (
-                        <div className="absolute inset-0 flex justify-center">
-                            <div className="relative w-full max-w-7xl h-full flex-shrink-0">
-                                <div
-                                    className="absolute inset-0"
-                                    style={{ backgroundImage: `url(${headerImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
-                                />
-                                <div
-                                    className="absolute inset-0"
-                                    style={{ backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(29,78,216,0.72)' }}
-                                />
+                {view === 'vehicles' ? (
+                    /* Full hero — only on the Vehicles tab */
+                    <header className="relative text-white shadow-lg overflow-hidden">
+                        {/* Full-width base colour — always fills edge to edge.
+                            In dark mode use the page background so the header blends into
+                            the dark navy layout instead of showing a bright blue strip. */}
+                        <div
+                            className="absolute inset-0"
+                            style={{ backgroundColor: isDark ? 'var(--color-background)' : 'var(--color-primary)' }}
+                        />
+                        {/* Image + overlay are both capped to page width (max-w-7xl) so on very
+                            wide monitors the image stays aligned with the content column and more
+                            of it is visible rather than being stretched thin across the viewport */}
+                        {headerImageUrl && (
+                            <div className="absolute inset-0 flex justify-center">
+                                <div className="relative w-full max-w-7xl h-full flex-shrink-0">
+                                    <div
+                                        className="absolute inset-0"
+                                        style={{ backgroundImage: `url(${headerImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+                                    />
+                                    <div
+                                        className="absolute inset-0"
+                                        style={{ backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(29,78,216,0.72)' }}
+                                    />
+                                </div>
                             </div>
-                        </div>
-                    )}
-                    <div className="relative page-container py-6">
-                        {/* Clickable title → home */}
-                        <button
-                            onClick={() => navigateTo('vehicles')}
-                            className="text-left group"
-                        >
-                            <h1 className="text-3xl font-bold group-hover:underline decoration-white/60">EVBench</h1>
-                        </button>
-                        <p className="mt-1" style={{color: 'rgba(255,255,255,0.8)'}}>Compare and benchmark electric vehicle performance data</p>
-
-                        {/* Admin-only: change header image */}
-                        {isAdmin && (
-                            <label className="absolute top-3 right-6 cursor-pointer flex items-center gap-1 text-xs text-white/60 hover:text-white/90 transition">
-                                📷 Change header image
-                                <input
-                                    type="file"
-                                    accept="image/*"
-                                    className="hidden"
-                                    onChange={(e) => { e.target.files[0] && uploadHeaderImage(e.target.files[0]); e.target.value = ''; }}
-                                />
-                            </label>
                         )}
-                    </div>
-                </header>
+                        <div className="relative page-container py-6">
+                            {/* Clickable title → home */}
+                            <button
+                                onClick={() => navigateTo('vehicles')}
+                                className="text-left group"
+                            >
+                                <h1 className="text-3xl font-bold group-hover:underline decoration-white/60">EVBench</h1>
+                            </button>
+                            <p className="mt-1" style={{color: 'rgba(255,255,255,0.8)'}}>Compare and benchmark electric vehicle performance data</p>
+
+                            {/* Admin-only: change header image */}
+                            {isAdmin && (
+                                <label className="absolute top-3 right-6 cursor-pointer flex items-center gap-1 text-xs text-white/60 hover:text-white/90 transition">
+                                    📷 Change header image
+                                    <input
+                                        type="file"
+                                        accept="image/*"
+                                        className="hidden"
+                                        onChange={(e) => { e.target.files[0] && uploadHeaderImage(e.target.files[0]); e.target.value = ''; }}
+                                    />
+                                </label>
+                            )}
+                        </div>
+                    </header>
+                ) : (
+                    /* Compact bar — all other tabs */
+                    <header className="app-header-compact">
+                        <div className="page-container flex items-center h-full">
+                            <button
+                                onClick={() => navigateTo('vehicles')}
+                                className="text-lg font-bold text-white hover:underline decoration-white/60"
+                            >
+                                EVBench
+                            </button>
+                        </div>
+                    </header>
+                )}
 
                 <nav className="app-nav">
                     <div className="page-container pt-3 pb-2">

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -570,15 +570,12 @@ export default function ChargeCompareView({
         <div>
             {/* ── Controls card — hidden in presentation/pop-out mode ── */}
             {!presentationMode && <div className="card mb-6">
-                <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-bold">Chart Options — Charge Compare</h3>
-                    {loading && (
-                        <span className="flex items-center gap-2 text-sm text-gray-500">
-                            <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
-                            Loading charging data…
-                        </span>
-                    )}
-                </div>
+                {loading && (
+                    <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+                        <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+                        Loading charging data…
+                    </div>
+                )}
                 <div className="flex flex-wrap items-center gap-6">
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-slate-200">
                         Starting SoC (%):

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -8,6 +8,7 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun } from '../utils/runUtils';
+import LoadingSpinner from './LoadingSpinner';
 
 // ── Interpolation helper ──────────────────────────────────────────────────────
 // Returns the interpolated yField value at targetX, given points sorted by xField.
@@ -570,12 +571,7 @@ export default function ChargeCompareView({
         <div>
             {/* ── Controls card — hidden in presentation/pop-out mode ── */}
             {!presentationMode && <div className="card mb-6">
-                {loading && (
-                    <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
-                        <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
-                        Loading charging data…
-                    </div>
-                )}
+                {loading && <LoadingSpinner message="Loading charging data…" />}
                 <div className="flex flex-wrap items-center gap-6">
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-slate-200">
                         Starting SoC (%):

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -14,6 +14,7 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
+import LoadingSpinner from './LoadingSpinner';
 
 export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, presentationMode = false }) {
     const { units } = useAppContext();
@@ -545,6 +546,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         <div>
             {/* ── Top card: presets, axis selectors, run selector — hidden in presentation mode ── */}
             {!presentationMode && <div className="card mb-6">
+                {loadingData && <LoadingSpinner message="Loading run data…" />}
                 {/* Presets */}
                 <div className="flex flex-wrap gap-2 mb-6">
                     {chartPresets.map(preset => (

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -545,10 +545,6 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         <div>
             {/* ── Top card: presets, axis selectors, run selector — hidden in presentation mode ── */}
             {!presentationMode && <div className="card mb-6">
-                <div className="flex items-center justify-between mb-4">
-                    <h3 className="section-title">Chart Options — Charging Performance</h3>
-                </div>
-
                 {/* Presets */}
                 <div className="flex flex-wrap gap-2 mb-6">
                     {chartPresets.map(preset => (

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -426,16 +426,11 @@ export default function EpaCurvesView({
             {/* ── Chart Options card ────────────────────────────────────────── */}
             {!presentationMode && (
                 <div className="card mb-6">
-                    <div className="flex items-center justify-between mb-4">
-                        <h3 className="section-title">
-                            Chart Options — EPA Efficiency Curves
-                            <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
-                        </h3>
-                    </div>
-
                     {/* Y-axis toggle */}
                     <div className="chart-toggles mb-4">
-                        <span className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>Y axis:</span>
+                        <span className="text-sm font-medium" style={{ color: 'var(--color-text-secondary)' }}>
+                            Y axis: <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
+                        </span>
                         <div className="chart-type-buttons">
                             {Y_MODES.map(m => (
                                 <button

--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -1,0 +1,12 @@
+/**
+ * Small inline spinner used at the top of chart control cards while
+ * async data is loading. Disappears once loading completes.
+ */
+export default function LoadingSpinner({ message = 'Loading…', className = '' }) {
+    return (
+        <div className={`flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400 mb-4 ${className}`}>
+            <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin shrink-0" />
+            {message}
+        </div>
+    );
+}

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -449,21 +449,18 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
         <div>
             {/* ── Config card — hidden in presentation mode ── */}
             {!presentationMode && <div className="card mb-6">
-                <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-bold">Chart Options — Range &amp; Efficiency</h3>
-                    {/* Efficiency unit toggle — relevant for efficiency charts */}
-                    <div className="efficiency-unit-toggle">
-                        {effOptions(units).map(({ value: key, label }) => (
-                            <button
-                                key={key}
-                                type="button"
-                                onClick={() => setEffUnit(key)}
-                                className={`px-3 py-1 rounded text-sm font-medium transition-colors ${effUnit === key ? 'bg-white shadow text-gray-900' : 'text-gray-500 dark:text-slate-300 hover:text-gray-700 dark:hover:text-slate-100'}`}
-                            >
-                                {label}
-                            </button>
-                        ))}
-                    </div>
+                {/* Efficiency unit toggle */}
+                <div className="efficiency-unit-toggle mb-4">
+                    {effOptions(units).map(({ value: key, label }) => (
+                        <button
+                            key={key}
+                            type="button"
+                            onClick={() => setEffUnit(key)}
+                            className={`px-3 py-1 rounded text-sm font-medium transition-colors ${effUnit === key ? 'bg-white shadow text-gray-900' : 'text-gray-500 dark:text-slate-300 hover:text-gray-700 dark:hover:text-slate-100'}`}
+                        >
+                            {label}
+                        </button>
+                    ))}
                 </div>
 
                 {/* Chart type buttons */}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -14,6 +14,7 @@ import {
     segmentsToChartPointsByTest,
     formatTime, speedCorrectionFactor,
 } from '../utils/roadTripSimulation';
+import LoadingSpinner from './LoadingSpinner';
 
 Chart.register(ZoomPlugin);
 
@@ -1231,6 +1232,7 @@ export default function RoadTripView({
             {/* ── Controls ─────────────────────────────────────────────── */}
             {!presentationMode && (
                 <div className="card mb-6">
+                    {loading && <LoadingSpinner message="Loading charging data…" />}
                     {/* Toggles row */}
                     <div className="flex flex-wrap gap-6 mb-4">
                         <div>

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1231,8 +1231,6 @@ export default function RoadTripView({
             {/* ── Controls ─────────────────────────────────────────────── */}
             {!presentationMode && (
                 <div className="card mb-6">
-                    <h3 className="text-lg font-bold mb-4">Road Trip Settings</h3>
-
                     {/* Toggles row */}
                     <div className="flex flex-wrap gap-6 mb-4">
                         <div>

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -1889,12 +1889,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         {/* Set Default — ghost text, green on hover, pale blue + × when active */}
                                         <button
                                             onClick={() => run.isDefault ? clearDefaultRun(vehicle.id) : onSetDefaultRun(run.id)}
-                                            title={run.isDefault ? 'Click to clear default' : 'Set as default for charts'}
+                                            title={!canCreate ? 'Sign in to save changes' : run.isDefault ? 'Click to clear default' : 'Set as default for charts'}
                                             className={`text-sm px-2 py-1 rounded transition-colors ${
                                                 run.isDefault
                                                     ? 'bg-blue-100 text-blue-700 hover:bg-red-50 hover:text-red-600 border border-blue-200 hover:border-red-200'
                                                     : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
-                                            }`}
+                                            }${!canCreate ? ' opacity-50 cursor-not-allowed' : ''}`}
                                         >
                                             {run.isDefault
                                                 ? <>Default <span className="text-red-500 font-bold">×</span></>
@@ -1905,7 +1905,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         )}
                                         <button
                                             onClick={() => isPending ? restoreItem(run.id) : queueDelete(run.id)}
-                                            className={`btn text-sm ${isPending ? 'bg-orange-100 text-orange-700 hover:bg-orange-200 border-0' : 'btn-danger'}`}
+                                            title={!canCreate && !isPending ? 'Sign in to save changes' : undefined}
+                                            className={`btn text-sm ${isPending ? 'bg-orange-100 text-orange-700 hover:bg-orange-200 border-0' : 'btn-danger'}${!canCreate && !isPending ? ' opacity-50 cursor-not-allowed' : ''}`}
                                         >
                                             {isPending ? '↩ Restore' : 'Delete'}
                                         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -302,6 +302,22 @@ body {
 }
 
 
+/* ── Compact header (non-Vehicles tabs) ─────────────────────────────────────── */
+
+.app-header-compact {
+    height: 48px;
+    background-color: var(--color-primary);
+    display: flex;
+    align-items: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .app-header-compact {
+    background-color: var(--color-background);
+    border-bottom: 1px solid var(--color-border);
+    box-shadow: none;
+}
+
 /* ── App navigation bar ─────────────────────────────────────────────────────── */
 
 .app-nav {


### PR DESCRIPTION
## Summary
- **Compact header on non-Vehicles tabs** — full hero (title + tagline + background image) only shows on the Vehicles tab; Tests & Data, Charts, Compare Specs, and Admin get a slim 48 px bar with just the EVBench title that links back home. Dark mode: bar uses `--color-background` with a bottom border to blend naturally.
- **Unauthenticated button dimming** — Set Default and Delete run buttons are `opacity-50 cursor-not-allowed` with a "Sign in to save changes" tooltip when not signed in. Buttons stay clickable so any attempt is captured by the access logger.
- **Chart card headings removed** — `<h3>` "Chart Options —" headings removed from ChargingView, RangeChartView, RoadTripView, and EpaCurvesView. In EpaCurvesView the InfoIcon was relocated to the Y-axis toggle row so context is preserved.

## Test plan
- [ ] Vehicles tab: full hero with image/tagline visible
- [ ] Navigate to Charts / Tests & Data / Compare Specs / Admin: confirm compact 48 px bar; click EVBench title → returns to Vehicles
- [ ] Dark mode: compact bar uses dark background with border (not blue)
- [ ] Sign out: Set Default + Delete buttons appear dimmed with tooltip; sign in → full opacity restored
- [ ] Open each chart tab: confirm no "Chart Options —" heading above the controls card; EpaCurvesView InfoIcon appears next to "Y axis:" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)