### PR TITLE
EPA curator refactor PR E: curator form in Tests & Data + read-fixes

### DIFF
--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -15,7 +15,7 @@ const roleBadgeStyle = {
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
     const {
         exportData, importData, importTableauSessions,
-        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod, updateEpaTestGroup,
+        importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaTestGroup,
         vehicles,
     } = useAppContext();
     const [users, setUsers]           = useState([]);
@@ -190,7 +190,6 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
             <EpaDataCard
                 getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
                 deleteEpaTestGroup={deleteEpaTestGroup}
-                updateEpaLabelMethod={updateEpaLabelMethod}
                 updateEpaTestGroup={updateEpaTestGroup}
             />
         </div>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -573,12 +573,13 @@ export default function EpaCurvesView({
                                                                         <span className="text-sm text-gray-500 dark:text-slate-400 ml-2">{epaGroup.model_year} · {epaGroup.test_group_id}</span>
                                                                         <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs" style={{ color: 'var(--color-text-muted)' }}>
                                                                             <ConfidenceBadge confidence={confidence} />
-                                                                            {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 && (
-                                                                                <span>
-                                                                                    EPA rated: {epaGroup.label_combined_mpge} MPGe
-                                                                                    {epaGroup.label_method && <> · {epaGroup.label_method}<InfoIcon text={EPA_EXPLAINERS.labelMethod} /></>}
+                                                                            {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 ? (
+                                                                                <span>EPA rated: {epaGroup.label_combined_mpge} MPGe</span>
+                                                                            ) : epaGroup.label_hwy_mpge && epaGroup.label_hwy_mpge < 500 ? (
+                                                                                <span title="Highway-only (proc 84); no combined MCT test">
+                                                                                    EPA hwy: {epaGroup.label_hwy_mpge} MPGe
                                                                                 </span>
-                                                                            )}
+                                                                            ) : null}
                                                                             {eta != null && (
                                                                                 <span>
                                                                                     η<sub>eff</sub>: {!etaResult.certain && '~'}{(eta * 100).toFixed(1)}%

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -20,20 +20,11 @@ const CONFIDENCE_COLORS = {
 };
 
 // Short labels keep the select narrow; full names shown in title tooltip
-const LABEL_METHOD_OPTIONS = [
-    { value: '',                 label: '—',        title: 'Unknown / not set'    },
-    { value: '2-cycle',          label: '2-cycle',  title: '2-cycle (city + hwy)' },
-    { value: '5-cycle',          label: '5-cycle',  title: '5-cycle adjusted'     },
-    { value: 'vehicle-specific', label: 'Veh-spec', title: 'Vehicle-specific test' },
-    { value: 'mpg-based',        label: 'MPG',      title: 'MPG-based (PHEV)'     },
-];
-
-export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaLabelMethod, updateEpaTestGroup }) {
+export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaTestGroup }) {
     const [groups,         setGroups]         = useState([]);
     const [loading,        setLoading]        = useState(true);
     const [query,          setQuery]          = useState('');
     const [deleting,       setDeleting]       = useState(new Set());
-    const [updatingMethod, setUpdatingMethod] = useState(new Set());
     const [draftNames,     setDraftNames]     = useState({});   // keyed by test_group_id
     const [savingName,     setSavingName]     = useState(new Set());
     const [error,          setError]          = useState(null);
@@ -95,22 +86,6 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
             setDraftNames(prev => ({ ...prev, [group.test_group_id]: current }));
         } finally {
             setSavingName(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
-        }
-    }
-
-    async function handleLabelMethodChange(group, method) {
-        setUpdatingMethod(prev => new Set(prev).add(group.test_group_id));
-        try {
-            await updateEpaLabelMethod?.(group.test_group_id, method);
-            setGroups(prev => prev.map(g =>
-                g.test_group_id === group.test_group_id
-                    ? { ...g, label_method: method || null }
-                    : g
-            ));
-        } catch (e) {
-            setError('Update failed: ' + e.message);
-        } finally {
-            setUpdatingMethod(prev => { const s = new Set(prev); s.delete(group.test_group_id); return s; });
         }
     }
 
@@ -186,7 +161,6 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">A · B · C</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">MPGe</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Method</th>
                                 <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
                                 <th className="px-3 py-2" />
                             </tr>
@@ -196,6 +170,9 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                 const mappings = g.epa_vehicle_mappings || [];
                                 const isDel    = deleting.has(g.test_group_id);
                                 const isSaving = savingName.has(g.test_group_id);
+                                // Coefficients live on the primary coefficient set now.
+                                const coeff = (g.epa_coefficient_sets || []).find(s => s.is_primary)
+                                    || (g.epa_coefficient_sets || [])[0] || {};
                                 return (
                                     <tr
                                         key={g.test_group_id}
@@ -244,8 +221,8 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                         <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
                                             <div>{g.drive || '—'}</div>
                                             <div className="text-gray-400 dark:text-slate-500 mt-0.5">
-                                                {g.equiv_test_weight_lbs != null
-                                                    ? `${Number(g.equiv_test_weight_lbs).toLocaleString()} lbs`
+                                                {coeff.equiv_test_weight_lbs != null
+                                                    ? `${Number(coeff.equiv_test_weight_lbs).toLocaleString()} lbs`
                                                     : '—'}
                                             </div>
                                         </td>
@@ -253,10 +230,10 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                         {/* Road-load A / B / C — prefer target; fall back to set */}
                                         <td className="px-3 py-2 font-mono whitespace-nowrap">
                                             {(() => {
-                                                const a = g.target_a ?? g.set_a;
-                                                const b = g.target_b ?? g.set_b;
-                                                const c = g.target_c ?? g.set_c;
-                                                const isTarget = g.target_a != null;
+                                                const a = coeff.target_a ?? coeff.set_a;
+                                                const b = coeff.target_b ?? coeff.set_b;
+                                                const c = coeff.target_c ?? coeff.set_c;
+                                                const isTarget = coeff.target_a != null;
                                                 if (a == null) return <span className="text-gray-300 dark:text-slate-600">—</span>;
                                                 return (
                                                     <div
@@ -272,39 +249,17 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                             })()}
                                         </td>
 
-                                        {/* Label MPGe */}
-                                        <td className="px-3 py-2 whitespace-nowrap">
+                                        {/* Label MPGe — combined, else highway-only (tagged) */}
+                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
                                             {g.label_combined_mpge != null && g.label_combined_mpge < 500 ? (
-                                                <span
-                                                    className={g.label_combined_mpge < 60
-                                                        ? 'text-amber-600 dark:text-amber-400 font-medium'
-                                                        : 'text-gray-500 dark:text-slate-400'}
-                                                    title={g.label_combined_mpge < 60
-                                                        ? 'Label < 60 MPGe — source column may be in MPGe not kWh/100mi. Re-import with the unit flip toggle.'
-                                                        : undefined}
-                                                >
-                                                    {g.label_combined_mpge < 60 && '⚠ '}
-                                                    {g.label_combined_mpge}
+                                                <span>{g.label_combined_mpge}</span>
+                                            ) : g.label_hwy_mpge != null && g.label_hwy_mpge < 500 ? (
+                                                <span title="Highway-only (proc 84); no combined MCT test">
+                                                    {g.label_hwy_mpge}<span className="text-gray-400 ml-1 text-[10px]">hwy</span>
                                                 </span>
                                             ) : (
                                                 <span className="text-gray-300 dark:text-slate-600">—</span>
                                             )}
-                                        </td>
-
-                                        {/* Label method — compact select */}
-                                        <td className="px-3 py-2">
-                                            <select
-                                                value={g.label_method ?? ''}
-                                                disabled={updatingMethod.has(g.test_group_id) || isDel}
-                                                onChange={e => handleLabelMethodChange(g, e.target.value)}
-                                                className="form-input text-xs py-0.5 w-24 disabled:opacity-50"
-                                                title={LABEL_METHOD_OPTIONS.find(o => o.value === (g.label_method ?? ''))?.title
-                                                    ?? 'Range label derivation method — look up on fueleconomy.gov'}
-                                            >
-                                                {LABEL_METHOD_OPTIONS.map(o => (
-                                                    <option key={o.value} value={o.value} title={o.title}>{o.label}</option>
-                                                ))}
-                                            </select>
                                         </td>
 
                                         {/* Linked vehicles with confidence badges */}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -9,6 +9,8 @@
 import { useState, useRef } from 'react';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
+import DerivedValues from './epa/DerivedValues';
+import EpaCuratorEditor from './epa/EpaCuratorEditor';
 
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
@@ -41,10 +43,14 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
     const [updatingConf, setUpdatingConf] = useState(false);
     const [draftName,    setDraftName]    = useState(null); // null = not editing
     const [savingName,   setSavingName]   = useState(false);
+    const [curating,     setCurating]     = useState(false);
     const g = mapping.epaGroup;
     if (!g) return null;
 
     const fmt = (n, dp = 4) => n != null ? n.toFixed(dp) : null;
+    // Coefficients now live on the primary coefficient set, not flat columns.
+    const coeff = (g.epa_coefficient_sets || []).find(s => s.is_primary)
+        || (g.epa_coefficient_sets || [])[0] || {};
 
     const handleUnlink = async () => {
         setUnlinking(true);
@@ -154,94 +160,73 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
                     <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
                         Test Setup
                     </div>
-                    <DataRow label="Test weight" value={g.equiv_test_weight_lbs != null ? g.equiv_test_weight_lbs.toLocaleString() + ' lbs' : null} />
+                    <DataRow label="Test weight" value={coeff.equiv_test_weight_lbs != null ? coeff.equiv_test_weight_lbs.toLocaleString() + ' lbs' : null} />
                     <DataRow label="Fuel type" value={g.fuel_type} />
+                    <DataRow label="Config #" value={g.vehicle_config_number} />
                 </div>
 
-                {/* Road-load coefficients */}
+                {/* Road-load coefficients (primary set) */}
                 <div>
                     <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
                         Road-Load Coefficients
                         <InfoIcon text={EPA_EXPLAINERS.roadLoad} position="right" />
                     </div>
-                    {g.target_a != null && (
+                    {coeff.target_a != null ? (
                         <>
-                            <DataRow label="Target A" value={fmt(g.target_a, 3) + ' lbf'} />
-                            <DataRow label="Target B" value={fmt(g.target_b, 5) + ' lbf/mph'} />
-                            <DataRow label="Target C" value={fmt(g.target_c, 6) + ' lbf/mph²'} />
+                            <DataRow label="Target A" value={fmt(coeff.target_a, 3) + ' lbf'} />
+                            <DataRow label="Target B" value={fmt(coeff.target_b, 5) + ' lbf/mph'} />
+                            <DataRow label="Target C" value={fmt(coeff.target_c, 6) + ' lbf/mph²'} />
                         </>
-                    )}
-                    {g.set_a != null && (
+                    ) : coeff.set_a != null ? (
                         <>
-                            <DataRow label="Set A" value={fmt(g.set_a, 3) + ' lbf'} muted />
-                            <DataRow label="Set B" value={fmt(g.set_b, 5) + ' lbf/mph'} muted />
-                            <DataRow label="Set C" value={fmt(g.set_c, 6) + ' lbf/mph²'} muted />
+                            <DataRow label="Set A" value={fmt(coeff.set_a, 3) + ' lbf'} muted />
+                            <DataRow label="Set B" value={fmt(coeff.set_b, 5) + ' lbf/mph'} muted />
+                            <DataRow label="Set C" value={fmt(coeff.set_c, 6) + ' lbf/mph²'} muted />
                         </>
+                    ) : (
+                        <p className="text-gray-400 text-[10px] italic">No coefficients yet</p>
                     )}
                 </div>
 
-                {/* Cycle results */}
-                <div>
-                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
-                        Cycle Results
-                        <InfoIcon text={EPA_EXPLAINERS.unadjVsAdj} position="right" />
+                {/* Label results + live derivations */}
+                <div className="space-y-2">
+                    <div>
+                        <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                            Label Results
+                        </div>
+                        {g.label_combined_mpge != null && g.label_combined_mpge < 500 && (
+                            <DataRow label="Label combined" value={g.label_combined_mpge.toFixed(1) + ' MPGe'} />
+                        )}
+                        {g.label_hwy_mpge != null && g.label_hwy_mpge < 500 && (
+                            <DataRow label="Label highway" value={g.label_hwy_mpge.toFixed(1) + ' MPGe'} />
+                        )}
+                        {g.label_range_published != null && (
+                            <DataRow label="Label range" value={g.label_range_published.toFixed(0) + ' mi'} />
+                        )}
+                        {g.label_combined_mpge == null && g.label_hwy_mpge == null && (
+                            <p className="text-gray-400 text-[10px] italic">No label data</p>
+                        )}
                     </div>
-                    {(g.udds_adj_kwh_100mi != null || g.udds_unadj_kwh_100mi != null) && (
-                        <DataRow
-                            label="UDDS (city)"
-                            value={(g.udds_adj_kwh_100mi ?? g.udds_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
-                        />
-                    )}
-                    {(g.hwfet_adj_kwh_100mi != null || g.hwfet_unadj_kwh_100mi != null) && (
-                        <DataRow
-                            label="HWFET (hwy)"
-                            value={(g.hwfet_adj_kwh_100mi ?? g.hwfet_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
-                        />
-                    )}
-                    {(g.us06_adj_kwh_100mi != null || g.us06_unadj_kwh_100mi != null) && (
-                        <DataRow
-                            label="US06"
-                            value={(g.us06_adj_kwh_100mi ?? g.us06_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
-                        />
-                    )}
-                    {(g.sc03_adj_kwh_100mi != null || g.sc03_unadj_kwh_100mi != null) && (
-                        <DataRow
-                            label="SC03 (AC)"
-                            value={(g.sc03_adj_kwh_100mi ?? g.sc03_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
-                        />
-                    )}
-                    {(g.cold_ftp_adj_kwh_100mi != null || g.cold_ftp_unadj_kwh_100mi != null) && (
-                        <DataRow
-                            label="Cold FTP"
-                            value={(g.cold_ftp_adj_kwh_100mi ?? g.cold_ftp_unadj_kwh_100mi)?.toFixed(1) + ' kWh/100mi'}
-                        />
-                    )}
-                    {/* Label values — suppress 999/sentinel placeholders used by EPA
-                        for records where the label has not yet been finalized */}
-                    {g.label_combined_mpge != null && g.label_combined_mpge < 500 && (
-                        <DataRow label="Label combined" value={g.label_combined_mpge.toFixed(1) + ' MPGe'} />
-                    )}
-                    {g.label_hwy_mpge != null && g.label_hwy_mpge < 500 && (
-                        <DataRow label="Label highway" value={g.label_hwy_mpge.toFixed(1) + ' MPGe'} />
-                    )}
-                    {g.label_city_mpge != null && g.label_city_mpge < 500 && (
-                        <DataRow label="Label city" value={g.label_city_mpge.toFixed(1) + ' MPGe'} />
-                    )}
-                    {g.label_combined_mi != null && (
-                        <DataRow label="Label range" value={g.label_combined_mi.toFixed(0) + ' mi'} />
-                    )}
-                    {g.label_method && (
-                        <DataRow label="Label method" value={g.label_method} />
-                    )}
-                    {/* No cycle data at all */}
-                    {g.label_combined_mpge == null && g.hwfet_adj_kwh_100mi == null && g.hwfet_unadj_kwh_100mi == null && (
-                        <p className="text-gray-400 text-[10px] italic">No cycle data in this record</p>
-                    )}
+                    <DerivedValues group={g} />
                 </div>
             </div>
 
             {mapping.notes && (
                 <p className="mt-2 text-xs text-gray-500 dark:text-slate-400 italic border-t pt-2">{mapping.notes}</p>
+            )}
+
+            {/* Curator form — contributor/admin only */}
+            {canEdit && (
+                <>
+                    <button
+                        type="button"
+                        onClick={() => setCurating(c => !c)}
+                        className="mt-3 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+                    >
+                        {curating ? '▾ Hide curator fields' : '▸ Curate fields & test data'}
+                    </button>
+                    {curating && <EpaCuratorEditor testGroupId={g.test_group_id} canEdit={canEdit} />}
+                </>
             )}
         </div>
     );

--- a/src/components/epa/CuratorField.jsx
+++ b/src/components/epa/CuratorField.jsx
@@ -1,0 +1,81 @@
+/**
+ * One curator-editable field: EPA label + tooltip, an input, an override flag,
+ * and save-on-blur. Reused across every section of the EPA curator form.
+ *
+ * Override flag (spec cross-cutting requirement): distinguishes
+ *   • CSV-imported values (subtle grey "csv")
+ *   • curator-overridden values (amber "edited")
+ * so curators can see at a glance what came from the spreadsheet vs. by hand.
+ */
+import { useState } from 'react';
+import InfoIcon from '../InfoIcon';
+
+export default function CuratorField({
+    label,
+    tooltip,
+    value,
+    type = 'text',
+    unit,
+    step,
+    placeholder,
+    overrideSource,        // 'csv' | 'manual' | undefined
+    canEdit = true,
+    onSave,                // (newValue) => Promise|void
+}) {
+    const [draft, setDraft]   = useState(null); // null = not editing
+    const [saving, setSaving] = useState(false);
+
+    const display = draft !== null ? draft : (value ?? '');
+
+    const commit = async () => {
+        if (draft === null) return;
+        const raw = draft.trim();
+        setDraft(null);
+        // Normalise to the stored representation for comparison.
+        const next = raw === '' ? null : (type === 'number' ? Number(raw) : raw);
+        if (type === 'number' && next !== null && Number.isNaN(next)) return;
+        const current = value ?? null;
+        if (next === current) return;
+        setSaving(true);
+        try { await onSave?.(next); } finally { setSaving(false); }
+    };
+
+    const onKeyDown = (e) => {
+        if (e.key === 'Enter')  e.target.blur();
+        if (e.key === 'Escape') setDraft(null);
+    };
+
+    return (
+        <div className="flex items-center justify-between gap-2 py-0.5">
+            <span className="text-gray-500 dark:text-slate-400 shrink-0 flex items-center gap-1">
+                {label}
+                {tooltip && <InfoIcon text={tooltip} position="right" />}
+                {overrideSource === 'manual' && (
+                    <span title="Curator-overridden value" className="text-amber-500 text-[9px] font-bold">●</span>
+                )}
+                {overrideSource === 'csv' && (
+                    <span title="Imported from CSV" className="text-gray-300 dark:text-slate-600 text-[9px]">csv</span>
+                )}
+            </span>
+            <span className="flex items-center gap-1 min-w-0">
+                {canEdit ? (
+                    <input
+                        type={type === 'number' ? 'number' : 'text'}
+                        step={step}
+                        value={display}
+                        placeholder={placeholder}
+                        disabled={saving}
+                        onFocus={() => setDraft(value != null ? String(value) : '')}
+                        onChange={e => setDraft(e.target.value)}
+                        onBlur={commit}
+                        onKeyDown={onKeyDown}
+                        className="form-input text-xs py-0.5 px-1.5 w-28 text-right font-mono disabled:opacity-50"
+                    />
+                ) : (
+                    <span className="font-mono text-xs text-right">{value ?? '—'}</span>
+                )}
+                {unit && <span className="text-gray-400 text-[10px] w-12 shrink-0">{unit}</span>}
+            </span>
+        </div>
+    );
+}

--- a/src/components/epa/DerivedValues.jsx
+++ b/src/components/epa/DerivedValues.jsx
@@ -1,0 +1,73 @@
+/**
+ * Section 8 — read-only derived values, computed live from the curator model
+ * via epaDerivations.deriveAll(). Each shows its value, a provenance badge
+ * (measured / assumed / estimated / manual), and a ⚠ when a sanity-band flag
+ * fires. Per-derivation provenance: η can be measured while charger eff is
+ * assumed on the same record.
+ */
+import { deriveAll } from '../../utils/epaDerivations';
+import InfoIcon from '../InfoIcon';
+import { EPA_EXPLAINERS } from '../../utils/epaExplainers';
+
+const SOURCE_LABEL = {
+    measured:            { text: 'measured',  cls: 'text-green-600 dark:text-green-400' },
+    'measured-fallback': { text: 'measured (proc 84)', cls: 'text-green-600 dark:text-green-400' },
+    assumed:             { text: 'assumed',   cls: 'text-amber-600 dark:text-amber-400' },
+    estimated:           { text: 'estimated', cls: 'text-amber-600 dark:text-amber-400' },
+    manual:              { text: 'manual',    cls: 'text-indigo-600 dark:text-indigo-400' },
+    computed:            { text: 'computed',  cls: 'text-green-600 dark:text-green-400' },
+};
+
+function DerivedRow({ label, tooltip, result, format }) {
+    const { value, source, certain, flags = [] } = result || {};
+    const meta = SOURCE_LABEL[source] || { text: source || '—', cls: 'text-gray-400' };
+    return (
+        <div className="flex items-center justify-between gap-2 py-0.5">
+            <span className="text-gray-500 dark:text-slate-400 flex items-center gap-1">
+                {label}
+                {tooltip && <InfoIcon text={tooltip} position="right" />}
+            </span>
+            <span className="flex items-center gap-1.5">
+                <span className="font-mono">
+                    {value == null ? '—' : `${!certain ? '~' : ''}${format(value)}`}
+                </span>
+                {source && <span className={`text-[10px] ${meta.cls}`}>{meta.text}</span>}
+                {flags.length > 0 && value != null && (
+                    <span title={flags.join(', ')} className="text-amber-500 text-xs">⚠</span>
+                )}
+            </span>
+        </div>
+    );
+}
+
+export default function DerivedValues({ group }) {
+    const d = deriveAll(group);
+    return (
+        <div>
+            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                Derived Values
+            </div>
+            <DerivedRow
+                label="Drivetrain η" tooltip={EPA_EXPLAINERS.hwfetCalibration}
+                result={d.eta} format={v => `${(v * 100).toFixed(1)}%`}
+            />
+            <DerivedRow
+                label="Charger eff." result={d.chargerEfficiency}
+                format={v => `${(v * 100).toFixed(1)}%`}
+            />
+            <DerivedRow
+                label="Adj. factor" result={d.effectiveAdjustmentFactor}
+                format={v => v.toFixed(3)}
+            />
+            <DerivedRow
+                label="Implied SS speed" result={d.impliedSsSpeed}
+                format={v => `${v.toFixed(0)} mph`}
+            />
+            {d.effectiveAdjustmentFactor?.basis?.method && (
+                <p className="text-[10px] text-gray-400 italic mt-1">
+                    Method: {d.effectiveAdjustmentFactor.basis.method}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -1,0 +1,168 @@
+/**
+ * The EPA curator form (Sections 1–8) for one test group, shown inline in
+ * Tests & Data. Lazy-loads the full hierarchy (coefficient sets, tests,
+ * phases) and edits the SHARED reference records — two vehicles linked to the
+ * same test group edit the same data (a hint is shown in the header).
+ *
+ * On every edit it: writes the value, marks the field source:'manual' in the
+ * row's `overrides`, and appends an audit-trail entry. Derivations (Section 8)
+ * recompute live from the edited model.
+ */
+import { useEffect, useState, useCallback } from 'react';
+import { useAppContext } from '../../context/AppContext';
+import CuratorField from './CuratorField';
+import DerivedValues from './DerivedValues';
+import TestPhaseEditor from './TestPhaseEditor';
+import { EPA_EXPLAINERS } from '../../utils/epaExplainers';
+
+function Section({ title, children }) {
+    return (
+        <div className="mb-4">
+            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">{title}</div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">{children}</div>
+        </div>
+    );
+}
+
+export default function EpaCuratorEditor({ testGroupId, canEdit }) {
+    const {
+        getEpaTestGroupFull, updateEpaTestGroup,
+        saveEpaCoefficientSet, saveEpaTest, deleteEpaTest,
+        saveEpaPhase, deleteEpaPhase, logEpaFieldEdit,
+    } = useAppContext();
+
+    const [group, setGroup]   = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError]   = useState(null);
+
+    const reload = useCallback(async () => {
+        try {
+            const g = await getEpaTestGroupFull(testGroupId);
+            setGroup(g);
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [getEpaTestGroupFull, testGroupId]);
+
+    useEffect(() => { reload(); }, [reload]);
+
+    if (loading) return <p className="text-xs text-gray-400 italic py-2">Loading curator data…</p>;
+    if (error)   return <p className="text-xs text-red-500 py-2">Error: {error}</p>;
+    if (!group)  return null;
+
+    const primary = (group.epa_coefficient_sets || []).find(s => s.is_primary)
+        || (group.epa_coefficient_sets || [])[0] || null;
+
+    // Provenance helpers
+    const gOv = (f) => group.overrides?.[f]?.source;
+    const cOv = (f) => primary?.overrides?.[f]?.source;
+
+    const audit = (tableName, rowId, field, prior, next) =>
+        logEpaFieldEdit?.({ tableName, rowId, field, priorValue: prior, newValue: next });
+
+    // ── Save handlers (mark source:'manual' + audit + reload) ───────────────────
+    const saveGroup = async (field, value) => {
+        const prior = group[field];
+        const overrides = { ...(group.overrides || {}), [field]: { source: 'manual', at: new Date().toISOString() } };
+        await updateEpaTestGroup(testGroupId, { [field]: value, overrides });
+        audit('epa_test_groups', testGroupId, field, prior, value);
+        await reload();
+    };
+
+    const saveCoeff = async (field, value) => {
+        const base = primary || { test_group_id: testGroupId, category: 'City/Highway', is_primary: true };
+        const prior = base[field];
+        const overrides = { ...(base.overrides || {}), [field]: { source: 'manual', at: new Date().toISOString() } };
+        const saved = await saveEpaCoefficientSet({ ...(primary?.id ? { id: primary.id } : {}), test_group_id: testGroupId, category: base.category, is_primary: true, [field]: value, overrides });
+        audit('epa_coefficient_sets', saved?.id ?? primary?.id ?? testGroupId, field, prior, value);
+        await reload();
+    };
+
+    const saveTest = async (row) => {
+        await saveEpaTest(row.id ? row : { ...row, test_group_id: testGroupId });
+        await reload();
+    };
+    const removeTest = async (t) => { await deleteEpaTest(t.id); await reload(); };
+    const addTest = async () => {
+        await saveEpaTest({ test_group_id: testGroupId, procedure_code: 77, source: 'manual' });
+        await reload();
+    };
+    const savePhase = async (row) => { await saveEpaPhase(row); await reload(); };
+    const removePhase = async (p) => { await deleteEpaPhase(p.id); await reload(); };
+    const addPhase = async (test) => {
+        const next = (test.epa_test_phases || []).reduce((m, p) => Math.max(m, p.phase_index), 0) + 1;
+        await saveEpaPhase({ test_id: test.id, phase_index: next, phase_type: 'HWY' });
+        await reload();
+    };
+
+    return (
+        <div className="border-t border-gray-100 dark:border-slate-700 mt-3 pt-3">
+            <p className="text-[10px] text-gray-400 italic mb-3">
+                Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
+            </p>
+
+            {/* Section 1: Identity */}
+            <Section title="Identity & Configuration">
+                <CuratorField label="Model year" type="number" value={group.model_year} canEdit={canEdit} overrideSource={gOv('model_year')} onSave={v => saveGroup('model_year', v)} />
+                <CuratorField label="Manufacturer" value={group.make} canEdit={canEdit} overrideSource={gOv('make')} onSave={v => saveGroup('make', v)} />
+                <CuratorField label="Carline" value={group.epa_carline_name} canEdit={canEdit} overrideSource={gOv('epa_carline_name')} onSave={v => saveGroup('epa_carline_name', v)} />
+                <CuratorField label="Config #" value={group.vehicle_config_number} canEdit={canEdit} overrideSource={gOv('vehicle_config_number')} onSave={v => saveGroup('vehicle_config_number', v)} />
+                <CuratorField label="Drive" value={group.drive} canEdit={canEdit} overrideSource={gOv('drive')} onSave={v => saveGroup('drive', v)} />
+                <CuratorField label="Evap family" value={group.evap_family} canEdit={canEdit} overrideSource={gOv('evap_family')} onSave={v => saveGroup('evap_family', v)} />
+                <CuratorField label="Fuel category" value={group.fuel_type} canEdit={canEdit} overrideSource={gOv('fuel_type')} onSave={v => saveGroup('fuel_type', v)} />
+            </Section>
+
+            {/* Section 2: Road load */}
+            <Section title="Road Load & Weight">
+                <CuratorField label="Test weight" type="number" unit="lbs" value={primary?.equiv_test_weight_lbs} canEdit={canEdit} overrideSource={cOv('equiv_test_weight_lbs')} onSave={v => saveCoeff('equiv_test_weight_lbs', v)} />
+                <span />
+                <CuratorField label="Target A" type="number" step="0.0001" unit="lbf" tooltip={EPA_EXPLAINERS.roadLoad} value={primary?.target_a} canEdit={canEdit} overrideSource={cOv('target_a')} onSave={v => saveCoeff('target_a', v)} />
+                <CuratorField label="Set A" type="number" step="0.0001" unit="lbf" value={primary?.set_a} canEdit={canEdit} overrideSource={cOv('set_a')} onSave={v => saveCoeff('set_a', v)} />
+                <CuratorField label="Target B" type="number" step="0.000001" unit="lbf/mph" value={primary?.target_b} canEdit={canEdit} overrideSource={cOv('target_b')} onSave={v => saveCoeff('target_b', v)} />
+                <CuratorField label="Set B" type="number" step="0.000001" unit="lbf/mph" value={primary?.set_b} canEdit={canEdit} overrideSource={cOv('set_b')} onSave={v => saveCoeff('set_b', v)} />
+                <CuratorField label="Target C" type="number" step="0.00000001" unit="lbf/mph²" value={primary?.target_c} canEdit={canEdit} overrideSource={cOv('target_c')} onSave={v => saveCoeff('target_c', v)} />
+                <CuratorField label="Set C" type="number" step="0.00000001" unit="lbf/mph²" value={primary?.set_c} canEdit={canEdit} overrideSource={cOv('set_c')} onSave={v => saveCoeff('set_c', v)} />
+            </Section>
+
+            {/* Sections 3–5: Tests & phases */}
+            <div className="mb-4">
+                <TestPhaseEditor
+                    tests={group.epa_tests}
+                    canEdit={canEdit}
+                    onSaveTest={saveTest}
+                    onDeleteTest={removeTest}
+                    onAddTest={addTest}
+                    onSavePhase={savePhase}
+                    onDeletePhase={removePhase}
+                    onAddPhase={addPhase}
+                />
+            </div>
+
+            {/* Section 6: Range & label */}
+            <Section title="Range & Label Values">
+                <CuratorField label="CD range combined (calc)" type="number" step="0.1" unit="mi" value={group.cd_range_combined_calc} canEdit={canEdit} overrideSource={gOv('cd_range_combined_calc')} onSave={v => saveGroup('cd_range_combined_calc', v)} />
+                <CuratorField label="CD range highway (calc)" type="number" step="0.1" unit="mi" value={group.cd_range_hwy_calc} canEdit={canEdit} overrideSource={gOv('cd_range_hwy_calc')} onSave={v => saveGroup('cd_range_hwy_calc', v)} />
+                <CuratorField label="Label range (published)" type="number" step="0.1" unit="mi" value={group.label_range_published} canEdit={canEdit} overrideSource={gOv('label_range_published')} onSave={v => saveGroup('label_range_published', v)} />
+                <CuratorField label="Label combined MPGe" type="number" step="0.1" value={group.label_combined_mpge} canEdit={canEdit} overrideSource={gOv('label_combined_mpge')} onSave={v => saveGroup('label_combined_mpge', v)} />
+                <CuratorField label="Label highway MPGe" type="number" step="0.1" value={group.label_hwy_mpge} canEdit={canEdit} overrideSource={gOv('label_hwy_mpge')} onSave={v => saveGroup('label_hwy_mpge', v)} />
+                <CuratorField label="Derived 5-cycle coeff." type="number" step="0.0001" value={group.derived_5cycle_coefficient} canEdit={canEdit} overrideSource={gOv('derived_5cycle_coefficient')} onSave={v => saveGroup('derived_5cycle_coefficient', v)} />
+            </Section>
+
+            {/* Section 7: Battery & powertrain */}
+            <Section title="Battery & Powertrain Assumptions">
+                <CuratorField label="Useable battery" type="number" step="0.001" unit="kWh" value={group.useable_kwh} canEdit={canEdit} overrideSource={gOv('useable_kwh')} onSave={v => saveGroup('useable_kwh', v)} />
+                <CuratorField label="Total voltage" type="number" step="0.1" unit="V" value={group.total_voltage} canEdit={canEdit} overrideSource={gOv('total_voltage')} onSave={v => saveGroup('total_voltage', v)} />
+                <CuratorField label="Specific energy" type="number" step="0.1" unit="Wh/kg" value={group.battery_specific_energy} canEdit={canEdit} overrideSource={gOv('battery_specific_energy')} onSave={v => saveGroup('battery_specific_energy', v)} />
+                <CuratorField label="Accessory load" type="number" step="1" unit="W" placeholder="300" value={group.accessory_load_w_override} canEdit={canEdit} overrideSource={gOv('accessory_load_w_override')} onSave={v => saveGroup('accessory_load_w_override', v)} />
+                <CuratorField label="Charger eff. override" type="number" step="0.001" placeholder="0.90" value={group.charger_efficiency_override} canEdit={canEdit} overrideSource={gOv('charger_efficiency_override')} onSave={v => saveGroup('charger_efficiency_override', v)} />
+            </Section>
+
+            {/* Section 8: Derived values */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
+                <DerivedValues group={group} />
+            </div>
+        </div>
+    );
+}

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -1,0 +1,201 @@
+/**
+ * Sections 3–5 editor: per-test records, their energy totals, and the child
+ * phase list. This is where the curator enters DC-side phase energy — adding a
+ * proc-77 (or proc-84) HWY phase is what flips the derived η from estimated to
+ * measured.
+ *
+ * Inline sanity checks (spec): phase DC sum vs Total DC, phase count vs the
+ * declared Bags/Phases Conducted, plus per-phase derived consumption.
+ */
+import { useState } from 'react';
+import CuratorField from './CuratorField';
+import { PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75 } from '../../utils/epaDerivations';
+
+const PROC_OPTIONS = [
+    { v: PROC_MCT,     label: '77 — Multi-Cycle Test' },
+    { v: PROC_CD_HWY,  label: '84 — CD Highway' },
+    { v: PROC_CD_UDDS, label: '81 — CD UDDS' },
+    { v: PROC_FTP75,   label: '2 — FTP-75' },
+];
+const PHASE_TYPES   = ['UDDS', 'HWY', 'SS', 'Cold-UDDS', 'US06', 'SC03'];
+const SOURCE_OPTS   = ['csv', 'j1634', 'csi_pdf', 'manual'];
+const ORIGINATORS   = ['MFR', 'EPA'];
+
+const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
+
+function PhaseRow({ phase, canEdit, onSave, onDelete }) {
+    const consumption = (() => {
+        const e = num(phase.dc_energy_kwh), d = num(phase.distance_mi);
+        return e != null && d != null && d > 0 ? (e / d * 1000).toFixed(0) : null; // Wh/mi
+    })();
+    const set = (field) => (val) => onSave({ ...phase, [field]: val });
+
+    return (
+        <tr className="border-t border-gray-100 dark:border-slate-700">
+            <td className="py-1 pr-2 text-gray-400 font-mono">{phase.phase_index}</td>
+            <td className="py-1 pr-2">
+                {canEdit ? (
+                    <select
+                        value={phase.phase_type ?? ''}
+                        onChange={e => onSave({ ...phase, phase_type: e.target.value || null })}
+                        className="form-input text-xs py-0.5 px-1 w-24"
+                    >
+                        <option value="">—</option>
+                        {PHASE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                ) : (phase.phase_type ?? '—')}
+            </td>
+            <td className="py-1 pr-2">
+                <InlineNum value={phase.dc_energy_kwh} canEdit={canEdit} step="0.001" onSave={set('dc_energy_kwh')} />
+            </td>
+            <td className="py-1 pr-2">
+                <InlineNum value={phase.distance_mi} canEdit={canEdit} step="0.001" onSave={set('distance_mi')} />
+            </td>
+            <td className="py-1 pr-2 text-right font-mono text-gray-500">{consumption ? `${consumption} Wh/mi` : '—'}</td>
+            <td className="py-1 text-right">
+                {canEdit && (
+                    <button onClick={() => onDelete(phase)} className="text-red-500 hover:text-red-600 text-xs" title="Delete phase">✕</button>
+                )}
+            </td>
+        </tr>
+    );
+}
+
+function InlineNum({ value, canEdit, step, onSave }) {
+    const [draft, setDraft] = useState(null);
+    if (!canEdit) return <span className="font-mono text-right">{value ?? '—'}</span>;
+    return (
+        <input
+            type="number" step={step}
+            value={draft !== null ? draft : (value ?? '')}
+            onFocus={() => setDraft(value != null ? String(value) : '')}
+            onChange={e => setDraft(e.target.value)}
+            onBlur={() => { const v = draft; setDraft(null); if (v !== null && String(value ?? '') !== v.trim()) onSave(v.trim() === '' ? null : Number(v)); }}
+            onKeyDown={e => { if (e.key === 'Enter') e.target.blur(); if (e.key === 'Escape') setDraft(null); }}
+            className="form-input text-xs py-0.5 px-1 w-24 text-right font-mono"
+        />
+    );
+}
+
+function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDeletePhase, onAddPhase }) {
+    const phases = [...(test.epa_test_phases || [])].sort((a, b) => a.phase_index - b.phase_index);
+    const saveField = (field) => (val) => onSaveTest({ id: test.id, [field]: val });
+
+    // Sanity: phase DC sum vs declared total; phase count vs declared bags.
+    const phaseSum = phases.reduce((s, p) => s + (num(p.dc_energy_kwh) ?? 0), 0);
+    const totalDc  = num(test.total_dc_energy_kwh);
+    const sumMismatch = totalDc != null && phaseSum > 0 && Math.abs(phaseSum - totalDc) / totalDc > 0.05;
+    const bags = num(test.bags_phases_conducted);
+    const bagMismatch = bags != null && bags !== phases.length;
+
+    return (
+        <div className="border rounded-lg p-3 mb-2 border-gray-200 dark:border-slate-700">
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2">
+                    {canEdit ? (
+                        <select
+                            value={test.procedure_code ?? ''}
+                            onChange={e => onSaveTest({ id: test.id, procedure_code: e.target.value ? Number(e.target.value) : null })}
+                            className="form-input text-xs py-0.5"
+                        >
+                            <option value="">Procedure…</option>
+                            {PROC_OPTIONS.map(o => <option key={o.v} value={o.v}>{o.label}</option>)}
+                        </select>
+                    ) : (
+                        <span className="text-xs font-semibold">proc {test.procedure_code ?? '—'}</span>
+                    )}
+                    <span className="font-mono text-xs text-gray-400">{test.test_number}</span>
+                </div>
+                {canEdit && (
+                    <button onClick={() => onDeleteTest(test)} className="btn btn-secondary text-xs py-0.5 px-2">Delete test</button>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs mb-2">
+                <CuratorField label="Test number" value={test.test_number} canEdit={canEdit} onSave={saveField('test_number')} />
+                <CuratorField label="Lab ID" value={test.lab_id} canEdit={canEdit} onSave={saveField('lab_id')} />
+                <EnumField label="Originator" value={test.originator} options={ORIGINATORS} canEdit={canEdit} onSave={saveField('originator')} />
+                <EnumField label="Source" value={test.source} options={SOURCE_OPTS} canEdit={canEdit} onSave={saveField('source')} />
+                <CuratorField label="Test date" type="text" placeholder="YYYY-MM-DD" value={test.test_date} canEdit={canEdit} onSave={saveField('test_date')} />
+                <CuratorField label="Total DC" type="number" step="0.001" unit="kWh" value={test.total_dc_energy_kwh} canEdit={canEdit} onSave={saveField('total_dc_energy_kwh')} />
+                <CuratorField label="AC recharge" type="number" step="0.001" unit="kWh" value={test.ac_recharge_kwh} canEdit={canEdit} onSave={saveField('ac_recharge_kwh')} />
+                <CuratorField label="Total distance" type="number" step="0.001" unit="mi" value={test.total_distance_mi} canEdit={canEdit} onSave={saveField('total_distance_mi')} />
+                <CuratorField label="Bags/phases" type="number" value={test.bags_phases_conducted} canEdit={canEdit} onSave={saveField('bags_phases_conducted')} />
+                <CuratorField label="Recharge V" type="number" step="0.1" unit="V" value={test.recharge_voltage} canEdit={canEdit} onSave={saveField('recharge_voltage')} />
+            </div>
+
+            {/* Phases */}
+            <table className="w-full text-xs">
+                <thead>
+                    <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
+                        <th className="font-semibold pr-2">#</th>
+                        <th className="font-semibold pr-2">Phase</th>
+                        <th className="font-semibold pr-2">DC (kWh)</th>
+                        <th className="font-semibold pr-2">Dist (mi)</th>
+                        <th className="font-semibold pr-2 text-right">Consumption</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {phases.map(p => (
+                        <PhaseRow key={p.id} phase={p} canEdit={canEdit}
+                            onSave={onSavePhase} onDelete={onDeletePhase} />
+                    ))}
+                    {phases.length === 0 && (
+                        <tr><td colSpan={6} className="py-1 text-gray-400 italic text-[11px]">No phases yet. Add the HWY phase to enable measured η.</td></tr>
+                    )}
+                </tbody>
+            </table>
+            {canEdit && (
+                <button onClick={() => onAddPhase(test)} className="text-xs text-indigo-600 dark:text-indigo-400 mt-1 hover:underline">
+                    + Add phase
+                </button>
+            )}
+
+            {/* Inline sanity */}
+            {(sumMismatch || bagMismatch) && (
+                <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400 space-y-0.5">
+                    {sumMismatch && <div>⚠ Phase DC sum {phaseSum.toFixed(2)} kWh ≠ Total DC {totalDc} kWh (&gt;5%)</div>}
+                    {bagMismatch && <div>⚠ {phases.length} phase(s) entered vs {bags} declared</div>}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function EnumField({ label, value, options, canEdit, onSave }) {
+    return (
+        <div className="flex items-center justify-between gap-2 py-0.5">
+            <span className="text-gray-500 dark:text-slate-400">{label}</span>
+            {canEdit ? (
+                <select value={value ?? ''} onChange={e => onSave(e.target.value || null)}
+                    className="form-input text-xs py-0.5 px-1 w-28">
+                    <option value="">—</option>
+                    {options.map(o => <option key={o} value={o}>{o}</option>)}
+                </select>
+            ) : <span className="font-mono text-xs">{value ?? '—'}</span>}
+        </div>
+    );
+}
+
+export default function TestPhaseEditor({ tests, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDeletePhase, onAddTest, onAddPhase }) {
+    const sorted = [...(tests || [])].sort((a, b) => (a.procedure_code ?? 99) - (b.procedure_code ?? 99));
+    return (
+        <div>
+            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                Tests &amp; Phases
+            </div>
+            {sorted.map(t => (
+                <TestCard key={t.id} test={t} canEdit={canEdit}
+                    onSaveTest={onSaveTest} onDeleteTest={onDeleteTest}
+                    onSavePhase={onSavePhase} onDeletePhase={onDeletePhase} onAddPhase={onAddPhase} />
+            ))}
+            {sorted.length === 0 && (
+                <p className="text-xs text-gray-400 italic mb-2">No tests entered. Add a Multi-Cycle Test (proc 77) and its HWY phase to compute a measured η.</p>
+            )}
+            {canEdit && (
+                <button onClick={onAddTest} className="btn btn-secondary text-xs py-1 px-2">+ Add test</button>
+            )}
+        </div>
+    );
+}

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -1154,11 +1154,9 @@ class DataService {
       .select(`
         test_group_id, epa_test_family_id,
         model_year, make, epa_carline_name, drive, transmission,
-        equiv_test_weight_lbs,
-        target_a, target_b, target_c,
-        set_a, set_b, set_c,
-        label_combined_mpge, label_method, display_name,
+        label_combined_mpge, label_hwy_mpge, display_name,
         source_file, ingested_at,
+        epa_coefficient_sets(category, is_primary, target_a, target_b, target_c, equiv_test_weight_lbs),
         epa_vehicle_mappings(
           id, confidence,
           vehicles(id, name, year)


### PR DESCRIPTION
The big one — makes the hierarchical model fully usable and fixes the blank-card regressions you spotted (data moved to `epa_coefficient_sets`, but the old cards still read the flat columns). Depends on A–D (all merged). Plan: `LocalDev/epa-curator-refactor-plan.md`.

## Curator form (new `src/components/epa/`)
Inline in **Tests & Data** via a "▸ Curate fields & test data" toggle on each linked EPA group (admin + contributor):
- **`EpaCuratorEditor`** — lazy-loads the full group and edits the **shared** reference records (Sections 1/2/6/7), with a "shared data" hint. Every edit marks the field `source:'manual'` in `overrides` and appends an `epa_field_audit` row.
- **`TestPhaseEditor`** — Sections 3–5: add/edit/delete **tests + phases**. Entering a proc-77 (or 84) **HWY phase** with DC energy + distance is what flips derived η from `~estimated` to `measured`. Inline sanity: phase-DC-sum vs Total DC, phase count vs declared bags, per-phase Wh/mi.
- **`DerivedValues`** — Section 8 live from `deriveAll`: η, charger eff, effective adjustment factor, implied SS speed — each with a provenance badge + sanity ⚠.
- **`CuratorField`** — reusable labeled input with EPA tooltip + csv/manual override flag + save-on-blur.

## Read-fixes (the blank cards)
- **`EpaVehicleSection`** summary now reads coeffs from the primary coefficient set, drops the dead per-cycle rows, and shows live `DerivedValues`.
- **Admin `EpaDataCard`** reads A/B/C + weight from the primary set; MPGe shows combined or highway-tagged; **dropped the dead Method column** + `label_method` machinery (thin admin per plan).
- `getVehicles` + `getEpaTestGroupsAdmin` selects updated (coeff sets, `label_hwy_mpge`).
- **`EpaCurvesView`** legend shows **"EPA hwy: X MPGe"** when there's no combined (the deferred highway-MPGe display, folded in here).

## How to verify
1. Tests & Data → a vehicle with a linked EPA group → coeffs/derived values now populate (no more blanks).
2. Click **Curate fields & test data** → edit a field → it gets the amber "edited" flag; reload persists; an audit row is written.
3. **Add a test (proc 77) + a HWY phase** with DC energy & distance → the curve's η badge flips from `~88% default η` to a `measured` value, and the curve shifts.
4. Admin EPA list shows A/B/C + MPGe again; no Method column.

Build ✓. No schema changes (uses A's tables/RPCs). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)