### PR TITLE
EPA curator form: phase auto-suggest fix, alignment, calc markers, tooltips

### DIFF
--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -44,8 +44,21 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
     const [draftName,    setDraftName]    = useState(null); // null = not editing
     const [savingName,   setSavingName]   = useState(false);
     const [curating,     setCurating]     = useState(false);
+    const [curatorDirty, setCuratorDirty] = useState(false);
     const g = mapping.epaGroup;
     if (!g) return null;
+
+    // Guard collapse: confirm before discarding unsaved buffered curator edits.
+    const toggleCurate = () => {
+        if (curating) {
+            if (curatorDirty && !window.confirm('You have unsaved curator edits. Discard them and close?')) return;
+            setCuratorDirty(false);
+            setCurating(false);
+        } else {
+            setCuratorDirty(false);
+            setCurating(true);
+        }
+    };
 
     const fmt = (n, dp = 4) => n != null ? n.toFixed(dp) : null;
     // Coefficients now live on the primary coefficient set, not flat columns.
@@ -220,12 +233,19 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
                 <>
                     <button
                         type="button"
-                        onClick={() => setCurating(c => !c)}
+                        onClick={toggleCurate}
                         className="mt-3 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
                     >
                         {curating ? '▾ Hide curator fields' : '▸ Curate fields & test data'}
+                        {curating && curatorDirty && <span className="ml-1 text-amber-500" title="Unsaved edits">●</span>}
                     </button>
-                    {curating && <EpaCuratorEditor testGroupId={g.test_group_id} canEdit={canEdit} />}
+                    {curating && (
+                        <EpaCuratorEditor
+                            testGroupId={g.test_group_id}
+                            canEdit={canEdit}
+                            onDirtyChange={setCuratorDirty}
+                        />
+                    )}
                 </>
             )}
         </div>

--- a/src/components/epa/CuratorField.jsx
+++ b/src/components/epa/CuratorField.jsx
@@ -52,6 +52,9 @@ export default function CuratorField({
                 {used && <span title="Used in a derived calculation" className="text-indigo-500">∗</span>}
                 {label}
                 {tooltip && <InfoIcon text={tooltip} position="right" />}
+                {overrideSource === 'pending' && (
+                    <span title="Unsaved edit — click Save changes to commit" className="text-amber-500 text-[9px] font-bold">✎</span>
+                )}
                 {overrideSource === 'manual' && (
                     <span title="Curator-overridden value" className="text-amber-500 text-[9px] font-bold">●</span>
                 )}

--- a/src/components/epa/CuratorField.jsx
+++ b/src/components/epa/CuratorField.jsx
@@ -19,6 +19,7 @@ export default function CuratorField({
     step,
     placeholder,
     overrideSource,        // 'csv' | 'manual' | undefined
+    used = false,          // true ⇒ feeds a derived calculation (highlighted)
     canEdit = true,
     onSave,                // (newValue) => Promise|void
 }) {
@@ -47,7 +48,8 @@ export default function CuratorField({
 
     return (
         <div className="flex items-center justify-between gap-2 py-0.5">
-            <span className="text-gray-500 dark:text-slate-400 shrink-0 flex items-center gap-1">
+            <span className={`shrink-0 flex items-center gap-1 ${used ? 'text-gray-700 dark:text-slate-200 font-semibold' : 'text-gray-500 dark:text-slate-400'}`}>
+                {used && <span title="Used in a derived calculation" className="text-indigo-500">∗</span>}
                 {label}
                 {tooltip && <InfoIcon text={tooltip} position="right" />}
                 {overrideSource === 'manual' && (
@@ -57,7 +59,9 @@ export default function CuratorField({
                     <span title="Imported from CSV" className="text-gray-300 dark:text-slate-600 text-[9px]">csv</span>
                 )}
             </span>
-            <span className="flex items-center gap-1 min-w-0">
+            {/* Fixed-width input + always-present unit column so right edges align
+                whether or not a field has a unit label. */}
+            <span className="flex items-center gap-1 shrink-0">
                 {canEdit ? (
                     <input
                         type={type === 'number' ? 'number' : 'text'}
@@ -72,9 +76,9 @@ export default function CuratorField({
                         className="form-input text-xs py-0.5 px-1.5 w-28 text-right font-mono disabled:opacity-50"
                     />
                 ) : (
-                    <span className="font-mono text-xs text-right">{value ?? '—'}</span>
+                    <span className="font-mono text-xs text-right w-28">{value ?? '—'}</span>
                 )}
-                {unit && <span className="text-gray-400 text-[10px] w-12 shrink-0">{unit}</span>}
+                <span className="text-gray-400 text-[10px] w-10 shrink-0">{unit || ''}</span>
             </span>
         </div>
     );

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -51,7 +51,7 @@ const TIP = {
     charger_override:  'Default derived from Total DC ÷ AC Recharge (≈0.84 measured for R2). Falls back to 0.90 when AC recharge is unavailable. Override to pin a known value.',
 };
 
-export default function EpaCuratorEditor({ testGroupId, canEdit }) {
+export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }) {
     const {
         getEpaTestGroupFull, updateEpaTestGroup,
         saveEpaCoefficientSet, saveEpaTest, deleteEpaTest,
@@ -98,6 +98,9 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
         window.addEventListener('beforeunload', h);
         return () => window.removeEventListener('beforeunload', h);
     }, [dirty]);
+
+    // Surface dirty state to the parent so it can guard collapse/navigation.
+    useEffect(() => { onDirtyChange?.(dirty); }, [dirty, onDirtyChange]);
 
     // Display view = DB truth with buffered edits overlaid. Drives every field
     // value AND the live derived-value/curve preview, so you see impact before Save.

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -240,31 +240,24 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
                 </div>
             )}
 
-            {/* Save / Discard bar — field edits are buffered until saved */}
-            {canEdit && (
-                <div className="flex items-center gap-2 mb-3 py-2 px-3 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800/40 sticky top-0 z-10">
-                    <button
-                        type="button"
-                        onClick={handleSave}
-                        disabled={!dirty || saving}
-                        className="btn btn-primary text-xs py-1 px-3 disabled:opacity-40"
-                    >
-                        {saving ? 'Saving…' : 'Save changes'}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={resetEdits}
-                        disabled={!dirty || saving}
-                        className="btn btn-secondary text-xs py-1 px-3 disabled:opacity-40"
-                    >
-                        Discard
-                    </button>
-                    <span className={`text-[11px] ${dirty ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-400'}`}>
-                        {dirty ? '● Unsaved field edits' : 'All changes saved'}
-                    </span>
-                    <span className="text-[10px] text-gray-400 ml-auto italic">
-                        Adding/removing tests &amp; phases saves immediately.
-                    </span>
+            {/* Save / Discard — fixed bottom action bar (shown only when dirty),
+                matching the app's delete-queue paradigm. */}
+            {canEdit && dirty && (
+                <div className="fixed-action-bar z-50 bg-amber-50 dark:bg-slate-800 border-t-2 border-amber-200 dark:border-slate-600">
+                    <div className="page-container py-3 flex items-center gap-4">
+                        <span className="font-medium flex-1 text-amber-800 dark:text-amber-300">
+                            ✎ Unsaved curator edits
+                            <span className="font-normal text-amber-700/70 dark:text-slate-400 text-sm ml-2">
+                                (adding/removing tests &amp; phases saves immediately)
+                            </span>
+                        </span>
+                        <button onClick={resetEdits} disabled={saving} className="btn btn-secondary text-sm disabled:opacity-40">
+                            Discard
+                        </button>
+                        <button onClick={handleSave} disabled={saving} className="btn btn-primary text-sm disabled:opacity-40">
+                            {saving ? 'Saving…' : 'Save changes'}
+                        </button>
+                    </div>
                 </div>
             )}
 

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -8,7 +8,7 @@
  * row's `overrides`, and appends an audit-trail entry. Derivations (Section 8)
  * recompute live from the edited model.
  */
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useAppContext } from '../../context/AppContext';
 import CuratorField from './CuratorField';
 import DerivedValues from './DerivedValues';
@@ -58,15 +58,24 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
         saveEpaPhase, deleteEpaPhase, logEpaFieldEdit, getEpaAuditForGroup,
     } = useAppContext();
 
-    const [group, setGroup]   = useState(null);
+    const [dbGroup, setDbGroup] = useState(null);
     const [loading, setLoading] = useState(true);
-    const [error, setError]   = useState(null);
+    const [error, setError]     = useState(null);
     const [citation, setCitation] = useState(''); // optional source for subsequent edits
+    const [saving, setSaving]   = useState(false);
+
+    // Buffered scalar-field edits — gated behind Save (structural add/delete of
+    // tests & phases stay live). Shape:
+    //   group:  { [field]: value }
+    //   coeff:  { [field]: value }          (primary coefficient set)
+    //   tests:  { [testId]:  { [field]: value } }
+    //   phases: { [phaseId]: { [field]: value } }
+    const [edits, setEdits] = useState({ group: {}, coeff: {}, tests: {}, phases: {} });
+    const resetEdits = () => setEdits({ group: {}, coeff: {}, tests: {}, phases: {} });
 
     const reload = useCallback(async () => {
         try {
-            const g = await getEpaTestGroupFull(testGroupId);
-            setGroup(g);
+            setDbGroup(await getEpaTestGroupFull(testGroupId));
         } catch (e) {
             setError(e.message);
         } finally {
@@ -76,50 +85,117 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
 
     useEffect(() => { reload(); }, [reload]);
 
+    const dirty =
+        Object.keys(edits.group).length > 0 ||
+        Object.keys(edits.coeff).length > 0 ||
+        Object.values(edits.tests).some(o => Object.keys(o).length) ||
+        Object.values(edits.phases).some(o => Object.keys(o).length);
+
+    // Warn before leaving/refreshing the tab with unsaved buffered edits.
+    useEffect(() => {
+        if (!dirty) return;
+        const h = (e) => { e.preventDefault(); e.returnValue = ''; };
+        window.addEventListener('beforeunload', h);
+        return () => window.removeEventListener('beforeunload', h);
+    }, [dirty]);
+
+    // Display view = DB truth with buffered edits overlaid. Drives every field
+    // value AND the live derived-value/curve preview, so you see impact before Save.
+    const group = useMemo(() => {
+        if (!dbGroup) return null;
+        const hasPrimary = (dbGroup.epa_coefficient_sets || []).some(s => s.is_primary);
+        const sets = (dbGroup.epa_coefficient_sets || []).map((s, i) =>
+            (s.is_primary || (!hasPrimary && i === 0)) ? { ...s, ...edits.coeff } : s);
+        const tests = (dbGroup.epa_tests || []).map(t => ({
+            ...t,
+            ...(edits.tests[t.id] || {}),
+            epa_test_phases: (t.epa_test_phases || []).map(p => ({ ...p, ...(edits.phases[p.id] || {}) })),
+        }));
+        return { ...dbGroup, ...edits.group, epa_coefficient_sets: sets, epa_tests: tests };
+    }, [dbGroup, edits]);
+
     if (loading) return <p className="text-xs text-gray-400 italic py-2">Loading curator data…</p>;
     if (error)   return <p className="text-xs text-red-500 py-2">Error: {error}</p>;
     if (!group)  return null;
 
-    const primary = (group.epa_coefficient_sets || []).find(s => s.is_primary)
-        || (group.epa_coefficient_sets || [])[0] || null;
+    const primary    = (group.epa_coefficient_sets || []).find(s => s.is_primary)    || (group.epa_coefficient_sets || [])[0]    || null;
+    const primaryRaw = (dbGroup.epa_coefficient_sets || []).find(s => s.is_primary) || (dbGroup.epa_coefficient_sets || [])[0] || null;
 
-    // Provenance helpers
-    const gOv = (f) => group.overrides?.[f]?.source;
-    const cOv = (f) => primary?.overrides?.[f]?.source;
+    // Provenance: 'pending' for unsaved buffered edits, else the saved source.
+    const gOv = (f) => (f in edits.group) ? 'pending' : dbGroup.overrides?.[f]?.source;
+    const cOv = (f) => (f in edits.coeff) ? 'pending' : primaryRaw?.overrides?.[f]?.source;
 
+    const now = () => new Date().toISOString();
     const audit = (tableName, rowId, field, prior, next) =>
         logEpaFieldEdit?.({ tableName, rowId, field, priorValue: prior, newValue: next,
             sourceCitation: citation.trim() || null });
 
-    // ── Save handlers (mark source:'manual' + audit + reload) ───────────────────
-    const saveGroup = async (field, value) => {
-        const prior = group[field];
-        const overrides = { ...(group.overrides || {}), [field]: { source: 'manual', at: new Date().toISOString() } };
-        await updateEpaTestGroup(testGroupId, { [field]: value, overrides });
-        audit('epa_test_groups', testGroupId, field, prior, value);
-        await reload();
+    // ── Buffered field edits (no DB write until Save) ───────────────────────────
+    const saveGroup = (field, value) => setEdits(e => ({ ...e, group: { ...e.group, [field]: value } }));
+    const saveCoeff = (field, value) => setEdits(e => ({ ...e, coeff: { ...e.coeff, [field]: value } }));
+    const saveTest = (row) => {
+        const { id, ...fields } = row;
+        if (id == null) return;
+        setEdits(e => ({ ...e, tests: { ...e.tests, [id]: { ...(e.tests[id] || {}), ...fields } } }));
+    };
+    const savePhase = (row) => {
+        const { id, phase_type, dc_energy_kwh, distance_mi } = row;
+        if (id == null) return;
+        setEdits(e => ({ ...e, phases: { ...e.phases, [id]: { ...(e.phases[id] || {}), phase_type, dc_energy_kwh, distance_mi } } }));
     };
 
-    const saveCoeff = async (field, value) => {
-        const base = primary || { test_group_id: testGroupId, category: 'City/Highway', is_primary: true };
-        const prior = base[field];
-        const overrides = { ...(base.overrides || {}), [field]: { source: 'manual', at: new Date().toISOString() } };
-        const saved = await saveEpaCoefficientSet({ ...(primary?.id ? { id: primary.id } : {}), test_group_id: testGroupId, category: base.category, is_primary: true, [field]: value, overrides });
-        audit('epa_coefficient_sets', saved?.id ?? primary?.id ?? testGroupId, field, prior, value);
-        await reload();
-    };
-
-    const saveTest = async (row) => {
-        await saveEpaTest(row.id ? row : { ...row, test_group_id: testGroupId });
-        await reload();
-    };
-    const removeTest = async (t) => { await deleteEpaTest(t.id); await reload(); };
+    // ── Structural ops stay live (immediate DB write + reload) ──────────────────
+    const dropTestEdits  = (id) => setEdits(e => { const tests = { ...e.tests }; delete tests[id]; return { ...e, tests }; });
+    const dropPhaseEdits = (id) => setEdits(e => { const phases = { ...e.phases }; delete phases[id]; return { ...e, phases }; });
     const addTest = async () => {
         await saveEpaTest({ test_group_id: testGroupId, procedure_code: 77, source: 'manual' });
         await reload();
     };
-    const savePhase = async (row) => { await saveEpaPhase(row); await reload(); };
-    const removePhase = async (p) => { await deleteEpaPhase(p.id); await reload(); };
+    const removeTest = async (t) => {
+        (t.epa_test_phases || []).forEach(p => dropPhaseEdits(p.id));
+        dropTestEdits(t.id);
+        await deleteEpaTest(t.id);
+        await reload();
+    };
+    const removePhase = async (p) => { dropPhaseEdits(p.id); await deleteEpaPhase(p.id); await reload(); };
+
+    // ── Save / Discard the buffered field edits ─────────────────────────────────
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            const gf = edits.group;
+            if (Object.keys(gf).length) {
+                const overrides = { ...(dbGroup.overrides || {}) };
+                Object.keys(gf).forEach(f => { overrides[f] = { source: 'manual', at: now() }; });
+                await updateEpaTestGroup(testGroupId, { ...gf, overrides });
+                Object.keys(gf).forEach(f => audit('epa_test_groups', testGroupId, f, dbGroup[f], gf[f]));
+            }
+            const cf = edits.coeff;
+            if (Object.keys(cf).length) {
+                const base = primaryRaw || { category: 'City/Highway', is_primary: true };
+                const overrides = { ...(base.overrides || {}) };
+                Object.keys(cf).forEach(f => { overrides[f] = { source: 'manual', at: now() }; });
+                const saved = await saveEpaCoefficientSet({
+                    ...(primaryRaw?.id ? { id: primaryRaw.id } : {}),
+                    test_group_id: testGroupId, category: base.category || 'City/Highway', is_primary: true,
+                    ...cf, overrides,
+                });
+                Object.keys(cf).forEach(f => audit('epa_coefficient_sets', saved?.id ?? primaryRaw?.id, f, base[f], cf[f]));
+            }
+            for (const [id, fields] of Object.entries(edits.tests)) {
+                if (Object.keys(fields).length) await saveEpaTest({ id: Number(id), ...fields });
+            }
+            for (const [id, fields] of Object.entries(edits.phases)) {
+                if (Object.keys(fields).length) await saveEpaPhase({ id: Number(id), ...fields });
+            }
+            resetEdits();
+            await reload();
+        } catch (e) {
+            setError('Save failed: ' + e.message);
+        } finally {
+            setSaving(false);
+        }
+    };
     // Add `count` phases (default 1) with no type set, so distance-entry can
     // auto-suggest it. count>1 is used by the "Add X phases" bulk action.
     const addPhase = async (test, count = 1) => {
@@ -158,6 +234,34 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
                         placeholder="e.g. J1634 sheet p.3 / CSI PDF — applied to edits below"
                         className="form-input text-xs py-0.5 flex-1"
                     />
+                </div>
+            )}
+
+            {/* Save / Discard bar — field edits are buffered until saved */}
+            {canEdit && (
+                <div className="flex items-center gap-2 mb-3 py-2 px-3 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800/40 sticky top-0 z-10">
+                    <button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={!dirty || saving}
+                        className="btn btn-primary text-xs py-1 px-3 disabled:opacity-40"
+                    >
+                        {saving ? 'Saving…' : 'Save changes'}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={resetEdits}
+                        disabled={!dirty || saving}
+                        className="btn btn-secondary text-xs py-1 px-3 disabled:opacity-40"
+                    >
+                        Discard
+                    </button>
+                    <span className={`text-[11px] ${dirty ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-400'}`}>
+                        {dirty ? '● Unsaved field edits' : 'All changes saved'}
+                    </span>
+                    <span className="text-[10px] text-gray-400 ml-auto italic">
+                        Adding/removing tests &amp; phases saves immediately.
+                    </span>
                 </div>
             )}
 

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -14,7 +14,6 @@ import CuratorField from './CuratorField';
 import DerivedValues from './DerivedValues';
 import TestPhaseEditor from './TestPhaseEditor';
 import AuditHistory from './AuditHistory';
-import { EPA_EXPLAINERS } from '../../utils/epaExplainers';
 
 function Section({ title, children }) {
     return (
@@ -24,6 +23,33 @@ function Section({ title, children }) {
         </div>
     );
 }
+
+// Field tooltips, verbatim from LocalDev/curator-fields-spec.md.
+const TIP = {
+    model_year:        'EPA active model year. May differ from marketing year.',
+    make:              'Certificate Manufacturer Name — the certifying manufacturer entity.',
+    carline:           "EPA's model name (Represented Test Vehicle Model) — frequently differs from the marketing name. Preserve verbatim.",
+    config:            'Specific tested configuration. One test group can cover multiple configs (e.g. different wheel/tire packages).',
+    drive:             'Test Drive Description — F/R/A/4 (front, rear, all-wheel, 4-wheel drive).',
+    evap_family:       'Certified Evaporative Family code. Blank for BEVs — its absence is itself a BEV indicator.',
+    fuel_category:     'Vehicle Fuel Category — Electricity / gasoline / diesel / etc. Determines which result units apply.',
+    weight:            'Equivalent Test Weight: curb weight + 300 lb, rounded. Dyno inertia value; differs from curb weight.',
+    target_a:          'Target Coefficient A (lbf): constant road-load term, dominated by rolling resistance. From EPA-accepted coastdown. Default for calculations.',
+    target_b:          'Target Coefficient B (lbf/mph): linear road-load term.',
+    target_c:          'Target Coefficient C (lbf/mph²): quadratic term, dominated by aerodynamic drag.',
+    set_abc:           'Set Coefficients: what was actually programmed on the dyno. Usually matches Target; kept when they differ. Target is the default for calculations.',
+    cd_range_combined: 'Charge Depleting Range (Calculated): unadjusted combined range from the test, before real-world derating.',
+    cd_range_hwy:      'Charge Depleting Range Highway (Calculated): unadjusted highway range.',
+    label_range:       'The window-sticker range after adjustment. Published ÷ computed combined range reveals the effective adjustment factor.',
+    label_combined:    'Published combined efficiency, AC-side, at 33.7 kWh/gal. City-weighted (55/45) — flatters EVs. Not comparable across label methods.',
+    label_hwy:         'Highway-only label MPGe (proc 84). Useful secondary metric; not the combined value.',
+    derived_5cycle:    'Present if the cert used a vehicle-specific 5-cycle adjustment rather than the default 0.7. Blank suggests the conservative 0.7 default.',
+    useable_kwh:       'Useable kWh — distinct from nameplate/gross. Drives range-mode chart. Cross-check against total DC discharged to depletion.',
+    total_voltage:     'Pack voltage. With amp-hours, an alternate route to capacity.',
+    specific_energy:   'Wh/kg. Fallback capacity estimate when capacity is blank.',
+    accessory_load:    'Default 300 W. Constant parasitic draw assumed in the efficiency back-solve. Override only with documented cause.',
+    charger_override:  'Default derived from Total DC ÷ AC Recharge (≈0.84 measured for R2). Falls back to 0.90 when AC recharge is unavailable. Override to pin a known value.',
+};
 
 export default function EpaCuratorEditor({ testGroupId, canEdit }) {
     const {
@@ -94,9 +120,13 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
     };
     const savePhase = async (row) => { await saveEpaPhase(row); await reload(); };
     const removePhase = async (p) => { await deleteEpaPhase(p.id); await reload(); };
-    const addPhase = async (test) => {
-        const next = (test.epa_test_phases || []).reduce((m, p) => Math.max(m, p.phase_index), 0) + 1;
-        await saveEpaPhase({ test_id: test.id, phase_index: next, phase_type: 'HWY' });
+    // Add `count` phases (default 1) with no type set, so distance-entry can
+    // auto-suggest it. count>1 is used by the "Add X phases" bulk action.
+    const addPhase = async (test, count = 1) => {
+        let next = (test.epa_test_phases || []).reduce((m, p) => Math.max(m, p.phase_index), 0) + 1;
+        for (let i = 0; i < count; i++) {
+            await saveEpaPhase({ test_id: test.id, phase_index: next++, phase_type: null });
+        }
         await reload();
     };
 
@@ -133,25 +163,25 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
 
             {/* Section 1: Identity */}
             <Section title="Identity & Configuration">
-                <CuratorField label="Model year" type="number" value={group.model_year} canEdit={canEdit} overrideSource={gOv('model_year')} onSave={v => saveGroup('model_year', v)} />
-                <CuratorField label="Manufacturer" value={group.make} canEdit={canEdit} overrideSource={gOv('make')} onSave={v => saveGroup('make', v)} />
-                <CuratorField label="Carline" value={group.epa_carline_name} canEdit={canEdit} overrideSource={gOv('epa_carline_name')} onSave={v => saveGroup('epa_carline_name', v)} />
-                <CuratorField label="Config #" value={group.vehicle_config_number} canEdit={canEdit} overrideSource={gOv('vehicle_config_number')} onSave={v => saveGroup('vehicle_config_number', v)} />
-                <CuratorField label="Drive" value={group.drive} canEdit={canEdit} overrideSource={gOv('drive')} onSave={v => saveGroup('drive', v)} />
-                <CuratorField label="Evap family" value={group.evap_family} canEdit={canEdit} overrideSource={gOv('evap_family')} onSave={v => saveGroup('evap_family', v)} />
-                <CuratorField label="Fuel category" value={group.fuel_type} canEdit={canEdit} overrideSource={gOv('fuel_type')} onSave={v => saveGroup('fuel_type', v)} />
+                <CuratorField label="Model year" type="number" tooltip={TIP.model_year} value={group.model_year} canEdit={canEdit} overrideSource={gOv('model_year')} onSave={v => saveGroup('model_year', v)} />
+                <CuratorField label="Manufacturer" tooltip={TIP.make} value={group.make} canEdit={canEdit} overrideSource={gOv('make')} onSave={v => saveGroup('make', v)} />
+                <CuratorField label="Carline" tooltip={TIP.carline} value={group.epa_carline_name} canEdit={canEdit} overrideSource={gOv('epa_carline_name')} onSave={v => saveGroup('epa_carline_name', v)} />
+                <CuratorField label="Config #" tooltip={TIP.config} value={group.vehicle_config_number} canEdit={canEdit} overrideSource={gOv('vehicle_config_number')} onSave={v => saveGroup('vehicle_config_number', v)} />
+                <CuratorField label="Drive" tooltip={TIP.drive} value={group.drive} canEdit={canEdit} overrideSource={gOv('drive')} onSave={v => saveGroup('drive', v)} />
+                <CuratorField label="Evap family" tooltip={TIP.evap_family} value={group.evap_family} canEdit={canEdit} overrideSource={gOv('evap_family')} onSave={v => saveGroup('evap_family', v)} />
+                <CuratorField label="Fuel category" tooltip={TIP.fuel_category} value={group.fuel_type} canEdit={canEdit} overrideSource={gOv('fuel_type')} onSave={v => saveGroup('fuel_type', v)} />
             </Section>
 
-            {/* Section 2: Road load */}
+            {/* Section 2: Road load (Target A/B/C drive the curve & η) */}
             <Section title="Road Load & Weight">
-                <CuratorField label="Test weight" type="number" unit="lbs" value={primary?.equiv_test_weight_lbs} canEdit={canEdit} overrideSource={cOv('equiv_test_weight_lbs')} onSave={v => saveCoeff('equiv_test_weight_lbs', v)} />
+                <CuratorField label="Test weight" type="number" unit="lbs" tooltip={TIP.weight} value={primary?.equiv_test_weight_lbs} canEdit={canEdit} overrideSource={cOv('equiv_test_weight_lbs')} onSave={v => saveCoeff('equiv_test_weight_lbs', v)} />
                 <span />
-                <CuratorField label="Target A" type="number" step="0.0001" unit="lbf" tooltip={EPA_EXPLAINERS.roadLoad} value={primary?.target_a} canEdit={canEdit} overrideSource={cOv('target_a')} onSave={v => saveCoeff('target_a', v)} />
-                <CuratorField label="Set A" type="number" step="0.0001" unit="lbf" value={primary?.set_a} canEdit={canEdit} overrideSource={cOv('set_a')} onSave={v => saveCoeff('set_a', v)} />
-                <CuratorField label="Target B" type="number" step="0.000001" unit="lbf/mph" value={primary?.target_b} canEdit={canEdit} overrideSource={cOv('target_b')} onSave={v => saveCoeff('target_b', v)} />
-                <CuratorField label="Set B" type="number" step="0.000001" unit="lbf/mph" value={primary?.set_b} canEdit={canEdit} overrideSource={cOv('set_b')} onSave={v => saveCoeff('set_b', v)} />
-                <CuratorField label="Target C" type="number" step="0.00000001" unit="lbf/mph²" value={primary?.target_c} canEdit={canEdit} overrideSource={cOv('target_c')} onSave={v => saveCoeff('target_c', v)} />
-                <CuratorField label="Set C" type="number" step="0.00000001" unit="lbf/mph²" value={primary?.set_c} canEdit={canEdit} overrideSource={cOv('set_c')} onSave={v => saveCoeff('set_c', v)} />
+                <CuratorField label="Target A" used type="number" step="0.0001" unit="lbf" tooltip={TIP.target_a} value={primary?.target_a} canEdit={canEdit} overrideSource={cOv('target_a')} onSave={v => saveCoeff('target_a', v)} />
+                <CuratorField label="Set A" type="number" step="0.0001" unit="lbf" tooltip={TIP.set_abc} value={primary?.set_a} canEdit={canEdit} overrideSource={cOv('set_a')} onSave={v => saveCoeff('set_a', v)} />
+                <CuratorField label="Target B" used type="number" step="0.000001" unit="lbf/mph" tooltip={TIP.target_b} value={primary?.target_b} canEdit={canEdit} overrideSource={cOv('target_b')} onSave={v => saveCoeff('target_b', v)} />
+                <CuratorField label="Set B" type="number" step="0.000001" unit="lbf/mph" tooltip={TIP.set_abc} value={primary?.set_b} canEdit={canEdit} overrideSource={cOv('set_b')} onSave={v => saveCoeff('set_b', v)} />
+                <CuratorField label="Target C" used type="number" step="0.00000001" unit="lbf/mph²" tooltip={TIP.target_c} value={primary?.target_c} canEdit={canEdit} overrideSource={cOv('target_c')} onSave={v => saveCoeff('target_c', v)} />
+                <CuratorField label="Set C" type="number" step="0.00000001" unit="lbf/mph²" tooltip={TIP.set_abc} value={primary?.set_c} canEdit={canEdit} overrideSource={cOv('set_c')} onSave={v => saveCoeff('set_c', v)} />
             </Section>
 
             {/* Sections 3–5: Tests & phases */}
@@ -168,29 +198,32 @@ export default function EpaCuratorEditor({ testGroupId, canEdit }) {
                 />
             </div>
 
-            {/* Section 6: Range & label */}
+            {/* Section 6: Range & label (CD combined + published feed the adj factor) */}
             <Section title="Range & Label Values">
-                <CuratorField label="CD range combined (calc)" type="number" step="0.1" unit="mi" value={group.cd_range_combined_calc} canEdit={canEdit} overrideSource={gOv('cd_range_combined_calc')} onSave={v => saveGroup('cd_range_combined_calc', v)} />
-                <CuratorField label="CD range highway (calc)" type="number" step="0.1" unit="mi" value={group.cd_range_hwy_calc} canEdit={canEdit} overrideSource={gOv('cd_range_hwy_calc')} onSave={v => saveGroup('cd_range_hwy_calc', v)} />
-                <CuratorField label="Label range (published)" type="number" step="0.1" unit="mi" value={group.label_range_published} canEdit={canEdit} overrideSource={gOv('label_range_published')} onSave={v => saveGroup('label_range_published', v)} />
-                <CuratorField label="Label combined MPGe" type="number" step="0.1" value={group.label_combined_mpge} canEdit={canEdit} overrideSource={gOv('label_combined_mpge')} onSave={v => saveGroup('label_combined_mpge', v)} />
-                <CuratorField label="Label highway MPGe" type="number" step="0.1" value={group.label_hwy_mpge} canEdit={canEdit} overrideSource={gOv('label_hwy_mpge')} onSave={v => saveGroup('label_hwy_mpge', v)} />
-                <CuratorField label="Derived 5-cycle coeff." type="number" step="0.0001" value={group.derived_5cycle_coefficient} canEdit={canEdit} overrideSource={gOv('derived_5cycle_coefficient')} onSave={v => saveGroup('derived_5cycle_coefficient', v)} />
+                <CuratorField label="CD range combined (calc)" used type="number" step="0.1" unit="mi" tooltip={TIP.cd_range_combined} value={group.cd_range_combined_calc} canEdit={canEdit} overrideSource={gOv('cd_range_combined_calc')} onSave={v => saveGroup('cd_range_combined_calc', v)} />
+                <CuratorField label="CD range highway (calc)" type="number" step="0.1" unit="mi" tooltip={TIP.cd_range_hwy} value={group.cd_range_hwy_calc} canEdit={canEdit} overrideSource={gOv('cd_range_hwy_calc')} onSave={v => saveGroup('cd_range_hwy_calc', v)} />
+                <CuratorField label="Label range (published)" used type="number" step="0.1" unit="mi" tooltip={TIP.label_range} value={group.label_range_published} canEdit={canEdit} overrideSource={gOv('label_range_published')} onSave={v => saveGroup('label_range_published', v)} />
+                <CuratorField label="Label combined MPGe" type="number" step="0.1" tooltip={TIP.label_combined} value={group.label_combined_mpge} canEdit={canEdit} overrideSource={gOv('label_combined_mpge')} onSave={v => saveGroup('label_combined_mpge', v)} />
+                <CuratorField label="Label highway MPGe" type="number" step="0.1" tooltip={TIP.label_hwy} value={group.label_hwy_mpge} canEdit={canEdit} overrideSource={gOv('label_hwy_mpge')} onSave={v => saveGroup('label_hwy_mpge', v)} />
+                <CuratorField label="Derived 5-cycle coeff." type="number" step="0.0001" tooltip={TIP.derived_5cycle} value={group.derived_5cycle_coefficient} canEdit={canEdit} overrideSource={gOv('derived_5cycle_coefficient')} onSave={v => saveGroup('derived_5cycle_coefficient', v)} />
             </Section>
 
-            {/* Section 7: Battery & powertrain */}
+            {/* Section 7: Battery & powertrain (useable/accessory/charger feed derivations) */}
             <Section title="Battery & Powertrain Assumptions">
-                <CuratorField label="Useable battery" type="number" step="0.001" unit="kWh" value={group.useable_kwh} canEdit={canEdit} overrideSource={gOv('useable_kwh')} onSave={v => saveGroup('useable_kwh', v)} />
-                <CuratorField label="Total voltage" type="number" step="0.1" unit="V" value={group.total_voltage} canEdit={canEdit} overrideSource={gOv('total_voltage')} onSave={v => saveGroup('total_voltage', v)} />
-                <CuratorField label="Specific energy" type="number" step="0.1" unit="Wh/kg" value={group.battery_specific_energy} canEdit={canEdit} overrideSource={gOv('battery_specific_energy')} onSave={v => saveGroup('battery_specific_energy', v)} />
-                <CuratorField label="Accessory load" type="number" step="1" unit="W" placeholder="300" value={group.accessory_load_w_override} canEdit={canEdit} overrideSource={gOv('accessory_load_w_override')} onSave={v => saveGroup('accessory_load_w_override', v)} />
-                <CuratorField label="Charger eff. override" type="number" step="0.001" placeholder="0.90" value={group.charger_efficiency_override} canEdit={canEdit} overrideSource={gOv('charger_efficiency_override')} onSave={v => saveGroup('charger_efficiency_override', v)} />
+                <CuratorField label="Useable battery" used type="number" step="0.001" unit="kWh" tooltip={TIP.useable_kwh} value={group.useable_kwh} canEdit={canEdit} overrideSource={gOv('useable_kwh')} onSave={v => saveGroup('useable_kwh', v)} />
+                <CuratorField label="Total voltage" type="number" step="0.1" unit="V" tooltip={TIP.total_voltage} value={group.total_voltage} canEdit={canEdit} overrideSource={gOv('total_voltage')} onSave={v => saveGroup('total_voltage', v)} />
+                <CuratorField label="Specific energy" type="number" step="0.1" unit="Wh/kg" tooltip={TIP.specific_energy} value={group.battery_specific_energy} canEdit={canEdit} overrideSource={gOv('battery_specific_energy')} onSave={v => saveGroup('battery_specific_energy', v)} />
+                <CuratorField label="Accessory load" used type="number" step="1" unit="W" placeholder="300" tooltip={TIP.accessory_load} value={group.accessory_load_w_override} canEdit={canEdit} overrideSource={gOv('accessory_load_w_override')} onSave={v => saveGroup('accessory_load_w_override', v)} />
+                <CuratorField label="Charger eff. override" used type="number" step="0.001" placeholder="0.90" tooltip={TIP.charger_override} value={group.charger_efficiency_override} canEdit={canEdit} overrideSource={gOv('charger_efficiency_override')} onSave={v => saveGroup('charger_efficiency_override', v)} />
             </Section>
 
             {/* Section 8: Derived values */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
                 <DerivedValues group={group} />
             </div>
+            <p className="text-[10px] text-gray-400 mt-1">
+                <span className="text-indigo-500">∗</span> feeds a derived calculation below.
+            </p>
 
             {/* Audit trail */}
             <AuditHistory group={group} getEpaAuditForGroup={getEpaAuditForGroup} />

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -119,12 +119,20 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
 
     // Sanity: phase DC sum vs declared total; phase count vs declared bags.
     const phaseSum = phases.reduce((s, p) => s + (num(p.dc_energy_kwh) ?? 0), 0);
+    const distSum  = phases.reduce((s, p) => s + (num(p.distance_mi) ?? 0), 0);
     const totalDc  = num(test.total_dc_energy_kwh);
     const sumMismatch = totalDc != null && phaseSum > 0 && Math.abs(phaseSum - totalDc) / totalDc > 0.05;
     const bags = num(test.bags_phases_conducted);
     const bagMismatch = bags != null && bags !== phases.length;
     // When a bag count is declared and no phases exist yet, offer to add them all at once.
     const addCount = (phases.length === 0 && bags != null && bags > 1) ? bags : 1;
+    // Fill Total DC + Total distance from the sum of all phases.
+    const canSumPhases = phaseSum > 0 || distSum > 0;
+    const fillTotalsFromPhases = () => onSaveTest({
+        id: test.id,
+        total_dc_energy_kwh: phaseSum > 0 ? Math.round(phaseSum * 1000) / 1000 : null,
+        total_distance_mi:   distSum  > 0 ? Math.round(distSum  * 1000) / 1000 : null,
+    });
 
     return (
         <div className="border rounded-lg p-3 mb-2 border-gray-200 dark:border-slate-700">
@@ -156,9 +164,9 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                 <EnumField label="Originator" tooltip="MFR (manufacturer's contracted lab, e.g. FEV) or EPA (Ann Arbor confirmatory). Prefer EPA-run tests when both exist." value={test.originator} options={ORIGINATORS} canEdit={canEdit} onSave={saveField('originator')} />
                 <EnumField label="Source" tooltip="Where this test's detail came from: CSV import, J1634 calculator sheet, CSI PDF, or manual entry." value={test.source} options={SOURCE_OPTS} canEdit={canEdit} onSave={saveField('source')} />
                 <CuratorField label="Test date" type="text" placeholder="YYYY-MM-DD" tooltip="Date of this specific test run." value={test.test_date} canEdit={canEdit} onSave={saveField('test_date')} />
-                <CuratorField label="Total DC" used type="number" step="0.001" unit="kWh" tooltip="Total battery-side energy discharged over the full depletion. Must include SS segments (~78% of total). Anchors useable capacity and charger efficiency." value={test.total_dc_energy_kwh} canEdit={canEdit} onSave={saveField('total_dc_energy_kwh')} />
-                <CuratorField label="AC recharge" used type="number" step="0.001" unit="kWh" tooltip="AC-side energy to refill the pack; includes charger losses. Often blank in CSI PDFs — nullable. Required for measured charger efficiency." value={test.ac_recharge_kwh} canEdit={canEdit} onSave={saveField('ac_recharge_kwh')} />
                 <CuratorField label="Total distance" type="number" step="0.001" unit="mi" tooltip="Total miles over the full depletion run." value={test.total_distance_mi} canEdit={canEdit} onSave={saveField('total_distance_mi')} />
+                <CuratorField label="AC recharge" used type="number" step="0.001" unit="kWh" tooltip="AC-side energy to refill the pack; includes charger losses. Often blank in CSI PDFs — nullable. Required for measured charger efficiency." value={test.ac_recharge_kwh} canEdit={canEdit} onSave={saveField('ac_recharge_kwh')} />
+                <CuratorField label="Total DC" used type="number" step="0.001" unit="kWh" tooltip="Total battery-side energy discharged over the full depletion. Must include SS segments (~78% of total). Anchors useable capacity and charger efficiency." value={test.total_dc_energy_kwh} canEdit={canEdit} onSave={saveField('total_dc_energy_kwh')} />
                 <CuratorField label="Bags/phases" type="number" tooltip="Number of Charge Depleting bags/phases conducted — expected phase count for verification. Your entered phases should match this." value={test.bags_phases_conducted} canEdit={canEdit} onSave={saveField('bags_phases_conducted')} />
                 <CuratorField label="Recharge V" type="number" step="0.1" unit="V" tooltip="AC supply voltage during recharge (e.g. 240V). Context for the recharge measurement." value={test.recharge_voltage} canEdit={canEdit} onSave={saveField('recharge_voltage')} />
             </div>
@@ -186,12 +194,23 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                 </tbody>
             </table>
             {canEdit && (
-                <button
-                    onClick={() => onAddPhase(test, addCount)}
-                    className="text-xs text-indigo-600 dark:text-indigo-400 mt-1 hover:underline"
-                >
-                    {addCount > 1 ? `+ Add ${addCount} phases` : '+ Add phase'}
-                </button>
+                <div className="flex items-center gap-4 mt-1">
+                    <button
+                        onClick={() => onAddPhase(test, addCount)}
+                        className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                    >
+                        {addCount > 1 ? `+ Add ${addCount} phases` : '+ Add phase'}
+                    </button>
+                    {canSumPhases && (
+                        <button
+                            onClick={fillTotalsFromPhases}
+                            className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                            title={`Set Total DC (${phaseSum.toFixed(2)} kWh) and Total distance (${distSum.toFixed(2)} mi) from the sum of all phases`}
+                        >
+                            Σ Fill totals from phases
+                        </button>
+                    )}
+                </div>
             )}
 
             {/* Inline sanity */}

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -9,6 +9,7 @@
  */
 import { useState } from 'react';
 import CuratorField from './CuratorField';
+import InfoIcon from '../InfoIcon';
 import { PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75 } from '../../utils/epaDerivations';
 
 const PROC_OPTIONS = [
@@ -70,10 +71,10 @@ function PhaseRow({ phase, canEdit, onSave, onDelete }) {
                 ) : (phase.phase_type ?? '—')}
             </td>
             <td className="py-1 pr-2">
-                <InlineNum value={phase.dc_energy_kwh} canEdit={canEdit} step="0.001" onSave={set('dc_energy_kwh')} />
+                <InlineNum value={phase.distance_mi} canEdit={canEdit} step="0.001" onSave={set('distance_mi')} />
             </td>
             <td className="py-1 pr-2">
-                <InlineNum value={phase.distance_mi} canEdit={canEdit} step="0.001" onSave={set('distance_mi')} />
+                <InlineNum value={phase.dc_energy_kwh} canEdit={canEdit} step="0.001" onSave={set('dc_energy_kwh')} />
             </td>
             <td className="py-1 pr-2 text-right font-mono text-gray-500">{consumption ? `${consumption} Wh/mi` : '—'}</td>
             <td className="py-1 text-right">
@@ -122,6 +123,8 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
     const sumMismatch = totalDc != null && phaseSum > 0 && Math.abs(phaseSum - totalDc) / totalDc > 0.05;
     const bags = num(test.bags_phases_conducted);
     const bagMismatch = bags != null && bags !== phases.length;
+    // When a bag count is declared and no phases exist yet, offer to add them all at once.
+    const addCount = (phases.length === 0 && bags != null && bags > 1) ? bags : 1;
 
     return (
         <div className="border rounded-lg p-3 mb-2 border-gray-200 dark:border-slate-700">
@@ -132,6 +135,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                             value={test.procedure_code ?? ''}
                             onChange={e => onSaveTest({ id: test.id, procedure_code: e.target.value ? Number(e.target.value) : null })}
                             className="form-input text-xs py-0.5"
+                            title="77 = Multi-Cycle Test (preferred — city + highway + totals in one run). 84 = Charge Depleting Highway (fallback). 81 = Charge Depleting UDDS (stored only). 2 = FTP-75."
                         >
                             <option value="">Procedure…</option>
                             {PROC_OPTIONS.map(o => <option key={o.v} value={o.v}>{o.label}</option>)}
@@ -147,27 +151,27 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs mb-2">
-                <CuratorField label="Test number" value={test.test_number} canEdit={canEdit} onSave={saveField('test_number')} />
-                <CuratorField label="Lab ID" value={test.lab_id} canEdit={canEdit} onSave={saveField('lab_id')} />
-                <EnumField label="Originator" value={test.originator} options={ORIGINATORS} canEdit={canEdit} onSave={saveField('originator')} />
-                <EnumField label="Source" value={test.source} options={SOURCE_OPTS} canEdit={canEdit} onSave={saveField('source')} />
-                <CuratorField label="Test date" type="text" placeholder="YYYY-MM-DD" value={test.test_date} canEdit={canEdit} onSave={saveField('test_date')} />
-                <CuratorField label="Total DC" type="number" step="0.001" unit="kWh" value={test.total_dc_energy_kwh} canEdit={canEdit} onSave={saveField('total_dc_energy_kwh')} />
-                <CuratorField label="AC recharge" type="number" step="0.001" unit="kWh" value={test.ac_recharge_kwh} canEdit={canEdit} onSave={saveField('ac_recharge_kwh')} />
-                <CuratorField label="Total distance" type="number" step="0.001" unit="mi" value={test.total_distance_mi} canEdit={canEdit} onSave={saveField('total_distance_mi')} />
-                <CuratorField label="Bags/phases" type="number" value={test.bags_phases_conducted} canEdit={canEdit} onSave={saveField('bags_phases_conducted')} />
-                <CuratorField label="Recharge V" type="number" step="0.1" unit="V" value={test.recharge_voltage} canEdit={canEdit} onSave={saveField('recharge_voltage')} />
+                <CuratorField label="Test number" tooltip="EPA test identifier (e.g. VRIV10093452)." value={test.test_number} canEdit={canEdit} onSave={saveField('test_number')} />
+                <CuratorField label="Lab ID" tooltip="Physical lab (e.g. FEV Michigan, EPA Ann Arbor). Lab-to-lab variation of ~1–2% is normal." value={test.lab_id} canEdit={canEdit} onSave={saveField('lab_id')} />
+                <EnumField label="Originator" tooltip="MFR (manufacturer's contracted lab, e.g. FEV) or EPA (Ann Arbor confirmatory). Prefer EPA-run tests when both exist." value={test.originator} options={ORIGINATORS} canEdit={canEdit} onSave={saveField('originator')} />
+                <EnumField label="Source" tooltip="Where this test's detail came from: CSV import, J1634 calculator sheet, CSI PDF, or manual entry." value={test.source} options={SOURCE_OPTS} canEdit={canEdit} onSave={saveField('source')} />
+                <CuratorField label="Test date" type="text" placeholder="YYYY-MM-DD" tooltip="Date of this specific test run." value={test.test_date} canEdit={canEdit} onSave={saveField('test_date')} />
+                <CuratorField label="Total DC" used type="number" step="0.001" unit="kWh" tooltip="Total battery-side energy discharged over the full depletion. Must include SS segments (~78% of total). Anchors useable capacity and charger efficiency." value={test.total_dc_energy_kwh} canEdit={canEdit} onSave={saveField('total_dc_energy_kwh')} />
+                <CuratorField label="AC recharge" used type="number" step="0.001" unit="kWh" tooltip="AC-side energy to refill the pack; includes charger losses. Often blank in CSI PDFs — nullable. Required for measured charger efficiency." value={test.ac_recharge_kwh} canEdit={canEdit} onSave={saveField('ac_recharge_kwh')} />
+                <CuratorField label="Total distance" type="number" step="0.001" unit="mi" tooltip="Total miles over the full depletion run." value={test.total_distance_mi} canEdit={canEdit} onSave={saveField('total_distance_mi')} />
+                <CuratorField label="Bags/phases" type="number" tooltip="Number of Charge Depleting bags/phases conducted — expected phase count for verification. Your entered phases should match this." value={test.bags_phases_conducted} canEdit={canEdit} onSave={saveField('bags_phases_conducted')} />
+                <CuratorField label="Recharge V" type="number" step="0.1" unit="V" tooltip="AC supply voltage during recharge (e.g. 240V). Context for the recharge measurement." value={test.recharge_voltage} canEdit={canEdit} onSave={saveField('recharge_voltage')} />
             </div>
 
             {/* Phases */}
             <table className="w-full text-xs">
                 <thead>
                     <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
-                        <th className="font-semibold pr-2">#</th>
-                        <th className="font-semibold pr-2">Phase</th>
-                        <th className="font-semibold pr-2">DC (kWh)</th>
-                        <th className="font-semibold pr-2">Dist (mi)</th>
-                        <th className="font-semibold pr-2 text-right">Consumption</th>
+                        <th className="font-semibold pr-2" title="Position in the test sequence (Bag/Phase number). Identity comes from procedure order, not the data.">#</th>
+                        <th className="font-semibold pr-2" title="UDDS / HWY / SS / Cold-UDDS / US06 / SC03. SS = steady-state depletion at a lab-chosen speed — stored for energy totals but NOT a valid efficiency anchor.">Phase</th>
+                        <th className="font-semibold pr-2" title="Actual distance driven for this phase (miles).">Dist (mi)</th>
+                        <th className="font-semibold pr-2" title="Integrated DC KW-HRS: battery-side energy for this phase — what actually left the battery. This is what efficiency derivation uses.">DC Energy (kWh)</th>
+                        <th className="font-semibold pr-2 text-right" title="Energy ÷ distance (Wh/mi). HWY phases at ~48.3 mph average are the efficiency anchor.">Consumption</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -182,8 +186,11 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                 </tbody>
             </table>
             {canEdit && (
-                <button onClick={() => onAddPhase(test)} className="text-xs text-indigo-600 dark:text-indigo-400 mt-1 hover:underline">
-                    + Add phase
+                <button
+                    onClick={() => onAddPhase(test, addCount)}
+                    className="text-xs text-indigo-600 dark:text-indigo-400 mt-1 hover:underline"
+                >
+                    {addCount > 1 ? `+ Add ${addCount} phases` : '+ Add phase'}
                 </button>
             )}
 
@@ -198,17 +205,23 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
     );
 }
 
-function EnumField({ label, value, options, canEdit, onSave }) {
+function EnumField({ label, value, options, tooltip, canEdit, onSave }) {
     return (
         <div className="flex items-center justify-between gap-2 py-0.5">
-            <span className="text-gray-500 dark:text-slate-400">{label}</span>
-            {canEdit ? (
-                <select value={value ?? ''} onChange={e => onSave(e.target.value || null)}
-                    className="form-input text-xs py-0.5 px-1 w-28">
-                    <option value="">—</option>
-                    {options.map(o => <option key={o} value={o}>{o}</option>)}
-                </select>
-            ) : <span className="font-mono text-xs">{value ?? '—'}</span>}
+            <span className="text-gray-500 dark:text-slate-400 flex items-center gap-1">
+                {label}
+                {tooltip && <InfoIcon text={tooltip} position="right" />}
+            </span>
+            <span className="flex items-center gap-1 shrink-0">
+                {canEdit ? (
+                    <select value={value ?? ''} onChange={e => onSave(e.target.value || null)}
+                        className="form-input text-xs py-0.5 px-1 w-28">
+                        <option value="">—</option>
+                        {options.map(o => <option key={o} value={o}>{o}</option>)}
+                    </select>
+                ) : <span className="font-mono text-xs text-right w-28">{value ?? '—'}</span>}
+                <span className="w-10 shrink-0" />
+            </span>
         </div>
     );
 }


### PR DESCRIPTION
Curator-form UX polish from hands-on feedback.

## Fixes
- **Phase auto-suggest now works** — new phases default to **no type** (was HWY, which pre-empted the suggestion). Entering a distance auto-fills: ~10.26 → HWY, ~7.45 → UDDS, ≫10× neighbors → SS. Still overridable.
- **Phase table** — swapped to **Dist (mi)** before **DC Energy (kWh)** (renamed from "DC (kWh)"). Entering distance first feeds the suggestion.
- **"+ Add N phases"** — when *Bags/phases* is set and no phases exist yet, the button bulk-adds that many typeless phases.
- **Field alignment** — `CuratorField` now reserves a fixed unit column, so input right-edges line up whether or not a field has a unit label (fixes the ragged right-justified inputs). `EnumField` matched.
- **Calc markers** — fields that feed a derived value are **bold + ∗** with a legend, so curators can distinguish essential inputs from optional metadata (Target A/B/C, CD range combined, Label range, Useable battery, Accessory load, Charger eff override, Total DC, AC recharge).
- **Tooltips** — applied to every field verbatim from `LocalDev/curator-fields-spec.md`, plus the phase-table headers and the procedure select.

## Notes
Removed the now-unused `EPA_EXPLAINERS` import from the editor. Build ✓. Pure UI/UX — no schema or data-flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)