### PR TITLE
EPA: in-browser CSI lab-PDF importer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chart.js": "^4.5.1",
         "chartjs-plugin-zoom": "^2.2.0",
         "papaparse": "^5.5.3",
+        "pdfjs-dist": "^6.0.227",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-image-crop": "^11.0.10"
@@ -802,6 +803,256 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -2243,6 +2494,18 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.0.227",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chart.js": "^4.5.1",
     "chartjs-plugin-zoom": "^2.2.0",
     "papaparse": "^5.5.3",
+    "pdfjs-dist": "^6.0.227",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-image-crop": "^11.0.10"

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import ImportTableauModal from './ImportTableauModal';
 import EpaImportModal from './EpaImportModal';
+import EpaPdfImportModal from './EpaPdfImportModal';
 import EpaDataCard from './EpaDataCard';
 
 const ROLES = ['user', 'contributor', 'admin'];
@@ -16,6 +17,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
     const {
         exportData, importData, importTableauSessions,
         importEpaTestGroups, getEpaTestGroupsAdmin, deleteEpaTestGroup, updateEpaTestGroup,
+        importEpaCsiGroups, getExistingEpaTestGroupIds,
         vehicles,
     } = useAppContext();
     const [users, setUsers]           = useState([]);
@@ -25,6 +27,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
     const [showImportMenu, setShowImportMenu] = useState(false);
     const [showTableauModal, setShowTableauModal] = useState(false);
     const [showEpaModal, setShowEpaModal]         = useState(false);
+    const [showEpaPdfModal, setShowEpaPdfModal]   = useState(false);
     const jsonImportRef = useRef();
 
     useEffect(() => {
@@ -72,6 +75,13 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                     onClose={() => setShowEpaModal(false)}
                 />
             )}
+            {showEpaPdfModal && (
+                <EpaPdfImportModal
+                    onImport={importEpaCsiGroups}
+                    getExistingIds={getExistingEpaTestGroupIds}
+                    onClose={() => setShowEpaPdfModal(false)}
+                />
+            )}
             <div className="flex justify-between items-center mb-6">
                 <div>
                     <h2 className="page-title">Admin Panel</h2>
@@ -100,7 +110,11 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                                     </button>
                                     <button className="dropdown-item w-full text-left"
                                         onClick={() => { setShowImportMenu(false); setShowEpaModal(true); }}>
-                                        ⚡ EPA Test Car Data
+                                        ⚡ EPA Test Car Data (CSV)
+                                    </button>
+                                    <button className="dropdown-item w-full text-left"
+                                        onClick={() => { setShowImportMenu(false); setShowEpaPdfModal(true); }}>
+                                        📑 EPA Lab PDF (CSI)
                                     </button>
                                 </div>
                             </>

--- a/src/components/EpaPdfImportModal.jsx
+++ b/src/components/EpaPdfImportModal.jsx
@@ -81,8 +81,10 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
     };
 
     return (
-        <div className="modal-overlay" onClick={onClose}>
-            <div className="modal-content max-w-3xl" onClick={e => e.stopPropagation()}>
+        <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+            <div className="modal-panel rounded-xl p-5"
+                 style={{ maxWidth: '760px', width: '96vw', maxHeight: '90vh', overflowY: 'auto' }}
+                 onClick={e => e.stopPropagation()}>
                 <div className="flex items-center justify-between mb-4">
                     <h3 className="text-lg font-bold">
                         Import EPA Lab PDF{targetVehicle ? ` → ${targetVehicle.name}` : ''}

--- a/src/components/EpaPdfImportModal.jsx
+++ b/src/components/EpaPdfImportModal.jsx
@@ -21,7 +21,7 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
     const [warnings, setWarnings] = useState([]);
     const [existing, setExisting] = useState(new Set());
     const [selected, setSelected] = useState(new Set());   // test_group_ids to import
-    const [linkId, setLinkId]   = useState('');            // config to link (per-vehicle mode)
+    const [linkIds, setLinkIds]   = useState(new Set());   // configs to link (per-vehicle mode)
     const [result, setResult]   = useState(null);
 
     const processFile = async (file) => {
@@ -44,7 +44,7 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
             if (targetVehicle) {
                 const vn = (targetVehicle.name || '').toLowerCase();
                 const best = g.find(x => vn && (x.epa_carline_name || '').toLowerCase().includes(vn.split(' ')[0]));
-                setLinkId((best || g[0]).test_group_id);
+                setLinkIds(new Set([(best || g[0]).test_group_id]));
             }
             setStep('review');
         } catch (e) {
@@ -55,7 +55,30 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
     };
 
     const onDrop = (e) => { e.preventDefault(); setDragOver(false); processFile(e.dataTransfer.files[0]); };
-    const toggle = (id) => setSelected(p => { const s = new Set(p); s.has(id) ? s.delete(id) : s.add(id); return s; });
+
+    // Import-select toggle; deselecting also drops any link.
+    const toggle = (id) => {
+        const willSelect = !selected.has(id);
+        setSelected(p => { const s = new Set(p); willSelect ? s.add(id) : s.delete(id); return s; });
+        if (!willSelect) setLinkIds(p => { const s = new Set(p); s.delete(id); return s; });
+    };
+    // Link toggle (per-vehicle); linking forces the row to be imported.
+    const toggleLink = (id) => {
+        const willLink = !linkIds.has(id);
+        setLinkIds(p => { const s = new Set(p); willLink ? s.add(id) : s.delete(id); return s; });
+        if (willLink) setSelected(p => new Set(p).add(id));
+    };
+    const allIds = groups.map(g => g.test_group_id);
+    const allSelected = allIds.length > 0 && allIds.every(id => selected.has(id));
+    const allLinked   = allIds.length > 0 && allIds.every(id => linkIds.has(id));
+    const toggleAllSelect = () => {
+        if (allSelected) { setSelected(new Set()); setLinkIds(new Set()); }
+        else setSelected(new Set(allIds));
+    };
+    const toggleAllLink = () => {
+        if (allLinked) setLinkIds(new Set());
+        else { setLinkIds(new Set(allIds)); setSelected(new Set(allIds)); }
+    };
 
     const overwriteCount = [...selected].filter(id => existing.has(id)).length;
 
@@ -68,8 +91,8 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
         }
         setBusy(true); setError(null);
         try {
-            const res = await onImport(toImport, targetVehicle && selected.has(linkId)
-                ? { linkVehicleId: targetVehicle.id, linkTestGroupId: linkId }
+            const res = await onImport(toImport, targetVehicle
+                ? { linkVehicleId: targetVehicle.id, linkTestGroupIds: [...linkIds].filter(id => selected.has(id)) }
                 : {});
             setResult(res);
             setStep('done');
@@ -122,8 +145,15 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                             <table className="w-full text-xs">
                                 <thead className="bg-gray-50 dark:bg-slate-800 sticky top-0">
                                     <tr className="text-left text-gray-500">
-                                        <th className="p-2"></th>
-                                        {targetVehicle && <th className="p-2">Link</th>}
+                                        <th className="p-2" title="Select all / none">
+                                            <input type="checkbox" checked={allSelected} onChange={toggleAllSelect} />
+                                        </th>
+                                        {targetVehicle && (
+                                            <th className="p-2">
+                                                <input type="checkbox" checked={allLinked} onChange={toggleAllLink} title="Link all / none" />
+                                                <span className="ml-1">Link</span>
+                                            </th>
+                                        )}
                                         <th className="p-2">Config ID</th>
                                         <th className="p-2">Make · Carline</th>
                                         <th className="p-2">Coeff / Tests / Phases</th>
@@ -139,8 +169,8 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                                                 <td className="p-2"><input type="checkbox" checked={selected.has(id)} onChange={() => toggle(id)} /></td>
                                                 {targetVehicle && (
                                                     <td className="p-2">
-                                                        <input type="radio" name="linkcfg" checked={linkId === id}
-                                                            disabled={!selected.has(id)} onChange={() => setLinkId(id)} />
+                                                        <input type="checkbox" checked={linkIds.has(id)}
+                                                            onChange={() => toggleLink(id)} />
                                                     </td>
                                                 )}
                                                 <td className="p-2 font-mono">{id}</td>
@@ -167,7 +197,7 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                         <div className="flex items-center gap-2 mt-4">
                             <span className="text-xs text-gray-500 flex-1">
                                 {selected.size} selected{overwriteCount ? ` · ${overwriteCount} overwrite` : ''}
-                                {targetVehicle && selected.has(linkId) ? ` · linking ${linkId} to ${targetVehicle.name}` : ''}
+                                {targetVehicle && linkIds.size ? ` · linking ${linkIds.size} to ${targetVehicle.name}` : ''}
                             </span>
                             <button onClick={() => setStep('upload')} className="btn btn-secondary text-sm" disabled={busy}>Back</button>
                             <button onClick={handleImport} className="btn btn-primary text-sm" disabled={busy || !selected.size}>

--- a/src/components/EpaPdfImportModal.jsx
+++ b/src/components/EpaPdfImportModal.jsx
@@ -1,0 +1,188 @@
+/**
+ * EPA CSI-PDF import modal. Drag/drop a lab Certification Summary PDF; pdf.js
+ * extracts the text (lazy-loaded), parseEpaCsiText builds the config records,
+ * and a preview lets the curator review before committing (clean-replace upsert).
+ *
+ * Two modes via `targetVehicle`:
+ *   • absent  → Admin bulk import (no auto-link)
+ *   • present → per-vehicle: pick which config links to the current vehicle
+ */
+import { useState } from 'react';
+import { extractPdfText } from '../utils/extractPdfText';
+import { parseEpaCsiText } from '../utils/parseEpaCsiPdf';
+
+export default function EpaPdfImportModal({ targetVehicle = null, onImport, getExistingIds, onClose }) {
+    const [step, setStep]       = useState('upload'); // upload | review | done
+    const [fileName, setFileName] = useState('');
+    const [busy, setBusy]       = useState(false);
+    const [error, setError]     = useState(null);
+    const [dragOver, setDragOver] = useState(false);
+    const [groups, setGroups]   = useState([]);
+    const [warnings, setWarnings] = useState([]);
+    const [existing, setExisting] = useState(new Set());
+    const [selected, setSelected] = useState(new Set());   // test_group_ids to import
+    const [linkId, setLinkId]   = useState('');            // config to link (per-vehicle mode)
+    const [result, setResult]   = useState(null);
+
+    const processFile = async (file) => {
+        if (!file) return;
+        setFileName(file.name);
+        setBusy(true);
+        setError(null);
+        try {
+            const items = await extractPdfText(file);
+            const { groups: g, warnings: w } = parseEpaCsiText(items);
+            if (!g.length) { setError(w[0] || 'No EPA configurations found in this PDF.'); setBusy(false); return; }
+            const ids = g.map(x => x.test_group_id);
+            let exists = [];
+            try { exists = await getExistingIds(ids); } catch { /* non-fatal */ }
+            setGroups(g);
+            setWarnings(w);
+            setExisting(new Set(exists));
+            setSelected(new Set(ids));
+            // Per-vehicle: default-link the config whose carline best matches the vehicle, else the first.
+            if (targetVehicle) {
+                const vn = (targetVehicle.name || '').toLowerCase();
+                const best = g.find(x => vn && (x.epa_carline_name || '').toLowerCase().includes(vn.split(' ')[0]));
+                setLinkId((best || g[0]).test_group_id);
+            }
+            setStep('review');
+        } catch (e) {
+            setError(e.message || 'Failed to read PDF.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const onDrop = (e) => { e.preventDefault(); setDragOver(false); processFile(e.dataTransfer.files[0]); };
+    const toggle = (id) => setSelected(p => { const s = new Set(p); s.has(id) ? s.delete(id) : s.add(id); return s; });
+
+    const overwriteCount = [...selected].filter(id => existing.has(id)).length;
+
+    const handleImport = async () => {
+        const toImport = groups.filter(g => selected.has(g.test_group_id));
+        if (!toImport.length) return;
+        if (overwriteCount > 0 &&
+            !window.confirm(`${overwriteCount} of these configuration(s) already exist and will be overwritten with the PDF data. Continue?`)) {
+            return;
+        }
+        setBusy(true); setError(null);
+        try {
+            const res = await onImport(toImport, targetVehicle && selected.has(linkId)
+                ? { linkVehicleId: targetVehicle.id, linkTestGroupId: linkId }
+                : {});
+            setResult(res);
+            setStep('done');
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content max-w-3xl" onClick={e => e.stopPropagation()}>
+                <div className="flex items-center justify-between mb-4">
+                    <h3 className="text-lg font-bold">
+                        Import EPA Lab PDF{targetVehicle ? ` → ${targetVehicle.name}` : ''}
+                    </h3>
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
+                </div>
+
+                {error && <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm">⚠️ {error}</div>}
+
+                {step === 'upload' && (
+                    <div
+                        onDrop={onDrop}
+                        onDragOver={e => { e.preventDefault(); setDragOver(true); }}
+                        onDragLeave={() => setDragOver(false)}
+                        className={`border-2 border-dashed rounded-lg p-10 text-center ${dragOver ? 'border-indigo-400 bg-indigo-50/40' : 'border-gray-300'}`}
+                    >
+                        <p className="text-sm text-gray-500 mb-3">
+                            {busy ? 'Reading PDF…' : 'Drop an EPA Certification Summary (CSI) PDF here, or'}
+                        </p>
+                        <label className="btn btn-secondary text-sm cursor-pointer">
+                            Choose PDF
+                            <input type="file" accept=".pdf" className="hidden"
+                                onChange={e => processFile(e.target.files[0])} />
+                        </label>
+                        <p className="text-xs text-gray-400 mt-3">Parsed entirely in your browser — nothing is uploaded.</p>
+                    </div>
+                )}
+
+                {step === 'review' && (
+                    <>
+                        <p className="text-sm text-gray-500 mb-2">
+                            <span className="font-medium">{fileName}</span> — {groups.length} configuration(s) found.
+                        </p>
+                        <div className="max-h-80 overflow-y-auto border rounded-lg">
+                            <table className="w-full text-xs">
+                                <thead className="bg-gray-50 dark:bg-slate-800 sticky top-0">
+                                    <tr className="text-left text-gray-500">
+                                        <th className="p-2"></th>
+                                        {targetVehicle && <th className="p-2">Link</th>}
+                                        <th className="p-2">Config ID</th>
+                                        <th className="p-2">Make · Carline</th>
+                                        <th className="p-2">Coeff / Tests / Phases</th>
+                                        <th className="p-2">Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y">
+                                    {groups.map(g => {
+                                        const id = g.test_group_id;
+                                        const phaseCount = g.tests.reduce((n, t) => n + t.phases.length, 0);
+                                        return (
+                                            <tr key={id} className={selected.has(id) ? '' : 'opacity-40'}>
+                                                <td className="p-2"><input type="checkbox" checked={selected.has(id)} onChange={() => toggle(id)} /></td>
+                                                {targetVehicle && (
+                                                    <td className="p-2">
+                                                        <input type="radio" name="linkcfg" checked={linkId === id}
+                                                            disabled={!selected.has(id)} onChange={() => setLinkId(id)} />
+                                                    </td>
+                                                )}
+                                                <td className="p-2 font-mono">{id}</td>
+                                                <td className="p-2">{g.make} · <span className="text-gray-500">{g.epa_carline_name}</span></td>
+                                                <td className="p-2 font-mono text-gray-500">{g.coefficient_sets.length} / {g.tests.length} / {phaseCount}</td>
+                                                <td className="p-2">
+                                                    {existing.has(id)
+                                                        ? <span className="text-amber-600 dark:text-amber-400">⟳ overwrite</span>
+                                                        : <span className="text-green-600 dark:text-green-400">＋ new</span>}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {warnings.length > 0 && (
+                            <ul className="mt-2 text-xs text-amber-600 dark:text-amber-400 list-disc pl-5">
+                                {warnings.map((w, i) => <li key={i}>{w}</li>)}
+                            </ul>
+                        )}
+
+                        <div className="flex items-center gap-2 mt-4">
+                            <span className="text-xs text-gray-500 flex-1">
+                                {selected.size} selected{overwriteCount ? ` · ${overwriteCount} overwrite` : ''}
+                                {targetVehicle && selected.has(linkId) ? ` · linking ${linkId} to ${targetVehicle.name}` : ''}
+                            </span>
+                            <button onClick={() => setStep('upload')} className="btn btn-secondary text-sm" disabled={busy}>Back</button>
+                            <button onClick={handleImport} className="btn btn-primary text-sm" disabled={busy || !selected.size}>
+                                {busy ? 'Importing…' : `Import ${selected.size} config(s)`}
+                            </button>
+                        </div>
+                    </>
+                )}
+
+                {step === 'done' && (
+                    <div className="text-center py-6">
+                        <p className="text-2xl mb-2">✓</p>
+                        <p className="text-sm">Imported {result?.count ?? selected.size} configuration(s).</p>
+                        <button onClick={onClose} className="btn btn-primary text-sm mt-4">Done</button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -11,6 +11,8 @@ import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 import DerivedValues from './epa/DerivedValues';
 import EpaCuratorEditor from './epa/EpaCuratorEditor';
+import EpaPdfImportModal from './EpaPdfImportModal';
+import { useAppContext } from '../context/AppContext';
 
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
@@ -263,6 +265,8 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
     const [searchError, setSearchError]   = useState(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [linking, setLinking]           = useState(false);
+    const [showPdfModal, setShowPdfModal] = useState(false);
+    const { importEpaCsiGroups, getExistingEpaTestGroupIds } = useAppContext();
     const [showCreate, setShowCreate]     = useState(false);
     const [createDraft, setCreateDraft]   = useState({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
     const [creating, setCreating]         = useState(false);
@@ -410,8 +414,25 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         )}
                     </div>
                     <p className="text-xs text-gray-400 mt-1">
-                        Import test groups via Admin → Import → EPA Test Car Data, or create one by hand below.
+                        Import an EPA lab PDF, the Test Car Data CSV (Admin), or create one by hand below.
                     </p>
+
+                    {/* Import from lab PDF — parses + links the matching config to this vehicle */}
+                    <button
+                        type="button"
+                        onClick={() => setShowPdfModal(true)}
+                        className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline mt-2 mr-4"
+                    >
+                        📑 Import from EPA lab PDF
+                    </button>
+                    {showPdfModal && (
+                        <EpaPdfImportModal
+                            targetVehicle={vehicle}
+                            onImport={importEpaCsiGroups}
+                            getExistingIds={getExistingEpaTestGroupIds}
+                            onClose={() => setShowPdfModal(false)}
+                        />
+                    )}
 
                     {/* Create from scratch — for vehicles with only a lab-submission PDF */}
                     {!showCreate ? (

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -40,8 +40,9 @@ function DataRow({ label, value, muted }) {
 }
 
 /** Card displaying the data for one EPA test group mapping. */
-function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdateDisplayName }) {
+function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence, onUpdateDisplayName }) {
     const [unlinking,    setUnlinking]    = useState(false);
+    const [deleting,     setDeleting]     = useState(false);
     const [updatingConf, setUpdatingConf] = useState(false);
     const [draftName,    setDraftName]    = useState(null); // null = not editing
     const [savingName,   setSavingName]   = useState(false);
@@ -70,6 +71,16 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
     const handleUnlink = async () => {
         setUnlinking(true);
         try { await onUnlink(mapping.id); } finally { setUnlinking(false); }
+    };
+
+    const handleDelete = async () => {
+        if (!window.confirm(
+            `Delete EPA test group "${g.test_group_id}" entirely?\n\n` +
+            `This removes its coefficients, tests and phases and unlinks it from ALL vehicles. ` +
+            `It cannot be undone. (Use "Unlink" to only detach it from this vehicle.)`
+        )) return;
+        setDeleting(true);
+        try { await onDelete?.(g.test_group_id); } finally { setDeleting(false); }
     };
 
     const handleConfidence = async (e) => {
@@ -158,11 +169,23 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onUpdateConfidence, onUpdate
                     {canEdit && (
                         <button
                             type="button"
-                            disabled={unlinking}
+                            disabled={unlinking || deleting}
                             onClick={handleUnlink}
                             className="btn btn-secondary text-xs py-0.5 px-2 disabled:opacity-40"
+                            title="Detach this test group from this vehicle (keeps the shared record)"
                         >
                             {unlinking ? '…' : 'Unlink'}
+                        </button>
+                    )}
+                    {canEdit && onDelete && (
+                        <button
+                            type="button"
+                            disabled={unlinking || deleting}
+                            onClick={handleDelete}
+                            className="btn btn-danger text-xs py-0.5 px-2 disabled:opacity-40"
+                            title="Delete the shared test group and all its data (affects every linked vehicle)"
+                        >
+                            {deleting ? '…' : 'Delete'}
                         </button>
                     )}
                 </div>
@@ -266,7 +289,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
     const [showDropdown, setShowDropdown] = useState(false);
     const [linking, setLinking]           = useState(false);
     const [showPdfModal, setShowPdfModal] = useState(false);
-    const { importEpaCsiGroups, getExistingEpaTestGroupIds } = useAppContext();
+    const { importEpaCsiGroups, getExistingEpaTestGroupIds, deleteEpaTestGroup } = useAppContext();
     const [showCreate, setShowCreate]     = useState(false);
     const [createDraft, setCreateDraft]   = useState({ test_group_id: '', model_year: '', make: '', epa_carline_name: '' });
     const [creating, setCreating]         = useState(false);
@@ -364,6 +387,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         mapping={m}
                         canEdit={canEdit}
                         onUnlink={onUnlink}
+                        onDelete={deleteEpaTestGroup}
                         onUpdateConfidence={onUpdateConfidence}
                         onUpdateDisplayName={onUpdateDisplayName}
                     />

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -807,6 +807,31 @@ export function AppProvider({ children }) {
         }
     };
 
+    /** Which of these test_group_ids already exist (for overwrite confirmation). */
+    const getExistingEpaTestGroupIds = (ids) => dataService.getExistingEpaTestGroupIds(ids);
+
+    /**
+     * Import parsed CSI-PDF groups (clean-replace each), optionally linking one
+     * to a vehicle, then refresh. Used by the PDF import modal from both Admin
+     * and the per-vehicle curator section.
+     */
+    const importEpaCsiGroups = async (groups, { linkVehicleId, linkTestGroupId } = {}) => {
+        try {
+            for (const g of groups) await dataService.importEpaGroupFull(g);
+            if (linkVehicleId && linkTestGroupId) {
+                try { await dataService.linkEpaTestGroup(linkVehicleId, linkTestGroupId, 'verified', null); }
+                catch { /* already linked — ignore UNIQUE conflict */ }
+            }
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess(`Imported ${groups.length} EPA config(s) from PDF.`);
+            return { count: groups.length };
+        } catch (error) {
+            showError('PDF import failed: ' + error.message);
+            throw error;
+        }
+    };
+
     const updateEpaMapping = async (mappingId, updates) => {
         try {
             await dataService.updateEpaMapping(mappingId, updates);
@@ -1060,6 +1085,8 @@ export function AppProvider({ children }) {
         searchEpaTestGroups,
         linkEpaTestGroup,
         createAndLinkEpaTestGroup,
+        importEpaCsiGroups,
+        getExistingEpaTestGroupIds,
         updateEpaMapping,
         unlinkEpaTestGroup,
         importEpaTestGroups,

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -815,12 +815,14 @@ export function AppProvider({ children }) {
      * to a vehicle, then refresh. Used by the PDF import modal from both Admin
      * and the per-vehicle curator section.
      */
-    const importEpaCsiGroups = async (groups, { linkVehicleId, linkTestGroupId } = {}) => {
+    const importEpaCsiGroups = async (groups, { linkVehicleId, linkTestGroupIds = [] } = {}) => {
         try {
             for (const g of groups) await dataService.importEpaGroupFull(g);
-            if (linkVehicleId && linkTestGroupId) {
-                try { await dataService.linkEpaTestGroup(linkVehicleId, linkTestGroupId, 'verified', null); }
-                catch { /* already linked — ignore UNIQUE conflict */ }
+            if (linkVehicleId) {
+                for (const tgid of linkTestGroupIds) {
+                    try { await dataService.linkEpaTestGroup(linkVehicleId, tgid, 'verified', null); }
+                    catch { /* already linked — ignore UNIQUE conflict */ }
+                }
             }
             const updated = await dataService.getVehicles();
             setVehicles(updated);

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1199,6 +1199,71 @@ class DataService {
     return data;
   }
 
+  /** Which of the given test_group_ids already exist (for overwrite confirmation). */
+  async getExistingEpaTestGroupIds(ids) {
+    if (!this.useSupabase || !ids.length) return [];
+    const { data, error } = await getSupabase()
+      .from('epa_test_groups')
+      .select('test_group_id')
+      .in('test_group_id', ids);
+    if (error) throw error;
+    return (data || []).map(r => r.test_group_id);
+  }
+
+  /**
+   * Import one fully-parsed group (from a CSI PDF) into the curator model:
+   * upsert the group, then CLEAN-REPLACE its coefficient sets, tests and phases
+   * (delete existing, insert from the parse) so re-import is deterministic
+   * "upload is truth". Populated fields are tagged source:'pdf' in overrides.
+   *
+   * @param {Object} group  Output element of parseEpaCsiText().groups
+   */
+  async importEpaGroupFull(group) {
+    if (!this.useSupabase) return;
+    const supabase = getSupabase();
+    const { coefficient_sets = [], tests = [], ...g } = group;
+    const tgid = g.test_group_id;
+
+    // Tag every populated scalar field as PDF-sourced.
+    const pdfOverrides = (obj) => {
+      const o = {};
+      for (const [k, v] of Object.entries(obj)) if (v != null && k !== 'overrides') o[k] = { source: 'pdf' };
+      return o;
+    };
+
+    // 1. Group (upsert).
+    const { error: gErr } = await supabase
+      .from('epa_test_groups')
+      .upsert({ ...g, source_file: g.source_file ?? null, overrides: pdfOverrides(g) },
+              { onConflict: 'test_group_id', ignoreDuplicates: false });
+    if (gErr) throw gErr;
+
+    // 2. Coefficient sets (clean-replace).
+    await supabase.from('epa_coefficient_sets').delete().eq('test_group_id', tgid);
+    if (coefficient_sets.length) {
+      const rows = coefficient_sets.map(cs => ({ test_group_id: tgid, ...cs, overrides: pdfOverrides(cs) }));
+      const { error } = await supabase.from('epa_coefficient_sets').insert(rows);
+      if (error) throw error;
+    }
+
+    // 3. Tests + phases (clean-replace; phases cascade on test delete).
+    await supabase.from('epa_tests').delete().eq('test_group_id', tgid);
+    for (const t of tests) {
+      const { phases = [], ...testRow } = t;
+      const { data: savedTest, error: tErr } = await supabase
+        .from('epa_tests')
+        .insert({ test_group_id: tgid, ...testRow, overrides: pdfOverrides(testRow) })
+        .select('id')
+        .single();
+      if (tErr) throw tErr;
+      if (phases.length) {
+        const pRows = phases.map(p => ({ test_id: savedTest.id, ...p, overrides: pdfOverrides(p) }));
+        const { error: pErr } = await supabase.from('epa_test_phases').insert(pRows);
+        if (pErr) throw pErr;
+      }
+    }
+  }
+
   /** Convenience alias kept for back-compat. */
   async updateEpaLabelMethod(testGroupId, method) {
     return this.updateEpaTestGroup(testGroupId, { label_method: method || null });

--- a/src/utils/extractPdfText.js
+++ b/src/utils/extractPdfText.js
@@ -12,17 +12,22 @@ export async function extractPdfText(file) {
     pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl;
 
     const data = await file.arrayBuffer();
-    const pdf = await pdfjsLib.getDocument({ data }).promise;
+    const loadingTask = pdfjsLib.getDocument({ data });
+    const pdf = await loadingTask.promise;
 
     const items = [];
-    for (let p = 1; p <= pdf.numPages; p++) {
-        const page = await pdf.getPage(p);
-        const content = await page.getTextContent();
-        for (const it of content.items) {
-            if (typeof it.str === 'string') items.push(it.str);
+    try {
+        for (let p = 1; p <= pdf.numPages; p++) {
+            const page = await pdf.getPage(p);
+            const content = await page.getTextContent();
+            for (const it of content.items) {
+                if (typeof it.str === 'string') items.push(it.str);
+            }
+            if (typeof page.cleanup === 'function') page.cleanup();
         }
-        page.cleanup();
+    } finally {
+        // pdf.js v6: destroy the loading task (the document proxy has no destroy()).
+        try { await loadingTask.destroy(); } catch { /* best-effort cleanup */ }
     }
-    await pdf.destroy();
     return items;
 }

--- a/src/utils/extractPdfText.js
+++ b/src/utils/extractPdfText.js
@@ -1,0 +1,28 @@
+/**
+ * Extract the ordered text items from a PDF File/Blob using pdf.js.
+ *
+ * pdf.js is dynamically imported so it lands in its own lazy chunk (it's only
+ * needed when a curator imports a PDF — never in the main bundle). Returns the
+ * text strings in content-stream order, which is what parseEpaCsiText expects.
+ */
+export async function extractPdfText(file) {
+    const pdfjsLib = await import('pdfjs-dist');
+    // Vite resolves the `?url` suffix to the worker asset URL.
+    const workerUrl = (await import('pdfjs-dist/build/pdf.worker.min.mjs?url')).default;
+    pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl;
+
+    const data = await file.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data }).promise;
+
+    const items = [];
+    for (let p = 1; p <= pdf.numPages; p++) {
+        const page = await pdf.getPage(p);
+        const content = await page.getTextContent();
+        for (const it of content.items) {
+            if (typeof it.str === 'string') items.push(it.str);
+        }
+        page.cleanup();
+    }
+    await pdf.destroy();
+    return items;
+}

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -214,11 +214,19 @@ export function parseEpaCsiText(rawItems) {
 
     const groups = cfgIdx.map((ci, k) => {
         const end = k + 1 < cfgIdx.length ? cfgIdx[k + 1] : items.length;
-        const [vehId, cfgNumRaw] = (items[ci + 1] || '').split('/').map(s => s.trim());
-        const cfgNum = cfgNumRaw || valAfter(items, 'Manufacturer Vehicle Configuration Number', ci, end);
-        // Unique key: bare Vehicle ID when unique in this PDF, else suffix the config #.
+        // "Vehicle ID / Configuration" = "<Vehicle ID> / <EPA config index>".
+        // The EPA config index distinguishes records under one reused Vehicle ID
+        // (e.g. BMW's 5 tire packages → 0..4), so it drives the unique key.
+        const idParts = (items[ci + 1] || '').split('/');
+        const vehId = idParts[0].trim();
+        const epaConfigIdx = (idParts[1] || '').trim();
+        // Manufacturer Vehicle Configuration Number is a SEPARATE field — the
+        // manufacturer's "mode" delineator (often 0). Captured on its own; it is
+        // not necessarily unique across configs, so it is NOT used for the key.
+        const modeNum = valAfter(items, 'Manufacturer Vehicle Configuration Number', ci, end);
+        // Unique key: bare Vehicle ID when unique in this PDF, else suffix the EPA config index.
         const test_group_id = vehId
-            ? (idCounts[vehId] > 1 ? `${vehId}-${cfgNum ?? k}` : vehId)
+            ? (idCounts[vehId] > 1 ? `${vehId}-${epaConfigIdx || k}` : vehId)
             : null;
 
         const rawMake = valAfter(items, 'Represented Test Vehicle Make', ci, end);
@@ -227,7 +235,7 @@ export function parseEpaCsiText(rawItems) {
         return {
             test_group_id,
             epa_test_family_id: valAfter(items, 'Original Test Group Name', ci, end),
-            vehicle_config_number: cfgNum ?? null,
+            vehicle_config_number: modeNum ?? null,   // mfr "mode" number, captured separately
             model_year: parseNum(valAfter(items, 'Original Test Vehicle Model Year', ci, end)),
             make,
             epa_carline_name: valAfter(items, 'Represented Test Vehicle Model', ci, end),

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -1,0 +1,248 @@
+/**
+ * Parse an EPA "Certification Summary Information" (CSI) PDF — the manufacturer's
+ * lab-submission report — into the curator model (one record per vehicle config).
+ *
+ * Input is the ordered list of text items extracted from the PDF (see
+ * extractPdfText.js, which uses pdf.js in the browser). CSI reports are
+ * iText-generated text PDFs laid out as (label)(value) pairs, so parsing is a
+ * label-anchored walk over the item stream, segmented Group → Config → Test →
+ * Bag/Phase.
+ *
+ * Output shape matches getEpaTestGroupFull / the importer contract:
+ *   { groups: [{ test_group_id, epa_test_family_id, model_year, make,
+ *                epa_carline_name, vehicle_config_number, drive, fuel_type,
+ *                total_voltage, battery_specific_energy, useable_kwh,
+ *                coefficient_sets: [...], tests: [{ ..., phases: [...] }] }],
+ *     warnings: [...] }
+ *
+ * Phase type is not stated in the PDF, so it's inferred from phase distance
+ * (~10.26 mi → HWY, ~7.45 mi → UDDS, ≫10× neighbors → SS), matching the curator
+ * form's auto-suggest. Everything is editable post-import.
+ */
+
+const HWFET_MI = 10.26, UDDS_MI = 7.45, DIST_TOL = 0.7;
+
+const parseNum = (s) => {
+    if (s == null) return null;
+    const t = String(s).trim().replace(/,/g, '');
+    if (!t || t === '--' || /^n\/?a$/i.test(t)) return null;
+    const n = parseFloat(t);
+    return Number.isNaN(n) ? null : n;
+};
+
+/** Infer a phase type from its distance + the test's other distances. */
+function inferPhaseType(distanceMi, otherDistances, cold) {
+    const d = parseNum(distanceMi);
+    if (d == null || d <= 0) return null;
+    const others = otherDistances.map(parseNum).filter(x => x != null && x > 0);
+    if (others.length && d >= 10 * Math.min(...others)) return 'SS';
+    if (Math.abs(d - HWFET_MI) <= DIST_TOL) return cold ? 'HWY' : 'HWY';
+    if (Math.abs(d - UDDS_MI)  <= DIST_TOL) return cold ? 'Cold-UDDS' : 'UDDS';
+    return null;
+}
+
+/** Trim verbose legal suffixes from a manufacturer name (Lucid USA, Inc → Lucid). */
+function cleanMake(make) {
+    if (!make) return null;
+    return make
+        .replace(/,?\s*\b(USA|Inc|LLC|Ltd|GmbH|AG|Corp|Corporation|Co|Company|Automotive|North America)\b\.?/gi, '')
+        .replace(/,\s*$/, '').trim() || make;
+}
+
+/** Map a CSI coefficient-category label to our enum. */
+function mapCoeffCategory(label) {
+    const s = label.toLowerCase();
+    if (s.includes('cold')) return 'Cold CO';
+    if (s.includes('us06')) return 'US06';
+    if (s.includes('city') || s.includes('highway')) return 'City/Highway';
+    return null;
+}
+
+/**
+ * Remove page header/footer noise that interleaves the content stream:
+ *   "Date: …", "Certification Summary Information Report", "Page N of M …",
+ *   and the running "Test Group"/id + "Evaporative/Refueling Family"/value
+ *   footer pair (we read those values from config-level labels instead).
+ */
+function stripNoise(items) {
+    const out = [];
+    for (let i = 0; i < items.length; i++) {
+        const s = (items[i] ?? '').trim();
+        if (!s) continue;
+        if (/^Page \d+ of \d+/.test(s)) continue;
+        if (s === 'Certification Summary Information Report') continue;
+        if (/^Date:\s*\d{2}\/\d{2}\/\d{4}/.test(s)) continue;
+        // Footer header pairs: drop the label AND its trailing value.
+        if (s === 'Test Group' || s === 'Evaporative/Refueling Family') { i++; continue; }
+        out.push(s);
+    }
+    return out;
+}
+
+// ── Label-anchored lookups within a [start,end) window ──────────────────────
+
+/** Index of the first item exactly equal to `label` in [start,end). */
+const idxOf = (items, label, start = 0, end = items.length) => {
+    for (let i = start; i < end; i++) if (items[i] === label) return i;
+    return -1;
+};
+
+/** The item immediately after the first occurrence of `label` (its value). */
+function valAfter(items, label, start = 0, end = items.length) {
+    const i = idxOf(items, label, start, end);
+    return i >= 0 && i + 1 < end ? items[i + 1] : null;
+}
+
+/** All indices in [start,end) where predicate(item) is true. */
+function indicesWhere(items, pred, start = 0, end = items.length) {
+    const out = [];
+    for (let i = start; i < end; i++) if (pred(items[i], i)) out.push(i);
+    return out;
+}
+
+// ── Coefficient table ───────────────────────────────────────────────────────
+
+/**
+ * Parse the coefficient table within [start,end). Layout: header labels, then
+ * per category one row of 7 numbers (target A/B/C, set A/B/C, HP). Returns
+ * coefficient_sets[].
+ */
+function parseCoefficients(items, start, end) {
+    const head = idxOf(items, 'Target Coefficients', start, end);
+    if (head < 0) return [];
+    const sets = [];
+    for (let i = head; i < end; i++) {
+        const cat = mapCoeffCategory(items[i] || '');
+        // Only treat as a category row when followed by ≥6 numbers.
+        if (!cat) continue;
+        const nums = [];
+        let j = i + 1;
+        while (j < end && nums.length < 7 && parseNum(items[j]) != null) { nums.push(parseNum(items[j])); j++; }
+        if (nums.length < 6) continue;
+        sets.push({
+            category: cat,
+            is_primary: cat === 'City/Highway',
+            target_a: nums[0], target_b: nums[1], target_c: nums[2],
+            set_a: nums[3], set_b: nums[4], set_c: nums[5],
+        });
+        i = j - 1;
+    }
+    // De-dup categories (first wins), guarantee one primary.
+    const seen = new Set();
+    const unique = sets.filter(s => (seen.has(s.category) ? false : seen.add(s.category)));
+    if (unique.length && !unique.some(s => s.is_primary)) unique[0].is_primary = true;
+    return unique;
+}
+
+// ── Tests & phases ──────────────────────────────────────────────────────────
+
+const isTestHeader = (s) => /^\d{1,3}\s*-\s*\S/.test(s) && /charge depleting|multi-?cycle|mct|highway|udds|ftp/i.test(s);
+
+function parsePhases(items, start, end, cold) {
+    const bagIdx = indicesWhere(items, s => /^Charge Depleting Bag\/Phase #\d+/.test(s), start, end);
+    const raw = bagIdx.map((bi, k) => {
+        const bEnd = k + 1 < bagIdx.length ? bagIdx[k + 1] : end;
+        const m = items[bi].match(/#(\d+)/);
+        return {
+            phase_index: m ? Number(m[1]) : k + 1,
+            distance_mi: parseNum(valAfter(items, 'Actual Distance Driven (miles)', bi, bEnd)),
+            dc_energy_kwh: parseNum(valAfter(items, 'Integrated DC KW-HRS', bi, bEnd)),
+        };
+    });
+    const dists = raw.map(p => p.distance_mi);
+    return raw.map(p => ({ ...p, phase_type: inferPhaseType(p.distance_mi, dists.filter((_, i) => raw[i] !== p), cold) }));
+}
+
+function parseTests(items, start, end) {
+    const testIdx = indicesWhere(items, isTestHeader, start, end);
+    return testIdx.map((ti, k) => {
+        const tEnd = k + 1 < testIdx.length ? testIdx[k + 1] : end;
+        const header = items[ti];
+        const procMatch = header.match(/^(\d{1,3})\s*-/);
+        const cold = /cold|degree/i.test(header);
+        // "Charge Depleting Range Highway" then "(Calculated miles)" then value.
+        const hwyLabelIdx = idxOf(items, 'Charge Depleting Range Highway', ti, tEnd);
+        const cdRangeHwy = hwyLabelIdx >= 0 ? parseNum(items[hwyLabelIdx + 2]) : null;
+        const phases = parsePhases(items, ti, tEnd, cold);
+        const total_dc = phases.reduce((s, p) => s + (p.dc_energy_kwh ?? 0), 0);
+        const total_dist = phases.reduce((s, p) => s + (p.distance_mi ?? 0), 0);
+        return {
+            procedure_code: procMatch ? Number(procMatch[1]) : null,
+            originator: 'MFR',
+            lab_id: valAfter(items, 'Verify Test Lab ID', ti, tEnd),
+            test_date: valAfter(items, 'Test Date', ti, tEnd),
+            source: 'pdf',
+            recharge_voltage: parseNum(valAfter(items, 'Recharge Event Voltage', ti, tEnd)),
+            ac_recharge_kwh: parseNum(valAfter(items, 'Recharge Event Energy (kiloWatt-hours)', ti, tEnd)),
+            cd_range_combined_calc: parseNum(valAfter(items, 'Charge Depleting Range (Calculated miles)', ti, tEnd)),
+            cd_range_hwy_calc: cdRangeHwy,
+            bags_phases_conducted: parseNum(valAfter(items, 'Conducted', ti, tEnd)),
+            total_dc_energy_kwh: total_dc > 0 ? Math.round(total_dc * 1000) / 1000 : null,
+            total_distance_mi: total_dist > 0 ? Math.round(total_dist * 1000) / 1000 : null,
+            phases,
+        };
+    });
+}
+
+// ── Top-level ───────────────────────────────────────────────────────────────
+
+/**
+ * @param {string[]} rawItems  Ordered text items from the CSI PDF.
+ * @returns {{ groups: Array, warnings: string[] }}
+ */
+export function parseEpaCsiText(rawItems) {
+    const items = stripNoise(rawItems || []);
+    const warnings = [];
+
+    // Each config begins at a "Vehicle ID / Configuration" anchor.
+    const cfgIdx = indicesWhere(items, s => s === 'Vehicle ID / Configuration');
+    if (!cfgIdx.length) {
+        return { groups: [], warnings: ['No vehicle configurations found — is this an EPA CSI PDF?'] };
+    }
+
+    // Group-level fields live in the preamble before the first config and are
+    // shared across configs (battery pack, certifying manufacturer).
+    const preEnd = cfgIdx[0];
+    const groupManufacturer = cleanMake(valAfter(items, 'Manufacturer', 0, preEnd));
+    const groupVoltage = parseNum(valAfter(items, 'Total Voltage of Battery Packs', 0, preEnd));
+    const groupSpecificEnergy = parseNum(valAfter(items, 'Battery Specific Energy', 0, preEnd));
+
+    // First pass: read raw vehicle IDs to detect repeats (BMW/Lucid reuse one ID
+    // across configs; we must disambiguate the test_group_id with the config #).
+    const rawIds = cfgIdx.map(ci => (items[ci + 1] || '').split('/')[0].trim());
+    const idCounts = rawIds.reduce((m, id) => (m[id] = (m[id] || 0) + 1, m), {});
+
+    const groups = cfgIdx.map((ci, k) => {
+        const end = k + 1 < cfgIdx.length ? cfgIdx[k + 1] : items.length;
+        const [vehId, cfgNumRaw] = (items[ci + 1] || '').split('/').map(s => s.trim());
+        const cfgNum = cfgNumRaw || valAfter(items, 'Manufacturer Vehicle Configuration Number', ci, end);
+        // Unique key: bare Vehicle ID when unique in this PDF, else suffix the config #.
+        const test_group_id = vehId
+            ? (idCounts[vehId] > 1 ? `${vehId}-${cfgNum ?? k}` : vehId)
+            : null;
+
+        const rawMake = valAfter(items, 'Represented Test Vehicle Make', ci, end);
+        const make = (!rawMake || /^\d+$/.test(rawMake)) ? groupManufacturer : cleanMake(rawMake);
+
+        return {
+            test_group_id,
+            epa_test_family_id: valAfter(items, 'Original Test Group Name', ci, end),
+            vehicle_config_number: cfgNum ?? null,
+            model_year: parseNum(valAfter(items, 'Original Test Vehicle Model Year', ci, end)),
+            make,
+            epa_carline_name: valAfter(items, 'Represented Test Vehicle Model', ci, end),
+            fuel_type: 'Electricity',
+            total_voltage: groupVoltage,
+            battery_specific_energy: groupSpecificEnergy,
+            // "Battery Energy Capacity" in the CSI is amp-hours, not useable kWh,
+            // so it's intentionally not mapped — curator sets useable capacity
+            // (best proxy: the MCT total DC to depletion).
+            useable_kwh: null,
+            coefficient_sets: parseCoefficients(items, ci, end),
+            tests: parseTests(items, ci, end),
+        };
+    }).filter(g => g.test_group_id);
+
+    if (!groups.length) warnings.push('Configurations found but no Vehicle IDs could be read.');
+    return { groups, warnings };
+}

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -22,6 +22,12 @@
 
 const HWFET_MI = 10.26, UDDS_MI = 7.45, DIST_TOL = 0.7;
 
+/** MM/DD/YYYY → YYYY-MM-DD (Postgres date); pass through anything else. */
+function toIsoDate(s) {
+    const m = String(s ?? '').trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    return m ? `${m[3]}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}` : (s || null);
+}
+
 const parseNum = (s) => {
     if (s == null) return null;
     const t = String(s).trim().replace(/,/g, '');
@@ -170,7 +176,7 @@ function parseTests(items, start, end) {
             procedure_code: procMatch ? Number(procMatch[1]) : null,
             originator: 'MFR',
             lab_id: valAfter(items, 'Verify Test Lab ID', ti, tEnd),
-            test_date: valAfter(items, 'Test Date', ti, tEnd),
+            test_date: toIsoDate(valAfter(items, 'Test Date', ti, tEnd)),
             source: 'pdf',
             recharge_voltage: parseNum(valAfter(items, 'Recharge Event Voltage', ti, tEnd)),
             ac_recharge_kwh: parseNum(valAfter(items, 'Recharge Event Energy (kiloWatt-hours)', ti, tEnd)),
@@ -232,6 +238,18 @@ export function parseEpaCsiText(rawItems) {
         const rawMake = valAfter(items, 'Represented Test Vehicle Make', ci, end);
         const make = (!rawMake || /^\d+$/.test(rawMake)) ? groupManufacturer : cleanMake(rawMake);
 
+        const coefficient_sets = parseCoefficients(items, ci, end);
+        const tests = parseTests(items, ci, end);
+
+        // CD range is a GROUP-level (Section 6) field, not an epa_tests column.
+        // Take it from the preferred test (77 → 84 → first), then drop it off the
+        // test rows so the epa_tests insert only has valid columns.
+        const pref = tests.find(t => t.procedure_code === 77)
+            || tests.find(t => t.procedure_code === 84) || tests[0];
+        const cd_range_combined_calc = pref?.cd_range_combined_calc ?? null;
+        const cd_range_hwy_calc = pref?.cd_range_hwy_calc ?? null;
+        tests.forEach(t => { delete t.cd_range_combined_calc; delete t.cd_range_hwy_calc; });
+
         return {
             test_group_id,
             epa_test_family_id: valAfter(items, 'Original Test Group Name', ci, end),
@@ -246,8 +264,10 @@ export function parseEpaCsiText(rawItems) {
             // so it's intentionally not mapped — curator sets useable capacity
             // (best proxy: the MCT total DC to depletion).
             useable_kwh: null,
-            coefficient_sets: parseCoefficients(items, ci, end),
-            tests: parseTests(items, ci, end),
+            cd_range_combined_calc,
+            cd_range_hwy_calc,
+            coefficient_sets,
+            tests,
         };
     }).filter(g => g.test_group_id);
 

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -177,7 +177,7 @@ function parseTests(items, start, end) {
             originator: 'MFR',
             lab_id: valAfter(items, 'Verify Test Lab ID', ti, tEnd),
             test_date: toIsoDate(valAfter(items, 'Test Date', ti, tEnd)),
-            source: 'pdf',
+            source: 'csi_pdf',   // epa_tests.source enum (override field-tag stays 'pdf')
             recharge_voltage: parseNum(valAfter(items, 'Recharge Event Voltage', ti, tEnd)),
             ac_recharge_kwh: parseNum(valAfter(items, 'Recharge Event Energy (kiloWatt-hours)', ti, tEnd)),
             cd_range_combined_calc: parseNum(valAfter(items, 'Charge Depleting Range (Calculated miles)', ti, tEnd)),

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -172,7 +172,14 @@ function parseTests(items, start, end) {
         const phases = parsePhases(items, ti, tEnd, cold);
         const total_dc = phases.reduce((s, p) => s + (p.dc_energy_kwh ?? 0), 0);
         const total_dist = phases.reduce((s, p) => s + (p.distance_mi ?? 0), 0);
+        // The EPA "Test #" + value precede the procedure header (Test # → value
+        // → Test Procedure → "NN - …"), so look back a few items for it.
+        let test_number = null;
+        for (let b = ti - 1; b >= Math.max(0, ti - 6); b--) {
+            if (items[b] === 'Test #') { test_number = items[b + 1] || null; break; }
+        }
         return {
+            test_number,
             procedure_code: procMatch ? Number(procMatch[1]) : null,
             originator: 'MFR',
             lab_id: valAfter(items, 'Verify Test Lab ID', ti, tEnd),


### PR DESCRIPTION
Curators can drag an EPA **Certification Summary Information (CSI)** lab PDF straight into the app — no install, no Python, no intermediate JSON. pdf.js extracts the text in-browser (lazy-loaded chunk, not in the main bundle); a pure parser turns it into the curator model.

## Validated against the real sample PDFs
Tested against `LocalDev/EPA_Files/` (Rivian, BMW, Lucid) — all parse cleanly:
- **Rivian** → 3 configs (R1S247XR20/22, R1T…), coeff sets City/Highway + Cold CO + US06, proc-77 + proc-86 tests, 8/4 phases each, summed DC ≈ 142 kWh ✓
- **BMW** → 5 configs (one Vehicle ID reused → disambiguated as `DA01672-0…4`)
- **Lucid** → 6 configs across 3 families; mis-filed make `"2025"` → corrected to `Lucid`

## What it extracts
Group → Config → Test → Bag/Phase: identity, **multiple coefficient categories**, tests (procedure code, lab, recharge V/energy, CD ranges, bag count), and phases (`Integrated DC KW-HRS` + distance). `test_group_id` = the CSI **Vehicle ID** (matches the TCL CSV key, so PDF/CSV reconcile), suffixed with the config # only when a manufacturer reuses one ID. **Phase type inferred from distance** (~10.26→HWY, ~7.45→UDDS, ≫10×→SS) since the PDF doesn't label it.

## Flow & entry points
- `DataService.importEpaGroupFull` — **clean-replace** upsert (group + coeff sets + tests + phases); fields tagged `source:'pdf'`. `getExistingEpaTestGroupIds` powers an overwrite confirmation ("upload is truth").
- `EpaPdfImportModal` — drag/drop → preview (counts, **new vs ⟳ overwrite**, warnings) → import.
- Wired from **Admin → Import → "EPA Lab PDF (CSI)"** (bulk) and the **per-vehicle EPA section** (pick which config links to the current trim). Same shared code.

## Bundle impact
pdf.js is dynamically imported → its own `pdf-*.js` (428 KB) + worker (1.2 MB) chunks load **only when importing a PDF**. Main bundle unchanged.

## Reviewer note
Parser logic is validated against the three real PDFs via extracted text. The one thing I couldn't exercise headless is **pdf.js running in an actual browser** (worker URL resolution) — worth a quick manual smoke test: Admin → Import → EPA Lab PDF → drop `CSI-SRIVT00.0SEP.PDF` → expect 3 Rivian configs in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)