### PR TITLE
EPA curator: create test groups from scratch + EPA source links

### DIFF
--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -234,16 +234,44 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
+const EPA_SOURCE_URL = 'https://dis.epa.gov/otaqpub/publist1.jsp';
+
+export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroups, onLink, onCreate, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
     const [query, setQuery]               = useState('');
     const [results, setResults]           = useState([]);
     const [searching, setSearching]       = useState(false);
     const [searchError, setSearchError]   = useState(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [linking, setLinking]           = useState(false);
+    const [showCreate, setShowCreate]     = useState(false);
+    const [createDraft, setCreateDraft]   = useState({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
+    const [creating, setCreating]         = useState(false);
+    const [createError, setCreateError]   = useState(null);
     const debounceRef = useRef(null);
 
     const mappings = vehicle?.epa_mappings ?? [];
+
+    const handleCreate = async () => {
+        const id = createDraft.test_group_id.trim();
+        if (!id) { setCreateError('Test Group ID is required.'); return; }
+        setCreating(true);
+        setCreateError(null);
+        // Mark hand-entered identity fields as curator-sourced.
+        const overrides = {};
+        const fields = { test_group_id: id, overrides };
+        if (createDraft.model_year.trim())       { fields.model_year = Number(createDraft.model_year) || null; overrides.model_year = { source: 'manual' }; }
+        if (createDraft.make.trim())             { fields.make = createDraft.make.trim(); overrides.make = { source: 'manual' }; }
+        if (createDraft.epa_carline_name.trim()) { fields.epa_carline_name = createDraft.epa_carline_name.trim(); overrides.epa_carline_name = { source: 'manual' }; }
+        try {
+            await onCreate(vehicle.id, fields);
+            setShowCreate(false);
+            setCreateDraft({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
+        } catch (e) {
+            setCreateError(e?.message || 'Create failed');
+        } finally {
+            setCreating(false);
+        }
+    };
 
     const handleQueryChange = (e) => {
         const q = e.target.value;
@@ -283,11 +311,20 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
 
     return (
         <div className="mt-6">
-            <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center justify-between gap-2 mb-3">
                 <h3 className="section-title">
                     EPA Testing Data
                     <InfoIcon text={EPA_EXPLAINERS.steadyStateCurve} position="right" className="ml-1" />
                 </h3>
+                <a
+                    href={EPA_SOURCE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline whitespace-nowrap"
+                    title="EPA Annual Certification Data — look up Test Groups, coefficients, and lab reports"
+                >
+                    EPA source data ↗
+                </a>
             </div>
 
             {/* Existing mappings */}
@@ -353,8 +390,84 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         )}
                     </div>
                     <p className="text-xs text-gray-400 mt-1">
-                        Results filtered by vehicle year when available. Import test groups via Admin → Import → EPA Test Car Data.
+                        Import test groups via Admin → Import → EPA Test Car Data, or create one by hand below.
                     </p>
+
+                    {/* Create from scratch — for vehicles with only a lab-submission PDF */}
+                    {!showCreate ? (
+                        <button
+                            type="button"
+                            onClick={() => { setShowCreate(true); setCreateError(null); }}
+                            className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline mt-2"
+                        >
+                            + Create EPA test group from scratch
+                        </button>
+                    ) : (
+                        <div className="mt-2 border rounded-lg p-3 border-gray-200 dark:border-slate-700">
+                            <div className="flex items-center justify-between mb-2">
+                                <span className="text-xs font-semibold">New EPA test group</span>
+                                <a href={EPA_SOURCE_URL} target="_blank" rel="noopener noreferrer"
+                                    className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline">
+                                    Find the Certified Test Group on EPA ↗
+                                </a>
+                            </div>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Test Group ID *</span>
+                                    <input
+                                        type="text" autoFocus
+                                        value={createDraft.test_group_id}
+                                        onChange={e => setCreateDraft(d => ({ ...d, test_group_id: e.target.value }))}
+                                        placeholder="e.g. SRIVT00.0R2A"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Model year</span>
+                                    <input
+                                        type="number"
+                                        value={createDraft.model_year}
+                                        onChange={e => setCreateDraft(d => ({ ...d, model_year: e.target.value }))}
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Manufacturer</span>
+                                    <input
+                                        type="text"
+                                        value={createDraft.make}
+                                        onChange={e => setCreateDraft(d => ({ ...d, make: e.target.value }))}
+                                        placeholder="e.g. Rivian"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                                <label className="text-xs">
+                                    <span className="text-gray-500 dark:text-slate-400">Carline</span>
+                                    <input
+                                        type="text"
+                                        value={createDraft.epa_carline_name}
+                                        onChange={e => setCreateDraft(d => ({ ...d, epa_carline_name: e.target.value }))}
+                                        placeholder="e.g. R2"
+                                        className="form-input text-xs w-full mt-0.5"
+                                    />
+                                </label>
+                            </div>
+                            {createError && <p className="text-xs text-red-500 mt-1">{createError}</p>}
+                            <p className="text-[11px] text-gray-400 mt-1">
+                                Creates and links the group; add coefficients, tests and phases in the curator fields afterward.
+                            </p>
+                            <div className="flex gap-2 mt-2">
+                                <button type="button" onClick={handleCreate} disabled={creating}
+                                    className="btn btn-primary text-xs py-1 px-3 disabled:opacity-50">
+                                    {creating ? 'Creating…' : 'Create & link'}
+                                </button>
+                                <button type="button" onClick={() => setShowCreate(false)} disabled={creating}
+                                    className="btn btn-secondary text-xs py-1 px-3">
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -278,7 +278,7 @@ const EstimateTimePanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2526,6 +2526,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 canEdit={isContributor && canEdit(vehicle)}
                 searchEpaTestGroups={searchEpaTestGroups}
                 onLink={linkEpaTestGroup}
+                onCreate={createAndLinkEpaTestGroup}
                 onUnlink={unlinkEpaTestGroup}
                 onUpdateConfidence={updateEpaMapping}
                 onUpdateDisplayName={(testGroupId, name) =>

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -102,9 +102,20 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
 
     return (
         <div className="border-t border-gray-100 dark:border-slate-700 mt-3 pt-3">
-            <p className="text-[10px] text-gray-400 italic mb-2">
-                Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
-            </p>
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <p className="text-[10px] text-gray-400 italic">
+                    Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
+                </p>
+                <a
+                    href="https://dis.epa.gov/otaqpub/publist1.jsp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline whitespace-nowrap shrink-0"
+                    title="EPA Annual Certification Data — source of truth for test groups, coefficients, and lab reports"
+                >
+                    EPA source data ↗
+                </a>
+            </div>
 
             {/* Optional source citation applied to subsequent edits' audit entries */}
             {canEdit && (

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -789,6 +789,24 @@ export function AppProvider({ children }) {
         }
     };
 
+    /**
+     * Create an EPA test group from scratch (hand-entered, e.g. from a lab PDF)
+     * and link it to the vehicle, then refresh so the curator form can fill in
+     * coefficients, tests and phases.
+     */
+    const createAndLinkEpaTestGroup = async (vehicleId, fields) => {
+        try {
+            await dataService.createEpaTestGroup(fields);
+            await dataService.linkEpaTestGroup(vehicleId, fields.test_group_id, 'likely', null);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('EPA test group created and linked.');
+        } catch (error) {
+            showError('Error creating EPA test group: ' + error.message);
+            throw error;
+        }
+    };
+
     const updateEpaMapping = async (mappingId, updates) => {
         try {
             await dataService.updateEpaMapping(mappingId, updates);
@@ -1041,6 +1059,7 @@ export function AppProvider({ children }) {
         clearDefaultRun,
         searchEpaTestGroups,
         linkEpaTestGroup,
+        createAndLinkEpaTestGroup,
         updateEpaMapping,
         unlinkEpaTestGroup,
         importEpaTestGroups,

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1181,6 +1181,24 @@ class DataService {
     if (error) throw error;
   }
 
+  /**
+   * Create a single EPA test group by hand (no CSV) — for vehicles whose data
+   * only exists in a lab-submission PDF. Coefficient sets, tests, and phases
+   * are added afterward via the curator form. Fails on duplicate test_group_id.
+   *
+   * @param {Object} group  epa_test_groups fields (test_group_id required)
+   */
+  async createEpaTestGroup(group) {
+    if (!this.useSupabase) return null;
+    const { data, error } = await getSupabase()
+      .from('epa_test_groups')
+      .insert(group)
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
   /** Convenience alias kept for back-compat. */
   async updateEpaLabelMethod(testGroupId, method) {
     return this.updateEpaTestGroup(testGroupId, { label_method: method || null });


### PR DESCRIPTION
Lets curators build an EPA test group entirely by hand — no CSV — for vehicles whose data only exists in a lab-submission PDF (your Rivian R2 case). **Stacked on PR F** (#114), which is stacked on E (#113). Retarget to `main` as the stack merges.

## Create from scratch
- **`+ Create EPA test group from scratch`** in Tests & Data → a small form: **Test Group ID** (required, the EPA Certified Test Group) plus optional model year / manufacturer / carline (hand-entered fields tagged `source:'manual'`).
- Creates the group, links it to the vehicle, and refreshes. From there the **existing curator form** fills in coefficients, tests, and phases — every field is editable, so a CSV is never required. Adding a proc-77 HWY phase still yields a measured η exactly as with imported groups.
- `DataService.createEpaTestGroup` (insert, curator RLS) + `AppContext.createAndLinkEpaTestGroup`.

## EPA source-of-truth links
Added **`EPA source data ↗`** → https://dis.epa.gov/otaqpub/publist1.jsp in three spots: the EPA Testing Data section header, the create form ("Find the Certified Test Group on EPA"), and the curator editor header.

## Verify
Tests & Data on a vehicle with no EPA data → **Create from scratch** → enter a Test Group ID (e.g. `SRIVT00.0R2A`), Rivian, R2 → Create & link → the card appears → **Curate fields & test data** → enter coefficients + a proc-77 test + HWY phase → curve renders with a measured η.

Build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)