### PR TITLE
EPA curator refactor PR A: hierarchical schema + service CRUD

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -828,6 +828,83 @@ export function AppProvider({ children }) {
         await dataService.updateEpaLabelMethod(testGroupId, method);
     };
 
+    // ── EPA curator hierarchy (coefficient sets, tests, phases, audit) ──────────
+    // Used by the curator form in Tests & Data. Save helpers return the saved row
+    // so the form can update local state; the form re-fetches the full hierarchy
+    // via getEpaTestGroupFull as needed.
+
+    /** Pass-through: fetch a group with its coefficient sets, tests and phases. */
+    const getEpaTestGroupFull = (testGroupId) => dataService.getEpaTestGroupFull(testGroupId);
+
+    const saveEpaCoefficientSet = async (row) => {
+        try {
+            const saved = await dataService.saveEpaCoefficientSet(row);
+            softRefreshVehicles(); // primary coeffs feed the curve
+            return saved;
+        } catch (error) {
+            showError('Error saving coefficient set: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deleteEpaCoefficientSet = async (id) => {
+        try {
+            await dataService.deleteEpaCoefficientSet(id);
+            softRefreshVehicles();
+        } catch (error) {
+            showError('Error deleting coefficient set: ' + error.message);
+            throw error;
+        }
+    };
+
+    const saveEpaTest = async (row) => {
+        try {
+            const saved = await dataService.saveEpaTest(row);
+            softRefreshVehicles(); // tests feed η / charger-eff derivations
+            return saved;
+        } catch (error) {
+            showError('Error saving test: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deleteEpaTest = async (id) => {
+        try {
+            await dataService.deleteEpaTest(id);
+            softRefreshVehicles();
+        } catch (error) {
+            showError('Error deleting test: ' + error.message);
+            throw error;
+        }
+    };
+
+    const saveEpaPhase = async (row) => {
+        try {
+            const saved = await dataService.saveEpaPhase(row);
+            softRefreshVehicles(); // HWY-phase consumption drives η
+            return saved;
+        } catch (error) {
+            showError('Error saving phase: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deleteEpaPhase = async (id) => {
+        try {
+            await dataService.deleteEpaPhase(id);
+            softRefreshVehicles();
+        } catch (error) {
+            showError('Error deleting phase: ' + error.message);
+            throw error;
+        }
+    };
+
+    /** Append an audit-trail entry. Best-effort: failures don't block the edit. */
+    const logEpaFieldEdit = (entry) => dataService.logEpaFieldEdit(entry);
+
+    /** Pass-through: read the audit trail for a row. */
+    const getEpaFieldAudit = (tableName, rowId) => dataService.getEpaFieldAudit(tableName, rowId);
+
     /** Delete an EPA test group and its vehicle mappings, then refresh vehicles. */
     const deleteEpaTestGroup = async (testGroupId) => {
         try {
@@ -965,6 +1042,16 @@ export function AppProvider({ children }) {
         deleteEpaTestGroup,
         updateEpaLabelMethod,
         updateEpaTestGroup,
+        // EPA curator hierarchy
+        getEpaTestGroupFull,
+        saveEpaCoefficientSet,
+        deleteEpaCoefficientSet,
+        saveEpaTest,
+        deleteEpaTest,
+        saveEpaPhase,
+        deleteEpaPhase,
+        logEpaFieldEdit,
+        getEpaFieldAudit,
     };
 
     return (

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1188,6 +1188,135 @@ class DataService {
     if (error) throw error;
   }
 
+  // ── EPA curator model: coefficient sets, tests, phases, audit ─────────────────
+
+  /**
+   * Fetch a single EPA test group with its full curator hierarchy:
+   * coefficient sets, tests, and each test's phases. Used by the curator
+   * form in Tests & Data.
+   *
+   * @param {string} testGroupId
+   * @returns {Object|null} group row with nested epa_coefficient_sets and
+   *   epa_tests(epa_test_phases), or null if not found.
+   */
+  async getEpaTestGroupFull(testGroupId) {
+    if (!this.useSupabase) return null;
+    const { data, error } = await getSupabase()
+      .from('epa_test_groups')
+      .select(`
+        *,
+        epa_coefficient_sets(*),
+        epa_tests(*, epa_test_phases(*))
+      `)
+      .eq('test_group_id', testGroupId)
+      .single();
+    if (error) throw error;
+    return data || null;
+  }
+
+  /**
+   * Insert (no id) or update (with id) a single coefficient set.
+   * Returns the saved row.
+   */
+  async saveEpaCoefficientSet(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('epa_coefficient_sets');
+    const { id, ...fields } = row;
+    const q = id
+      ? db.update(fields).eq('id', id)
+      : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deleteEpaCoefficientSet(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_coefficient_sets').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /** Insert (no id) or update (with id) a single test record. Returns the saved row. */
+  async saveEpaTest(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('epa_tests');
+    const { id, epa_test_phases, ...fields } = row; // never write nested phases here
+    const q = id
+      ? db.update(fields).eq('id', id)
+      : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deleteEpaTest(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_tests').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /** Insert (no id) or update (with id) a single phase row. Returns the saved row. */
+  async saveEpaPhase(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('epa_test_phases');
+    const { id, ...fields } = row;
+    const q = id
+      ? db.update(fields).eq('id', id)
+      : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deleteEpaPhase(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_test_phases').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /**
+   * Append a row to the field-edit audit trail. Records who/when/prior/new
+   * plus an optional source citation. Insert-only (immutable history).
+   *
+   * @param {{ tableName, rowId, field, priorValue, newValue, sourceCitation }} entry
+   */
+  async logEpaFieldEdit({ tableName, rowId, field, priorValue, newValue, sourceCitation }) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('epa_field_audit')
+      .insert({
+        table_name:      tableName,
+        row_id:          String(rowId),
+        field,
+        prior_value:     priorValue != null ? String(priorValue) : null,
+        new_value:       newValue != null ? String(newValue) : null,
+        source_citation: sourceCitation || null,
+        edited_by:       this.user?.id ?? null,
+      });
+    if (error) throw error;
+  }
+
+  /**
+   * Read the audit trail for a single row (most recent first).
+   *
+   * @param {string} tableName
+   * @param {string|number} rowId
+   */
+  async getEpaFieldAudit(tableName, rowId) {
+    if (!this.useSupabase) return [];
+    const { data, error } = await getSupabase()
+      .from('epa_field_audit')
+      .select('*')
+      .eq('table_name', tableName)
+      .eq('row_id', String(rowId))
+      .order('edited_at', { ascending: false });
+    if (error) throw error;
+    return data || [];
+  }
+
   // ── Access logging ──────────────────────────────────────────────────────────
 
   /**

--- a/supabase/migrations/026_epa_curator_groups.sql
+++ b/supabase/migrations/026_epa_curator_groups.sql
@@ -1,0 +1,72 @@
+-- ============================================================
+-- Migration 026: EPA curator refactor — Part 1 (epa_test_groups)
+--
+-- Reshapes epa_test_groups for the curator model described in
+-- LocalDev/curator-fields-spec.md. ADDITIVE ONLY — no columns are
+-- dropped here so the existing getVehicles() select stays valid
+-- through the refactor. Dead columns (per-cycle *_kwh_100mi,
+-- label_method*, drivetrain_eta_override, old range_*/label_* variants,
+-- target/set coeffs once moved) are removed in a later cleanup
+-- migration after the UI stops referencing them.
+--
+-- FRESH START: existing EPA rows are truncated. The old per-cycle data
+-- is AC-adjusted (label basis) and cannot seed the new DC-based η
+-- derivation, so re-curation under the new model starts clean.
+--
+-- Curator role: writes open to admin + contributor (was admin-only).
+-- ============================================================
+
+-- ── Fresh start: clear EPA data (mappings cascade off test_groups) ──────────────
+TRUNCATE TABLE epa_test_groups CASCADE;
+
+-- ── New config-level columns (Spec Sections 1, 6, 7) ────────────────────────────
+
+ALTER TABLE epa_test_groups
+    -- Section 1: Identity & Configuration
+    ADD COLUMN IF NOT EXISTS evap_family            text,    -- Certified Evaporative Family (blank ⇒ BEV)
+    ADD COLUMN IF NOT EXISTS vehicle_config_number  text,    -- Vehicle ID / Configuration Number
+    -- Section 6: Range & Label Values
+    ADD COLUMN IF NOT EXISTS cd_range_combined_calc numeric(8,2),  -- CD Range Combined (calc, unadjusted)
+    ADD COLUMN IF NOT EXISTS cd_range_hwy_calc      numeric(8,2),  -- CD Range Highway (calc, unadjusted)
+    ADD COLUMN IF NOT EXISTS label_range_published  numeric(8,2),  -- window-sticker range (adjusted)
+    ADD COLUMN IF NOT EXISTS derived_5cycle_coefficient numeric(8,4), -- blank ⇒ default 0.7 used
+    -- Section 7: Battery & Powertrain Assumptions
+    ADD COLUMN IF NOT EXISTS total_voltage              numeric(8,2),  -- Total Voltage of Battery Packs
+    ADD COLUMN IF NOT EXISTS battery_specific_energy    numeric(8,2),  -- Wh/kg fallback for capacity
+    ADD COLUMN IF NOT EXISTS accessory_load_w_override  numeric(8,2),  -- default 300 W in derivation
+    ADD COLUMN IF NOT EXISTS charger_efficiency_override numeric(4,3)
+        CHECK (charger_efficiency_override IS NULL
+               OR (charger_efficiency_override > 0 AND charger_efficiency_override <= 1)),
+    -- Cross-cutting: which fields are curator-overridden vs CSV-imported.
+    -- Shape: { "<field>": { "source": "csv|manual", "at": "<iso>", "by": "<uuid>" } }
+    ADD COLUMN IF NOT EXISTS overrides jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN epa_test_groups.make IS
+    'Certificate Manufacturer Name (EPA). Column name kept as make for app compatibility.';
+COMMENT ON COLUMN epa_test_groups.epa_carline_name IS
+    'Represented Test Vehicle Model (EPA) — preserved verbatim.';
+COMMENT ON COLUMN epa_test_groups.overrides IS
+    'Per-field provenance: which columns were curator-edited vs CSV-imported. Drives the override flag in the curator form.';
+
+-- ── Relax identity NOT NULLs for partial/pre-spreadsheet curator entry ──────────
+ALTER TABLE epa_test_groups ALTER COLUMN model_year       DROP NOT NULL;
+ALTER TABLE epa_test_groups ALTER COLUMN make             DROP NOT NULL;
+ALTER TABLE epa_test_groups ALTER COLUMN epa_carline_name DROP NOT NULL;
+
+-- ── RLS: open writes to admin + contributor (curator role) ──────────────────────
+DROP POLICY IF EXISTS "Admins insert epa_test_groups" ON epa_test_groups;
+DROP POLICY IF EXISTS "Admins update epa_test_groups" ON epa_test_groups;
+DROP POLICY IF EXISTS "Admins delete epa_test_groups" ON epa_test_groups;
+
+CREATE POLICY "Curators insert epa_test_groups"
+    ON epa_test_groups FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update epa_test_groups"
+    ON epa_test_groups FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+-- Deletes remain admin-only to protect shared reference data.
+CREATE POLICY "Admins delete epa_test_groups"
+    ON epa_test_groups FOR DELETE
+    USING (current_user_role() = 'admin');

--- a/supabase/migrations/027_epa_coefficient_sets.sql
+++ b/supabase/migrations/027_epa_coefficient_sets.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- Migration 027: EPA curator refactor — Part 2 (coefficient sets)
+--
+-- Spec Section 2 (Road Load & Weight). A configuration can carry more
+-- than one coefficient set, distinguished by Coefficient Category
+-- (City/Highway, Cold CO, US06, Evap). City/Highway is the primary set
+-- used by the steady-state curve; others are kept for context and
+-- specialised derivations (e.g. Cold-CO notes).
+--
+-- Coefficients live here rather than on epa_test_groups so the category
+-- dimension is first-class. (The legacy target/set columns remain on
+-- epa_test_groups until the post-PR-E cleanup migration.)
+-- ============================================================
+
+CREATE TABLE epa_coefficient_sets (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    test_group_id   text NOT NULL
+                        REFERENCES epa_test_groups(test_group_id) ON DELETE CASCADE,
+
+    -- Which coefficient set this is. Cold-CO coefficients run higher to
+    -- account for cold-soak tire stiffness; US06 covers aggressive transients.
+    category        text NOT NULL DEFAULT 'City/Highway'
+                        CHECK (category IN ('City/Highway','Cold CO','US06','Evap')),
+    -- Exactly one set per group is the primary (drives the curve).
+    is_primary      boolean NOT NULL DEFAULT false,
+
+    -- Curb weight + 300 lb, rounded — dyno inertia simulator value.
+    equiv_test_weight_lbs numeric(10,2),
+
+    -- EPA standard units: A [lbf], B [lbf/mph], C [lbf/mph²].
+    target_a        numeric(10,4),   -- EPA-accepted (coastdown) — default for calcs
+    target_b        numeric(10,6),
+    target_c        numeric(10,8),
+    set_a           numeric(10,4),   -- what was actually programmed on the dyno
+    set_b           numeric(10,6),
+    set_c           numeric(10,8),
+
+    overrides       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at      timestamptz DEFAULT now(),
+
+    UNIQUE (test_group_id, category)
+);
+
+CREATE INDEX idx_epa_coeff_sets_group ON epa_coefficient_sets(test_group_id);
+
+-- At most one primary coefficient set per test group.
+CREATE UNIQUE INDEX idx_epa_coeff_sets_one_primary
+    ON epa_coefficient_sets(test_group_id)
+    WHERE is_primary;
+
+ALTER TABLE epa_coefficient_sets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read epa_coefficient_sets"
+    ON epa_coefficient_sets FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert epa_coefficient_sets"
+    ON epa_coefficient_sets FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update epa_coefficient_sets"
+    ON epa_coefficient_sets FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete epa_coefficient_sets"
+    ON epa_coefficient_sets FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/028_epa_tests_phases.sql
+++ b/supabase/migrations/028_epa_tests_phases.sql
@@ -1,0 +1,86 @@
+-- ============================================================
+-- Migration 028: EPA curator refactor — Part 3 (tests + phases)
+--
+-- Spec Sections 3–5. A configuration can have multiple tests (one per
+-- procedure run); each test has a variable number of phases.
+--
+--   Procedure precedence for derivations: 77 (MCT) preferred,
+--   84 (Charge Depleting Highway) fallback, 81 (CD UDDS) stored but
+--   excluded from efficiency derivation.
+--
+-- Phase DC energy / AC recharge / test numbers are NOT in the quarterly
+-- Test Car List CSV — they come from J1634 sheets / CSI PDFs and are
+-- entered by the curator. Hence everything here is nullable.
+-- ============================================================
+
+-- ── epa_tests (Section 3 record + Section 5 energy totals) ──────────────────────
+CREATE TABLE epa_tests (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    test_group_id   text NOT NULL
+                        REFERENCES epa_test_groups(test_group_id) ON DELETE CASCADE,
+
+    -- Section 3: Per-Test Record
+    test_number     text,          -- EPA test identifier (e.g. VRIV10093452)
+    procedure_code  integer,       -- 77 MCT | 84 CD-Hwy | 81 CD-UDDS | 2 FTP-75
+    originator      text CHECK (originator IS NULL OR originator IN ('MFR','EPA')),
+    lab_id          text,          -- physical lab (FEV Michigan, EPA Ann Arbor, …)
+    test_date       date,
+    source          text CHECK (source IS NULL
+                        OR source IN ('csv','j1634','csi_pdf','manual')),
+
+    -- Section 5: Test-Level Energy Totals
+    total_dc_energy_kwh   numeric(10,4),  -- total battery-side energy to depletion (incl. SS)
+    ac_recharge_kwh       numeric(10,4),  -- AC-side refill energy (nullable; for charger eff)
+    bags_phases_conducted integer,        -- expected phase count for verification
+    total_distance_mi     numeric(10,3),
+    recharge_voltage      numeric(8,2),
+
+    overrides       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at      timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_epa_tests_group ON epa_tests(test_group_id);
+
+-- ── epa_test_phases (Section 4 — child list per test) ───────────────────────────
+CREATE TABLE epa_test_phases (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    test_id         bigint NOT NULL REFERENCES epa_tests(id) ON DELETE CASCADE,
+
+    phase_index     integer NOT NULL,   -- position in the test sequence
+    -- Identity comes from procedure order, NOT inferred from values.
+    -- SS = steady-state depletion at a lab-chosen speed: stored for energy
+    -- totals but NOT a valid efficiency anchor (speed not standardized).
+    phase_type      text CHECK (phase_type IS NULL OR phase_type IN
+                        ('UDDS','HWY','SS','Cold-UDDS','US06','SC03')),
+    dc_energy_kwh   numeric(10,4),       -- Integrated DC KW-HRS (battery-side)
+    distance_mi     numeric(10,3),       -- Actual Distance Driven (miles)
+    -- dc_consumption (Wh/mi) is DERIVED at read time, never stored.
+
+    overrides       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at      timestamptz DEFAULT now(),
+
+    UNIQUE (test_id, phase_index)
+);
+
+CREATE INDEX idx_epa_phases_test ON epa_test_phases(test_id);
+
+-- ── RLS (both tables): public read, admin+contributor write ─────────────────────
+ALTER TABLE epa_tests       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE epa_test_phases ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read epa_tests"       ON epa_tests       FOR SELECT USING (true);
+CREATE POLICY "Public read epa_test_phases" ON epa_test_phases FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert epa_tests" ON epa_tests FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+CREATE POLICY "Curators update epa_tests" ON epa_tests FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+CREATE POLICY "Curators delete epa_tests" ON epa_tests FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators insert epa_test_phases" ON epa_test_phases FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+CREATE POLICY "Curators update epa_test_phases" ON epa_test_phases FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+CREATE POLICY "Curators delete epa_test_phases" ON epa_test_phases FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/029_epa_field_audit.sql
+++ b/supabase/migrations/029_epa_field_audit.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- Migration 029: EPA curator refactor — Part 4 (audit trail)
+--
+-- Cross-cutting requirement: every imported field is editable, with an
+-- audit trail (who, when, prior value, source citation). This is the
+-- history log; the current override state lives in each table's
+-- `overrides` jsonb column for fast rendering.
+--
+-- Polymorphic: row_id is text so it covers epa_test_groups (text PK)
+-- and the bigint-keyed children (stringified). Records are immutable —
+-- insert-only, no update/delete.
+-- ============================================================
+
+CREATE TABLE epa_field_audit (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    table_name      text NOT NULL,   -- 'epa_test_groups' | 'epa_coefficient_sets' | 'epa_tests' | 'epa_test_phases'
+    row_id          text NOT NULL,   -- stringified PK of the edited row
+    field           text NOT NULL,
+    prior_value     text,
+    new_value       text,
+    source_citation text,            -- where the new value came from (sheet, PDF page, …)
+    edited_by       uuid REFERENCES auth.users(id),
+    edited_at       timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_epa_audit_row ON epa_field_audit(table_name, row_id);
+CREATE INDEX idx_epa_audit_edited_at ON epa_field_audit(edited_at DESC);
+
+ALTER TABLE epa_field_audit ENABLE ROW LEVEL SECURITY;
+
+-- Curators can read the trail and append to it. No updates or deletes
+-- (immutable history) — absence of those policies denies them under RLS.
+CREATE POLICY "Curators read epa_field_audit"
+    ON epa_field_audit FOR SELECT
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators insert epa_field_audit"
+    ON epa_field_audit FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));


### PR DESCRIPTION
First PR of the EPA curator refactor (full plan: `LocalDev/epa-curator-refactor-plan.md`, gitignored). Replaces the flat, import-only `epa_test_groups` table with the hierarchical, curator-editable model from the spec. **Additive only** — no columns dropped yet, so existing reads keep working through PRs A–E.

## Schema (migrations 026–029)
- **026** — add Section 1/6/7 config columns to `epa_test_groups` (`evap_family`, `vehicle_config_number`, CD/label range fields, battery/powertrain overrides, `overrides jsonb`); relax identity `NOT NULL`s for partial curator entry; **fresh-start `TRUNCATE`** (old AC-adjusted rows can't seed DC-based η); open writes to **admin + contributor**.
- **027** — `epa_coefficient_sets` (Section 2): per-category coeffs (City/Highway, Cold CO, US06, Evap), one-primary-per-group constraint.
- **028** — `epa_tests` (Sections 3+5) and `epa_test_phases` (Section 4).
- **029** — `epa_field_audit`: immutable who/when/prior/source trail.

## Service / context
- `DataService`: `getEpaTestGroupFull` (nested fetch), `save/delete` for coefficient sets / tests / phases, `logEpaFieldEdit` + `getEpaFieldAudit`.
- `AppContext`: thin wrappers (soft-refresh + error toasts), exported.

## Not in this PR
- No UI (curator form is PR E, in Tests & Data).
- The η bug fix (DC-side back-solve) lands in **PR B** (`epaDerivations.js`).

## ⚠️ Deploy note
Migrations 026–029 must be applied in the Supabase SQL editor. **026 truncates EPA data** — intended (fresh start, re-curate). Verify build: `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)