### PR TITLE
EPA curator: audit history + create-from-scratch + phase auto-suggest (F+G+#117)

### DIFF
--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -234,16 +234,44 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
+const EPA_SOURCE_URL = 'https://dis.epa.gov/otaqpub/publist1.jsp';
+
+export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onCreate, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
     const [query, setQuery]               = useState('');
     const [results, setResults]           = useState([]);
     const [searching, setSearching]       = useState(false);
     const [searchError, setSearchError]   = useState(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [linking, setLinking]           = useState(false);
+    const [showCreate, setShowCreate]     = useState(false);
+    const [createDraft, setCreateDraft]   = useState({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
+    const [creating, setCreating]         = useState(false);
+    const [createError, setCreateError]   = useState(null);
     const debounceRef = useRef(null);
 
     const mappings = vehicle?.epa_mappings ?? [];
+
+    const handleCreate = async () => {
+        const id = createDraft.test_group_id.trim();
+        if (!id) { setCreateError('Test Group ID is required.'); return; }
+        setCreating(true);
+        setCreateError(null);
+        // Mark hand-entered identity fields as curator-sourced.
+        const overrides = {};
+        const fields = { test_group_id: id, overrides };
+        if (createDraft.model_year.trim())       { fields.model_year = Number(createDraft.model_year) || null; overrides.model_year = { source: 'manual' }; }
+        if (createDraft.make.trim())             { fields.make = createDraft.make.trim(); overrides.make = { source: 'manual' }; }
+        if (createDraft.epa_carline_name.trim()) { fields.epa_carline_name = createDraft.epa_carline_name.trim(); overrides.epa_carline_name = { source: 'manual' }; }
+        try {
+            await onCreate(vehicle.id, fields);
+            setShowCreate(false);
+            setCreateDraft({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
+        } catch (e) {
+            setCreateError(e?.message || 'Create failed');
+        } finally {
+            setCreating(false);
+        }
+    };
 
     const handleQueryChange = (e) => {
         const q = e.target.value;
@@ -283,11 +311,20 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
 
     return (
         <div className="mt-6">
-            <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center justify-between gap-2 mb-3">
                 <h3 className="section-title">
                     EPA Testing Data
                     <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
                 </h3>
+                <a
+                    href={EPA_SOURCE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline whitespace-nowrap"
+                    title="EPA Annual Certification Data — look up Test Groups, coefficients, and lab reports"
+                >
+                    EPA source data ↗
+                </a>
             </div>
 
             {/* Existing mappings */}
@@ -353,8 +390,84 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         )}
                     </div>
                     <p className="text-xs text-gray-400 mt-1">
-                        Results filtered by vehicle year when available. Import test groups via Admin → Import → EPA Test Car Data.
+                        Import test groups via Admin → Import → EPA Test Car Data, or create one by hand below.
                     </p>
+
+                    {/* Create from scratch — for vehicles with only a lab-submission PDF */}
+                    {!showCreate ? (
+                        <button
+                            type="button"
+                            onClick={() => { setShowCreate(true); setCreateError(null); }}
+                            className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline mt-2"
+                        >
+                            + Create EPA test group from scratch
+                        </button>
+                    ) : (
+                        <div className="mt-2 border rounded-lg p-3 border-gray-200 dark:border-slate-700">
+                            <div className="flex items-center justify-between mb-2">
+                                <span className="text-xs font-semibold">New EPA test group</span>
+                                <a href={EPA_SOURCE_URL} target="_blank" rel="noopener noreferrer"
+                                    className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline">
+                                    Find the Certified Test Group on EPA ↗
+                                </a>
+                            </div>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Test Group ID *</span>
+                                    <input
+                                        type="text" autoFocus
+                                        value={createDraft.test_group_id}
+                                        onChange={e => setCreateDraft(d => ({ ...d, test_group_id: e.target.value }))}
+                                        placeholder="e.g. SRIVT00.0R2A"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Model year</span>
+                                    <input
+                                        type="number"
+                                        value={createDraft.model_year}
+                                        onChange={e => setCreateDraft(d => ({ ...d, model_year: e.target.value }))}
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Manufacturer</span>
+                                    <input
+                                        type="text"
+                                        value={createDraft.make}
+                                        onChange={e => setCreateDraft(d => ({ ...d, make: e.target.value }))}
+                                        placeholder="e.g. Rivian"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Carline</span>
+                                    <input
+                                        type="text"
+                                        value={createDraft.epa_carline_name}
+                                        onChange={e => setCreateDraft(d => ({ ...d, epa_carline_name: e.target.value }))}
+                                        placeholder="e.g. R2"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                            </div>
+                            {createError && <p className="text-xs text-red-500 mt-1">{createError}</p>}
+                            <p className="text-[11px] text-gray-400 mt-1">
+                                Creates and links the group; add coefficients, tests and phases in the curator fields afterward.
+                            </p>
+                            <div className="flex gap-2 mt-2">
+                                <button type="button" onClick={handleCreate} disabled={creating}
+                                    className="btn btn-primary text-xs py-1 px-3 disabled:opacity-50">
+                                    {creating ? 'Creating…' : 'Create & link'}
+                                </button>
+                                <button type="button" onClick={() => setShowCreate(false)} disabled={creating}
+                                    className="btn btn-secondary text-xs py-1 px-3">
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -278,7 +278,7 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2526,6 +2526,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 canEdit={isContributor && canEdit(vehicle)}
                 searchEpaTestGroups={searchEpaTestGroups}
                 onLink={linkEpaTestGroup}
+                onCreate={createAndLinkEpaTestGroup}
                 onUnlink={unlinkEpaTestGroup}
                 onUpdateConfidence={updateEpaMapping}
                 onUpdateDisplayName={(testGroupId, name) =>

--- a/src/components/epa/AuditHistory.jsx
+++ b/src/components/epa/AuditHistory.jsx
@@ -1,0 +1,100 @@
+/**
+ * Audit-trail viewer for one EPA test group (Section: cross-cutting audit
+ * requirement). Lists who changed what, when, prior → new, and any source
+ * citation, across the group row and all its child rows (coefficient sets,
+ * tests, phases). Collapsible; loads on first open.
+ */
+import { useState } from 'react';
+
+const TABLE_LABEL = {
+    epa_test_groups:     'group',
+    epa_coefficient_sets:'coeff',
+    epa_tests:           'test',
+    epa_test_phases:     'phase',
+};
+
+function timeAgo(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export default function AuditHistory({ group, getEpaAuditForGroup }) {
+    const [open, setOpen]       = useState(false);
+    const [rows, setRows]       = useState(null); // null = not loaded
+    const [loading, setLoading] = useState(false);
+    const [error, setError]     = useState(null);
+
+    const childIds = [
+        ...(group.epa_coefficient_sets || []).map(s => s.id),
+        ...(group.epa_tests || []).flatMap(t => [t.id, ...(t.epa_test_phases || []).map(p => p.id)]),
+    ].filter(id => id != null);
+
+    const load = async () => {
+        setLoading(true); setError(null);
+        try {
+            setRows(await getEpaAuditForGroup(group.test_group_id, childIds));
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const toggle = () => {
+        const next = !open;
+        setOpen(next);
+        if (next && rows === null) load();
+    };
+
+    return (
+        <div className="mt-3 border-t border-gray-100 dark:border-slate-700 pt-2">
+            <button
+                type="button"
+                onClick={toggle}
+                className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:underline"
+            >
+                {open ? '▾' : '▸'} Edit history{rows?.length ? ` (${rows.length})` : ''}
+            </button>
+            {open && (
+                <div className="mt-2 text-[11px]">
+                    {loading && <p className="text-gray-400 italic">Loading…</p>}
+                    {error && <p className="text-red-500">Error: {error}</p>}
+                    {!loading && !error && rows && rows.length === 0 && (
+                        <p className="text-gray-400 italic">No edits recorded yet.</p>
+                    )}
+                    {!loading && rows && rows.length > 0 && (
+                        <div className="max-h-56 overflow-y-auto">
+                            <table className="w-full">
+                                <thead>
+                                    <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
+                                        <th className="font-semibold pr-2 py-0.5">When</th>
+                                        <th className="font-semibold pr-2">Field</th>
+                                        <th className="font-semibold pr-2">Change</th>
+                                        <th className="font-semibold">Source</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="font-mono">
+                                    {rows.map(r => (
+                                        <tr key={r.id} className="border-t border-gray-100 dark:border-slate-800 align-top">
+                                            <td className="pr-2 py-0.5 text-gray-400 whitespace-nowrap">{timeAgo(r.edited_at)}</td>
+                                            <td className="pr-2">
+                                                <span className="text-gray-400">{TABLE_LABEL[r.table_name] || r.table_name}·</span>{r.field}
+                                            </td>
+                                            <td className="pr-2">
+                                                <span className="text-gray-400 line-through">{r.prior_value ?? '∅'}</span>
+                                                {' → '}
+                                                <span className="text-gray-700 dark:text-slate-200">{r.new_value ?? '∅'}</span>
+                                            </td>
+                                            <td className="text-gray-400 italic">{r.source_citation || '—'}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -102,9 +102,20 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
 
     return (
         <div className="border-t border-gray-100 dark:border-slate-700 mt-3 pt-3">
-            <p className="text-[10px] text-gray-400 italic mb-2">
-                Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
-            </p>
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <p className="text-[10px] text-gray-400 italic">
+                    Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
+                </p>
+                <a
+                    href="https://dis.epa.gov/otaqpub/publist1.jsp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline whitespace-nowrap shrink-0"
+                    title="EPA Annual Certification Data — source of truth for test groups, coefficients, and lab reports"
+                >
+                    EPA source data ↗
+                </a>
+            </div>
 
             {/* Optional source citation applied to subsequent edits' audit entries */}
             {canEdit && (

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -13,6 +13,7 @@ import { useAppContext } from '../../context/AppContext';
 import CuratorField from './CuratorField';
 import DerivedValues from './DerivedValues';
 import TestPhaseEditor from './TestPhaseEditor';
+import AuditHistory from './AuditHistory';
 import { EPA_EXPLAINERS } from '../../utils/epaExplainers';
 
 function Section({ title, children }) {
@@ -28,12 +29,13 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
     const {
         getEpaTestGroupFull, updateEpaTestGroup,
         saveEpaCoefficientSet, saveEpaTest, deleteEpaTest,
-        saveEpaPhase, deleteEpaPhase, logEpaFieldEdit,
+        saveEpaPhase, deleteEpaPhase, logEpaFieldEdit, getEpaAuditForGroup,
     } = useAppContext();
 
     const [group, setGroup]   = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError]   = useState(null);
+    const [citation, setCitation] = useState(''); // optional source for subsequent edits
 
     const reload = useCallback(async () => {
         try {
@@ -60,7 +62,8 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
     const cOv = (f) => primary?.overrides?.[f]?.source;
 
     const audit = (tableName, rowId, field, prior, next) =>
-        logEpaFieldEdit?.({ tableName, rowId, field, priorValue: prior, newValue: next });
+        logEpaFieldEdit?.({ tableName, rowId, field, priorValue: prior, newValue: next,
+            sourceCitation: citation.trim() || null });
 
     // ── Save handlers (mark source:'manual' + audit + reload) ───────────────────
     const saveGroup = async (field, value) => {
@@ -99,9 +102,23 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
 
     return (
         <div className="border-t border-gray-100 dark:border-slate-700 mt-3 pt-3">
-            <p className="text-[10px] text-gray-400 italic mb-3">
+            <p className="text-[10px] text-gray-400 italic mb-2">
                 Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
             </p>
+
+            {/* Optional source citation applied to subsequent edits' audit entries */}
+            {canEdit && (
+                <div className="flex items-center gap-2 mb-3 text-xs">
+                    <span className="text-gray-500 dark:text-slate-400 shrink-0">Source citation</span>
+                    <input
+                        type="text"
+                        value={citation}
+                        onChange={e => setCitation(e.target.value)}
+                        placeholder="e.g. J1634 sheet p.3 / CSI PDF — applied to edits below"
+                        className="form-input text-xs py-0.5 flex-1"
+                    />
+                </div>
+            )}
 
             {/* Section 1: Identity */}
             <Section title="Identity & Configuration">
@@ -163,6 +180,9 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
                 <DerivedValues group={group} />
             </div>
+
+            {/* Audit trail */}
+            <AuditHistory group={group} getEpaAuditForGroup={getEpaAuditForGroup} />
         </div>
     );
 }

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -21,7 +21,31 @@ const PHASE_TYPES   = ['UDDS', 'HWY', 'SS', 'Cold-UDDS', 'US06', 'SC03'];
 const SOURCE_OPTS   = ['csv', 'j1634', 'csi_pdf', 'manual'];
 const ORIGINATORS   = ['MFR', 'EPA'];
 
+// Standard cycle distances (miles) for phase-type auto-suggestion.
+const HWFET_MI  = 10.26;
+const UDDS_MI   = 7.45;
+const DIST_TOL  = 0.7;   // ± tolerance around the standard distance
+
 const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
+
+/**
+ * Suggest a phase type from its distance (curator can always override):
+ *   ~10.26 mi → HWY, ~7.45 mi → UDDS, a bag ≫10× its neighbors → SS.
+ * Returns a type string or null when nothing matches confidently.
+ *
+ * @param {number} distanceMi
+ * @param {number[]} otherDistances  distances of the test's other phases
+ */
+export function suggestPhaseType(distanceMi, otherDistances = []) {
+    const d = num(distanceMi);
+    if (d == null || d <= 0) return null;
+    // SS: a depletion bag far longer than its shortest neighbor.
+    const others = otherDistances.map(num).filter(x => x != null && x > 0);
+    if (others.length && d >= 10 * Math.min(...others)) return 'SS';
+    if (Math.abs(d - HWFET_MI) <= DIST_TOL) return 'HWY';
+    if (Math.abs(d - UDDS_MI)  <= DIST_TOL) return 'UDDS';
+    return null;
+}
 
 function PhaseRow({ phase, canEdit, onSave, onDelete }) {
     const consumption = (() => {
@@ -81,6 +105,17 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
     const phases = [...(test.epa_test_phases || [])].sort((a, b) => a.phase_index - b.phase_index);
     const saveField = (field) => (val) => onSaveTest({ id: test.id, [field]: val });
 
+    // Auto-suggest the phase type from distance when the curator hasn't set one
+    // (never overrides an explicit choice). Uses sibling distances for the SS case.
+    const handleSavePhase = (row) => {
+        if (!row.phase_type && row.distance_mi != null) {
+            const others = phases.filter(p => p.id !== row.id).map(p => p.distance_mi);
+            const suggested = suggestPhaseType(row.distance_mi, others);
+            if (suggested) { onSavePhase({ ...row, phase_type: suggested }); return; }
+        }
+        onSavePhase(row);
+    };
+
     // Sanity: phase DC sum vs declared total; phase count vs declared bags.
     const phaseSum = phases.reduce((s, p) => s + (num(p.dc_energy_kwh) ?? 0), 0);
     const totalDc  = num(test.total_dc_energy_kwh);
@@ -139,7 +174,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                 <tbody>
                     {phases.map(p => (
                         <PhaseRow key={p.id} phase={p} canEdit={canEdit}
-                            onSave={onSavePhase} onDelete={onDeletePhase} />
+                            onSave={handleSavePhase} onDelete={onDeletePhase} />
                     ))}
                     {phases.length === 0 && (
                         <tr><td colSpan={6} className="py-1 text-gray-400 italic text-[11px]">No phases yet. Add the HWY phase to enable measured η.</td></tr>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -905,6 +905,10 @@ export function AppProvider({ children }) {
     /** Pass-through: read the audit trail for a row. */
     const getEpaFieldAudit = (tableName, rowId) => dataService.getEpaFieldAudit(tableName, rowId);
 
+    /** Pass-through: read the audit trail for a whole group (+ its child rows). */
+    const getEpaAuditForGroup = (testGroupId, childRowIds) =>
+        dataService.getEpaAuditForGroup(testGroupId, childRowIds);
+
     /** Delete an EPA test group and its vehicle mappings, then refresh vehicles. */
     const deleteEpaTestGroup = async (testGroupId) => {
         try {
@@ -1052,6 +1056,7 @@ export function AppProvider({ children }) {
         deleteEpaPhase,
         logEpaFieldEdit,
         getEpaFieldAudit,
+        getEpaAuditForGroup,
     };
 
     return (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -789,6 +789,24 @@ export function AppProvider({ children }) {
         }
     };
 
+    /**
+     * Create an EPA test group from scratch (hand-entered, e.g. from a lab PDF)
+     * and link it to the vehicle, then refresh so the curator form can fill in
+     * coefficients, tests and phases.
+     */
+    const createAndLinkEpaTestGroup = async (vehicleId, fields) => {
+        try {
+            await dataService.createEpaTestGroup(fields);
+            await dataService.linkEpaTestGroup(vehicleId, fields.test_group_id, 'likely', null);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('EPA test group created and linked.');
+        } catch (error) {
+            showError('Error creating EPA test group: ' + error.message);
+            throw error;
+        }
+    };
+
     const updateEpaMapping = async (mappingId, updates) => {
         try {
             await dataService.updateEpaMapping(mappingId, updates);
@@ -1041,6 +1059,7 @@ export function AppProvider({ children }) {
         clearDefaultRun,
         searchEpaTestGroups,
         linkEpaTestGroup,
+        createAndLinkEpaTestGroup,
         updateEpaMapping,
         unlinkEpaTestGroup,
         importEpaTestGroups,

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -899,8 +899,10 @@ export function AppProvider({ children }) {
         }
     };
 
-    /** Append an audit-trail entry. Best-effort: failures don't block the edit. */
-    const logEpaFieldEdit = (entry) => dataService.logEpaFieldEdit(entry);
+    /** Append an audit-trail entry. Best-effort: failures must never block or
+     *  surface from the edit that triggered them (fire-and-forget). */
+    const logEpaFieldEdit = (entry) =>
+        Promise.resolve(dataService.logEpaFieldEdit(entry)).catch(() => {});
 
     /** Pass-through: read the audit trail for a row. */
     const getEpaFieldAudit = (tableName, rowId) => dataService.getEpaFieldAudit(tableName, rowId);

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1335,6 +1335,27 @@ class DataService {
     return data || [];
   }
 
+  /**
+   * Fetch the audit trail for a whole test group: the group row plus all of its
+   * child rows (coefficient sets, tests, phases). Matches on the union of row
+   * ids (the group's text id + the stringified child ids). Most recent first.
+   *
+   * @param {string} testGroupId
+   * @param {Array<string|number>} childRowIds  ids of coeff sets / tests / phases
+   */
+  async getEpaAuditForGroup(testGroupId, childRowIds = []) {
+    if (!this.useSupabase) return [];
+    const ids = [String(testGroupId), ...childRowIds.map(String)];
+    const { data, error } = await getSupabase()
+      .from('epa_field_audit')
+      .select('*')
+      .in('row_id', ids)
+      .order('edited_at', { ascending: false })
+      .limit(200);
+    if (error) throw error;
+    return data || [];
+  }
+
   // ── Access logging ──────────────────────────────────────────────────────────
 
   /**

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1181,6 +1181,24 @@ class DataService {
     if (error) throw error;
   }
 
+  /**
+   * Create a single EPA test group by hand (no CSV) — for vehicles whose data
+   * only exists in a lab-submission PDF. Coefficient sets, tests, and phases
+   * are added afterward via the curator form. Fails on duplicate test_group_id.
+   *
+   * @param {Object} group  epa_test_groups fields (test_group_id required)
+   */
+  async createEpaTestGroup(group) {
+    if (!this.useSupabase) return null;
+    const { data, error } = await getSupabase()
+      .from('epa_test_groups')
+      .insert(group)
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
   /** Convenience alias kept for back-compat. */
   async updateEpaLabelMethod(testGroupId, method) {
     return this.updateEpaTestGroup(testGroupId, { label_method: method || null });

--- a/supabase/migrations/030_epa_drop_legacy_columns.sql
+++ b/supabase/migrations/030_epa_drop_legacy_columns.sql
@@ -1,0 +1,57 @@
+-- ============================================================
+-- Migration 030: EPA curator refactor — cleanup (drop legacy columns)
+--
+-- Apply ONLY after PRs C, D, E (+ F) are merged. By then no code reads these
+-- columns: coefficients live in epa_coefficient_sets, per-cycle/label-method/
+-- η data is superseded by the read-time DC-based derivations, and the surviving
+-- label fields (label_combined_mpge, label_hwy_mpge, label_range_published,
+-- cd_range_*) are populated by the new importer / curator form.
+--
+-- getEpaTestGroupFull() uses SELECT *, which tolerates the removed columns;
+-- no explicit select names any of them post-PR-E. Safe and reversible only via
+-- the migration-020/025 definitions, so confirm before running in prod.
+--
+-- KEPT (still in use): label_combined_mpge, label_hwy_mpge, label_range_published,
+--   cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient,
+--   useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override,
+--   charger_efficiency_override, evap_family, vehicle_config_number, display_name,
+--   overrides, identity columns.
+-- ============================================================
+
+ALTER TABLE public.epa_test_groups
+    -- Flat road-load coefficients + weight → moved to epa_coefficient_sets
+    DROP COLUMN IF EXISTS target_a,
+    DROP COLUMN IF EXISTS target_b,
+    DROP COLUMN IF EXISTS target_c,
+    DROP COLUMN IF EXISTS set_a,
+    DROP COLUMN IF EXISTS set_b,
+    DROP COLUMN IF EXISTS set_c,
+    DROP COLUMN IF EXISTS equiv_test_weight_lbs,
+
+    -- Per-cycle AC energy → superseded by DC-side phase data (epa_test_phases)
+    DROP COLUMN IF EXISTS udds_unadj_kwh_100mi,
+    DROP COLUMN IF EXISTS udds_adj_kwh_100mi,
+    DROP COLUMN IF EXISTS hwfet_unadj_kwh_100mi,
+    DROP COLUMN IF EXISTS hwfet_adj_kwh_100mi,
+    DROP COLUMN IF EXISTS us06_unadj_kwh_100mi,
+    DROP COLUMN IF EXISTS us06_adj_kwh_100mi,
+    DROP COLUMN IF EXISTS sc03_unadj_kwh_100mi,
+    DROP COLUMN IF EXISTS sc03_adj_kwh_100mi,
+    DROP COLUMN IF EXISTS cold_ftp_unadj_kwh_100mi,
+    DROP COLUMN IF EXISTS cold_ftp_adj_kwh_100mi,
+
+    -- Label-method inference → replaced by the effective-adjustment-factor derivation
+    DROP COLUMN IF EXISTS label_method,
+    DROP COLUMN IF EXISTS label_method_inferred,
+
+    -- η override → η is now purely derived from DC phase data
+    DROP COLUMN IF EXISTS drivetrain_eta_override,
+
+    -- Legacy range / label variants → replaced by cd_range_* / label_range_published
+    DROP COLUMN IF EXISTS range_city_mi,
+    DROP COLUMN IF EXISTS range_hwy_mi,
+    DROP COLUMN IF EXISTS range_combined_mi,
+    DROP COLUMN IF EXISTS label_city_mpge,
+    DROP COLUMN IF EXISTS label_combined_mi,
+    DROP COLUMN IF EXISTS label_city_mi,
+    DROP COLUMN IF EXISTS label_hwy_mi;


### PR DESCRIPTION
Consolidated final EPA curator PR. Because #115 and #117 were merged into this branch (stacked-PR parent), this now lands the remaining three pieces together on `main`:

- **Audit history** (orig PR F): `AuditHistory` viewer, `getEpaAuditForGroup`, source-citation input, fire-and-forget logging, and **migration 030** (drop legacy columns).
- **Create from scratch** (#115): hand-enter an EPA test group with no CSV (Rivian R2 case) + EPA source links → https://dis.epa.gov/otaqpub/publist1.jsp.
- **Phase-type auto-suggest** (#117): ~10.26 mi → HWY, ~7.45 mi → UDDS, ≫10× neighbors → SS; never overrides an explicit choice.

Rebased onto current `main` (which already has A–E + altitude). Build ✓.

⚠️ **Apply migration 030 in Supabase only after this merges** — it drops the now-dead legacy columns (keeps `label_combined_mpge`/`label_hwy_mpge` + all curator fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)