### PR TITLE
EPA Curves: Wh/mi axis, dashed legend, nearest tooltip

### DIFF
--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -126,6 +126,7 @@ function makeCalloutPlugin(calloutMphs, yAxis, units, isDark) {
 
 const Y_MODES = [
     { key: 'kwh100mi', label: 'kWh/100mi' },
+    { key: 'wh_mi',    label: 'Wh/mi'     },
     { key: 'mi_kwh',   label: 'mi/kWh'    },
     { key: 'mpge',     label: 'MPGe'       },
     { key: 'range_mi', label: 'Range (mi)' },
@@ -134,6 +135,7 @@ const Y_MODES = [
 function getYValue(point, yAxis) {
     switch (yAxis) {
         case 'kwh100mi': return point.kwh100mi;
+        case 'wh_mi':    return point.kwh100mi != null ? point.kwh100mi * 10 : null;
         case 'mi_kwh':   return point.miPerKwh;
         case 'mpge':     return point.mpge;
         case 'range_mi': return point.rangeMi;
@@ -145,9 +147,11 @@ function yAxisLabel(yAxis, units) {
     if (yAxis === 'range_mi') return `Range (${distanceLabel(units)})`;
     if (units === 'metric') {
         if (yAxis === 'kwh100mi') return 'kWh/100km';
+        if (yAxis === 'wh_mi')    return 'Wh/km';
         if (yAxis === 'mi_kwh')   return 'km/kWh';
     }
     if (yAxis === 'kwh100mi') return 'kWh/100mi';
+    if (yAxis === 'wh_mi')    return 'Wh/mi';
     if (yAxis === 'mi_kwh')   return 'mi/kWh';
     if (yAxis === 'mpge')     return 'MPGe';
     return '';
@@ -157,6 +161,7 @@ function convertYValue(val, yAxis, units) {
     if (val == null) return null;
     if (units !== 'metric') return val;
     if (yAxis === 'kwh100mi') return val / 1.60934;
+    if (yAxis === 'wh_mi')    return val / 1.60934; // Wh/mi → Wh/km
     if (yAxis === 'mi_kwh')   return val * 1.60934;
     if (yAxis === 'range_mi') return val * 1.60934;
     return val;
@@ -340,7 +345,25 @@ export default function EpaCurvesView({
                 plugins: {
                     legend: {
                         display: datasets.length > 1,
-                        labels: { color: legendColor, usePointStyle: true, pointStyleWidth: 16 },
+                        labels: {
+                            color: legendColor,
+                            // Draw a short dashed line matching each dataset's line style
+                            // rather than the default filled circle.
+                            generateLabels(chart) {
+                                return chart.data.datasets.map((ds, i) => ({
+                                    text:        ds.label,
+                                    fillStyle:   'transparent',
+                                    strokeStyle: ds.borderColor,
+                                    lineWidth:   ds.borderWidth ?? 2,
+                                    lineDash:    ds.borderDash  ?? [],
+                                    hidden:      !chart.isDatasetVisible(i),
+                                    datasetIndex: i,
+                                }));
+                            },
+                            usePointStyle: false,
+                            boxWidth: 24,
+                            boxHeight: 2,
+                        },
                     },
                     tooltip: {
                         callbacks: {
@@ -364,6 +387,11 @@ export default function EpaCurvesView({
                                     valStr = pt.kwh100mi != null
                                         ? `${(units === 'metric' ? pt.kwh100mi / 1.60934 : pt.kwh100mi).toFixed(1)} ${units === 'metric' ? 'kWh/100km' : 'kWh/100mi'}`
                                         : '—';
+                                } else if (yAxis === 'wh_mi') {
+                                    const wh = pt.kwh100mi != null ? pt.kwh100mi * 10 : null;
+                                    valStr = wh != null
+                                        ? `${(units === 'metric' ? wh / 1.60934 : wh).toFixed(1)} ${units === 'metric' ? 'Wh/km' : 'Wh/mi'}`
+                                        : '—';
                                 } else if (yAxis === 'mi_kwh') {
                                     valStr = pt.miPerKwh != null
                                         ? `${(units === 'metric' ? pt.miPerKwh * 1.60934 : pt.miPerKwh).toFixed(2)} ${units === 'metric' ? 'km/kWh' : 'mi/kWh'}`
@@ -378,7 +406,7 @@ export default function EpaCurvesView({
                                 return `${ds.label}: ${valStr}`;
                             },
                         },
-                        mode: 'index',
+                        mode: 'nearest',
                         intersect: false,
                     },
                 },

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -352,6 +352,7 @@ export default function EpaCurvesView({
                             generateLabels(chart) {
                                 return chart.data.datasets.map((ds, i) => ({
                                     text:        ds.label,
+                                    fontColor:   legendColor,
                                     fillStyle:   'transparent',
                                     strokeStyle: ds.borderColor,
                                     lineWidth:   ds.borderWidth ?? 2,


### PR DESCRIPTION
## Summary

- **Wh/mi Y-axis option** — added to the axis selector alongside mi/kWh and kWh/100mi; automatically converts to Wh/km in metric mode
- **Dashed-line legend** — replaced the default filled circles with line indicators that mirror each series' dash style (solid for 55 mph, dashed for 70 mph, etc.)
- **Nearest-only tooltip** — tooltip now shows only the single closest series to the cursor instead of all series stacked, making it much easier to read individual curve values

## Test plan

- [ ] Open EPA Curves tab with ≥1 vehicle that has EPA data
- [ ] Switch Y-axis to Wh/mi — confirm axis label and values update; switch units to metric, confirm Wh/km
- [ ] Inspect legend — entries should show short dashed/solid line indicators, not filled circles
- [ ] Hover over the chart — tooltip should show only the nearest curve's label and value

🤖 Generated with [Claude Code](https://claude.com/claude-code)