### PR TITLE
Centralize math constants + Admin Model Constants knobs + sub-tab reorg

### DIFF
--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -4,6 +4,7 @@ import ImportTableauModal from './ImportTableauModal';
 import EpaImportModal from './EpaImportModal';
 import EpaPdfImportModal from './EpaPdfImportModal';
 import EpaDataCard from './EpaDataCard';
+import ConstantsKnobs from './admin/ConstantsKnobs';
 
 const ROLES = ['user', 'contributor', 'admin'];
 
@@ -206,6 +207,8 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                 deleteEpaTestGroup={deleteEpaTestGroup}
                 updateEpaTestGroup={updateEpaTestGroup}
             />
+
+            <ConstantsKnobs />
         </div>
     );
 }

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -96,7 +96,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
             <div className="flex justify-between items-center mb-4">
                 <div>
                     <h2 className="page-title">Admin Panel</h2>
-                    <p className="text-gray-500 mt-1">{SUBTITLES[subtab]}</p>
+                    <p className="text-secondary mt-1">{SUBTITLES[subtab]}</p>
                 </div>
                 <div className="flex items-center gap-2">
                     <button onClick={exportData} className="btn btn-secondary text-sm">

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -4,14 +4,22 @@ import ImportTableauModal from './ImportTableauModal';
 import EpaImportModal from './EpaImportModal';
 import EpaPdfImportModal from './EpaPdfImportModal';
 import EpaDataCard from './EpaDataCard';
+import RolesPermissions from './admin/RolesPermissions';
 import ConstantsKnobs from './admin/ConstantsKnobs';
+import InterfaceSettings from './admin/InterfaceSettings';
 
-const ROLES = ['user', 'contributor', 'admin'];
+const SUBTABS = [
+    { id: 'roles',     label: 'Roles & Permissions' },
+    { id: 'epa',       label: 'EPA Data' },
+    { id: 'constants', label: 'Model Constants' },
+    { id: 'interface', label: 'Interface Settings' },
+];
 
-const roleBadgeStyle = {
-    admin:       { backgroundColor: '#fef3c7', color: '#92400e', border: '1px solid #fcd34d' },
-    contributor: { backgroundColor: '#dbeafe', color: '#1e40af', border: '1px solid #93c5fd' },
-    user:        { backgroundColor: '#f3f4f6', color: '#374151', border: '1px solid #d1d5db' },
+const SUBTITLES = {
+    roles:     'Manage registered users and their roles.',
+    epa:       'Browse, edit, link, and delete imported EPA test groups.',
+    constants: 'Tune the EPA model math (local sandbox).',
+    interface: 'Site-wide appearance settings.',
 };
 
 export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId }) {
@@ -21,6 +29,7 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
         importEpaCsiGroups, getExistingEpaTestGroupIds,
         vehicles,
     } = useAppContext();
+    const [subtab, setSubtab]         = useState('roles');
     const [users, setUsers]           = useState([]);
     const [loading, setLoading]       = useState(true);
     const [saving, setSaving]         = useState(null);
@@ -83,10 +92,11 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                     onClose={() => setShowEpaPdfModal(false)}
                 />
             )}
-            <div className="flex justify-between items-center mb-6">
+
+            <div className="flex justify-between items-center mb-4">
                 <div>
                     <h2 className="page-title">Admin Panel</h2>
-                    <p className="text-gray-500 mt-1">Manage registered users and their roles.</p>
+                    <p className="text-gray-500 mt-1">{SUBTITLES[subtab]}</p>
                 </div>
                 <div className="flex items-center gap-2">
                     <button onClick={exportData} className="btn btn-secondary text-sm">
@@ -121,10 +131,24 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                             </>
                         )}
                     </div>
-                    <button onClick={load} className="btn btn-secondary text-sm" disabled={loading}>
-                        {loading ? 'Loading…' : '↻ Refresh'}
-                    </button>
+                    {subtab === 'roles' && (
+                        <button onClick={load} className="btn btn-secondary text-sm" disabled={loading}>
+                            {loading ? 'Loading…' : '↻ Refresh'}
+                        </button>
+                    )}
                 </div>
+            </div>
+
+            <div className="admin-subtabs">
+                {SUBTABS.map(t => (
+                    <button
+                        key={t.id}
+                        className={`btn-chart-mode ${subtab === t.id ? 'active' : ''}`}
+                        onClick={() => setSubtab(t.id)}
+                    >
+                        {t.label}
+                    </button>
+                ))}
             </div>
 
             {error && (
@@ -133,82 +157,27 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
                 </div>
             )}
 
-            {loading ? (
-                <div className="empty-state">Loading users…</div>
-            ) : users.length === 0 ? (
-                <div className="empty-state">No users found.</div>
-            ) : (
-                <div className="card p-0 overflow-hidden">
-                    <table className="w-full text-sm">
-                        <thead>
-                            <tr className="border-b bg-gray-50 text-left">
-                                <th className="px-4 py-3 font-semibold text-gray-600">Email</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Joined</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Role</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Change Role</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {users.map(u => (
-                                <tr key={u.id} className="border-t hover:bg-gray-50/50 transition">
-                                    <td className="px-4 py-3 font-medium text-gray-800">{u.email}</td>
-                                    <td className="px-4 py-3 text-gray-500">
-                                        {new Date(u.created_at).toLocaleDateString()}
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        <span
-                                            className="px-2 py-0.5 rounded-full text-xs font-semibold"
-                                            style={roleBadgeStyle[u.role] || roleBadgeStyle.user}
-                                        >
-                                            {u.role}
-                                        </span>
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        {u.id === currentUserId ? (
-                                            <span className="text-xs text-gray-400 italic">can't change own role</span>
-                                        ) : (
-                                            <div className="flex gap-1 flex-wrap">
-                                                {ROLES.map(role => (
-                                                    <button
-                                                        key={role}
-                                                        onClick={() => handleRoleChange(u.id, role)}
-                                                        disabled={u.role === role || saving === u.id}
-                                                        className={`px-2.5 py-1 rounded border text-xs font-medium transition ${
-                                                            u.role === role
-                                                                ? 'opacity-40 cursor-default'
-                                                                : 'bg-white hover:bg-gray-100 border-gray-300 text-gray-700'
-                                                        }`}
-                                                    >
-                                                        {saving === u.id && u.role !== role ? '…' : role}
-                                                    </button>
-                                                ))}
-                                            </div>
-                                        )}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+            {subtab === 'roles' && (
+                <RolesPermissions
+                    users={users}
+                    loading={loading}
+                    saving={saving}
+                    currentUserId={currentUserId}
+                    onRoleChange={handleRoleChange}
+                />
             )}
 
-            <div className="mt-6 p-4 rounded-lg border bg-amber-50 border-amber-200">
-                <p className="text-sm text-amber-800 font-semibold mb-1">Role permissions</p>
-                <ul className="text-xs text-amber-700 space-y-1">
-                    <li><strong>admin</strong> — full access: edit/delete any vehicle or test, manage users, toggle visibility, change site settings</li>
-                    <li><strong>contributor</strong> — edit any public vehicle or test, plus anything they submitted; can toggle visibility</li>
-                    <li><strong>user</strong> — edit only vehicles and tests they submitted; visibility locked</li>
-                    <li><em>Unauthenticated</em> — read-only access to public content</li>
-                </ul>
-            </div>
+            {subtab === 'epa' && (
+                <EpaDataCard
+                    getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
+                    deleteEpaTestGroup={deleteEpaTestGroup}
+                    updateEpaTestGroup={updateEpaTestGroup}
+                />
+            )}
 
-            <EpaDataCard
-                getEpaTestGroupsAdmin={getEpaTestGroupsAdmin}
-                deleteEpaTestGroup={deleteEpaTestGroup}
-                updateEpaTestGroup={updateEpaTestGroup}
-            />
+            {subtab === 'constants' && <ConstantsKnobs />}
 
-            <ConstantsKnobs />
+            {subtab === 'interface' && <InterfaceSettings />}
         </div>
     );
 }

--- a/src/components/admin/ConstantsKnobs.jsx
+++ b/src/components/admin/ConstantsKnobs.jsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { KNOB_GROUPS, knobDefault } from '../../constants/knobs';
+import { getOverrides, setOverride, clearOverrides } from '../../constants/overrides';
+
+/**
+ * Admin panel for tuning the EPA model constants in real time.
+ *
+ * Writes per-browser overrides to localStorage (constants/overrides.js); the math
+ * modules read them at load, so changes apply on the next page reload. Pure local
+ * sandbox — never touches the DB or other users.
+ */
+const eq = (a, b) =>
+    Array.isArray(a) && Array.isArray(b) ? a[0] === b[0] && a[1] === b[1] : a === b;
+
+const numOrNull = (s) => (s === '' || s == null ? null : Number(s));
+
+export default function ConstantsKnobs() {
+    const [overrides, setOverrides] = useState(getOverrides);
+    const [dirty, setDirty] = useState(false);
+
+    // Effective (live) value for a knob: override if set, else default.
+    const valueOf = (key) => (key in overrides ? overrides[key] : knobDefault(key));
+    const isModified = (key) => key in overrides && !eq(overrides[key], knobDefault(key));
+
+    function commit(key, value) {
+        const def = knobDefault(key);
+        if (value == null || eq(value, def)) setOverride(key, null);
+        else setOverride(key, value);
+        setOverrides(getOverrides());
+        setDirty(true);
+    }
+
+    function resetKey(key) {
+        setOverride(key, null);
+        setOverrides(getOverrides());
+        setDirty(true);
+    }
+
+    function resetAll() {
+        clearOverrides();
+        setOverrides(getOverrides());
+        setDirty(true);
+    }
+
+    const anyModified = KNOB_GROUPS.some(g => g.knobs.some(k => isModified(k.key)));
+
+    return (
+        <div className="card mt-6 p-5">
+            <div className="flex items-start justify-between gap-4 mb-1">
+                <div>
+                    <h3 className="text-lg font-semibold text-gray-800">Model Constants</h3>
+                    <p className="text-sm text-gray-500 mt-0.5">
+                        Tune the EPA math on <strong>this browser only</strong>. Changes are saved
+                        instantly but apply on the next page reload. Never affects the database or
+                        other users.
+                    </p>
+                </div>
+                <button
+                    onClick={resetAll}
+                    disabled={!anyModified}
+                    className="btn btn-secondary text-sm whitespace-nowrap disabled:opacity-40"
+                >
+                    Reset all
+                </button>
+            </div>
+
+            {dirty && (
+                <div className="my-3 flex items-center justify-between gap-3 p-3 rounded-lg border bg-blue-50 border-blue-200">
+                    <span className="text-sm text-blue-800">
+                        Overrides saved — reload to apply them to the calculations.
+                    </span>
+                    <button onClick={() => window.location.reload()} className="btn btn-primary text-sm whitespace-nowrap">
+                        ↻ Reload now
+                    </button>
+                </div>
+            )}
+
+            {KNOB_GROUPS.map(group => (
+                <div key={group.title} className="mt-4">
+                    <h4 className="text-sm font-semibold text-gray-700">{group.title}</h4>
+                    {group.blurb && <p className="text-xs text-gray-400 mb-2">{group.blurb}</p>}
+                    <div className="divide-y divide-gray-100 border-t border-gray-100">
+                        {group.knobs.map(knob => (
+                            <KnobRow
+                                key={knob.key}
+                                knob={knob}
+                                value={valueOf(knob.key)}
+                                def={knobDefault(knob.key)}
+                                modified={isModified(knob.key)}
+                                onChange={(v) => commit(knob.key, v)}
+                                onReset={() => resetKey(knob.key)}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function KnobRow({ knob, value, def, modified, onChange, onReset }) {
+    const { label, help, kind, min, max, step, unit } = knob;
+
+    return (
+        <div className="py-3 flex items-start justify-between gap-4">
+            <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-gray-800">{label}</span>
+                    {modified && (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-700 border border-amber-200">
+                            modified
+                        </span>
+                    )}
+                </div>
+                {help && <p className="text-xs text-gray-400 mt-0.5">{help}</p>}
+                <p className="text-[11px] text-gray-400 mt-0.5">
+                    default: <code>{Array.isArray(def) ? `${def[0]}–${def[1]}` : String(def)}</code>
+                    {unit ? ` ${unit}` : ''}
+                </p>
+            </div>
+
+            <div className="flex items-center gap-2 shrink-0">
+                {kind === 'range' ? (
+                    <>
+                        <input
+                            type="number" min={min} max={max} step={step}
+                            value={value[0]}
+                            onChange={(e) => onChange([numOrNull(e.target.value) ?? def[0], value[1]])}
+                            className="form-input w-20 text-sm"
+                        />
+                        <span className="text-gray-400 text-sm">–</span>
+                        <input
+                            type="number" min={min} max={max} step={step}
+                            value={value[1]}
+                            onChange={(e) => onChange([value[0], numOrNull(e.target.value) ?? def[1]])}
+                            className="form-input w-20 text-sm"
+                        />
+                    </>
+                ) : (
+                    <input
+                        type="number" min={min} max={max} step={step}
+                        value={value}
+                        onChange={(e) => onChange(numOrNull(e.target.value))}
+                        className="form-input w-24 text-sm"
+                    />
+                )}
+                {unit && <span className="text-xs text-gray-400 w-7">{unit}</span>}
+                <button
+                    onClick={onReset}
+                    disabled={!modified}
+                    title="Reset to default"
+                    className="text-xs text-gray-400 hover:text-gray-700 disabled:opacity-30 px-1"
+                >
+                    ↺
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/ConstantsKnobs.jsx
+++ b/src/components/admin/ConstantsKnobs.jsx
@@ -45,7 +45,7 @@ export default function ConstantsKnobs() {
     const anyModified = KNOB_GROUPS.some(g => g.knobs.some(k => isModified(k.key)));
 
     return (
-        <div className="card mt-6 p-5">
+        <div className="card p-5">
             <div className="flex items-start justify-between gap-4 mb-1">
                 <div>
                     <h3 className="text-lg font-semibold text-gray-800">Model Constants</h3>

--- a/src/components/admin/ConstantsKnobs.jsx
+++ b/src/components/admin/ConstantsKnobs.jsx
@@ -48,8 +48,8 @@ export default function ConstantsKnobs() {
         <div className="card p-5">
             <div className="flex items-start justify-between gap-4 mb-1">
                 <div>
-                    <h3 className="text-lg font-semibold text-gray-800">Model Constants</h3>
-                    <p className="text-sm text-gray-500 mt-0.5">
+                    <h3 className="section-title">Model Constants</h3>
+                    <p className="text-sm text-secondary mt-0.5">
                         Tune the EPA math on <strong>this browser only</strong>. Changes are saved
                         instantly but apply on the next page reload. Never affects the database or
                         other users.
@@ -65,8 +65,8 @@ export default function ConstantsKnobs() {
             </div>
 
             {dirty && (
-                <div className="my-3 flex items-center justify-between gap-3 p-3 rounded-lg border bg-blue-50 border-blue-200">
-                    <span className="text-sm text-blue-800">
+                <div className="notice-info my-3 flex items-center justify-between gap-3 p-3 rounded-lg">
+                    <span className="text-sm">
                         Overrides saved — reload to apply them to the calculations.
                     </span>
                     <button onClick={() => window.location.reload()} className="btn btn-primary text-sm whitespace-nowrap">
@@ -77,9 +77,9 @@ export default function ConstantsKnobs() {
 
             {KNOB_GROUPS.map(group => (
                 <div key={group.title} className="mt-4">
-                    <h4 className="text-sm font-semibold text-gray-700">{group.title}</h4>
-                    {group.blurb && <p className="text-xs text-gray-400 mb-2">{group.blurb}</p>}
-                    <div className="divide-y divide-gray-100 border-t border-gray-100">
+                    <h4 className="subsection-title">{group.title}</h4>
+                    {group.blurb && <p className="text-xs text-faint mb-2">{group.blurb}</p>}
+                    <div className="divide-y divide-[var(--color-border)] border-t border-[var(--color-border)]">
                         {group.knobs.map(knob => (
                             <KnobRow
                                 key={knob.key}
@@ -99,21 +99,24 @@ export default function ConstantsKnobs() {
 }
 
 function KnobRow({ knob, value, def, modified, onChange, onReset }) {
-    const { label, help, kind, min, max, step, unit } = knob;
+    const { key, label, help, kind, min, max, step, unit } = knob;
 
     return (
         <div className="py-3 flex items-start justify-between gap-4">
             <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-gray-800">{label}</span>
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm font-medium">{label}</span>
+                    <code className="text-[11px] text-muted bg-[var(--color-surface-sunken)] px-1.5 py-0.5 rounded">
+                        {key}
+                    </code>
                     {modified && (
                         <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-700 border border-amber-200">
                             modified
                         </span>
                     )}
                 </div>
-                {help && <p className="text-xs text-gray-400 mt-0.5">{help}</p>}
-                <p className="text-[11px] text-gray-400 mt-0.5">
+                {help && <p className="text-xs text-faint mt-0.5">{help}</p>}
+                <p className="text-[11px] text-faint mt-0.5">
                     default: <code>{Array.isArray(def) ? `${def[0]}–${def[1]}` : String(def)}</code>
                     {unit ? ` ${unit}` : ''}
                 </p>
@@ -128,7 +131,7 @@ function KnobRow({ knob, value, def, modified, onChange, onReset }) {
                             onChange={(e) => onChange([numOrNull(e.target.value) ?? def[0], value[1]])}
                             className="form-input w-20 text-sm"
                         />
-                        <span className="text-gray-400 text-sm">–</span>
+                        <span className="text-faint text-sm">–</span>
                         <input
                             type="number" min={min} max={max} step={step}
                             value={value[1]}
@@ -144,12 +147,12 @@ function KnobRow({ knob, value, def, modified, onChange, onReset }) {
                         className="form-input w-24 text-sm"
                     />
                 )}
-                {unit && <span className="text-xs text-gray-400 w-7">{unit}</span>}
+                {unit && <span className="text-xs text-faint w-7">{unit}</span>}
                 <button
                     onClick={onReset}
                     disabled={!modified}
                     title="Reset to default"
-                    className="text-xs text-gray-400 hover:text-gray-700 disabled:opacity-30 px-1"
+                    className="text-xs text-faint hover:text-secondary disabled:opacity-30 px-1"
                 >
                     ↺
                 </button>

--- a/src/components/admin/InterfaceSettings.jsx
+++ b/src/components/admin/InterfaceSettings.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useAppContext } from '../../context/AppContext';
+
+/**
+ * Admin sub-tab: site-wide interface settings.
+ *
+ * Currently the site header image (a global setting stored via update_site_setting).
+ * Per-user preferences (theme, units) are intentionally NOT here — they live in the
+ * top bar because they're per-browser, not site-wide.
+ */
+export default function InterfaceSettings() {
+    const { headerImageUrl, uploadHeaderImage } = useAppContext();
+    const [uploading, setUploading] = useState(false);
+
+    async function handleUpload(file) {
+        if (!file) return;
+        setUploading(true);
+        try {
+            await uploadHeaderImage(file);
+        } finally {
+            setUploading(false);
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="card p-5">
+                <h3 className="text-lg font-semibold text-gray-800">Site header image</h3>
+                <p className="text-sm text-gray-500 mt-0.5 mb-3">
+                    Background image shown behind the title on the home page. Applies site-wide for
+                    all visitors.
+                </p>
+
+                {headerImageUrl ? (
+                    <div
+                        className="w-full h-32 rounded-lg border border-gray-200 mb-3"
+                        style={{ backgroundImage: `url(${headerImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+                    />
+                ) : (
+                    <div className="w-full h-32 rounded-lg border border-dashed border-gray-300 flex items-center justify-center text-sm text-gray-400 mb-3">
+                        No header image set
+                    </div>
+                )}
+
+                <label className="btn btn-secondary text-sm cursor-pointer inline-flex">
+                    {uploading ? 'Uploading…' : headerImageUrl ? '📷 Replace image' : '📷 Upload image'}
+                    <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        disabled={uploading}
+                        onChange={(e) => { handleUpload(e.target.files[0]); e.target.value = ''; }}
+                    />
+                </label>
+            </div>
+
+            <div className="card p-5">
+                <h3 className="text-lg font-semibold text-gray-800">Personal preferences</h3>
+                <p className="text-sm text-gray-500 mt-0.5">
+                    Theme and unit system (imperial/metric) are per-browser preferences — set them
+                    from the toggles in the top bar. They aren't site-wide settings, so they live
+                    there rather than here.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/InterfaceSettings.jsx
+++ b/src/components/admin/InterfaceSettings.jsx
@@ -25,19 +25,19 @@ export default function InterfaceSettings() {
     return (
         <div className="space-y-6">
             <div className="card p-5">
-                <h3 className="text-lg font-semibold text-gray-800">Site header image</h3>
-                <p className="text-sm text-gray-500 mt-0.5 mb-3">
+                <h3 className="section-title">Site header image</h3>
+                <p className="text-sm text-secondary mt-0.5 mb-3">
                     Background image shown behind the title on the home page. Applies site-wide for
                     all visitors.
                 </p>
 
                 {headerImageUrl ? (
                     <div
-                        className="w-full h-32 rounded-lg border border-gray-200 mb-3"
+                        className="w-full h-32 rounded-lg border border-[var(--color-border)] mb-3"
                         style={{ backgroundImage: `url(${headerImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
                     />
                 ) : (
-                    <div className="w-full h-32 rounded-lg border border-dashed border-gray-300 flex items-center justify-center text-sm text-gray-400 mb-3">
+                    <div className="w-full h-32 rounded-lg border border-dashed border-[var(--color-border-strong)] flex items-center justify-center text-sm text-faint mb-3">
                         No header image set
                     </div>
                 )}
@@ -55,8 +55,8 @@ export default function InterfaceSettings() {
             </div>
 
             <div className="card p-5">
-                <h3 className="text-lg font-semibold text-gray-800">Personal preferences</h3>
-                <p className="text-sm text-gray-500 mt-0.5">
+                <h3 className="section-title">Personal preferences</h3>
+                <p className="text-sm text-secondary mt-0.5">
                     Theme and unit system (imperial/metric) are per-browser preferences — set them
                     from the toggles in the top bar. They aren't site-wide settings, so they live
                     there rather than here.

--- a/src/components/admin/RolesPermissions.jsx
+++ b/src/components/admin/RolesPermissions.jsx
@@ -1,0 +1,86 @@
+const ROLES = ['user', 'contributor', 'admin'];
+
+const roleBadgeStyle = {
+    admin:       { backgroundColor: '#fef3c7', color: '#92400e', border: '1px solid #fcd34d' },
+    contributor: { backgroundColor: '#dbeafe', color: '#1e40af', border: '1px solid #93c5fd' },
+    user:        { backgroundColor: '#f3f4f6', color: '#374151', border: '1px solid #d1d5db' },
+};
+
+/**
+ * Admin sub-tab: user list + role assignment, plus the role-permission legend.
+ * State lives in the parent AdminView; this is a presentational component.
+ */
+export default function RolesPermissions({ users, loading, saving, currentUserId, onRoleChange }) {
+    return (
+        <>
+            {loading ? (
+                <div className="empty-state">Loading users…</div>
+            ) : users.length === 0 ? (
+                <div className="empty-state">No users found.</div>
+            ) : (
+                <div className="card p-0 overflow-hidden">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b bg-gray-50 text-left">
+                                <th className="px-4 py-3 font-semibold text-gray-600">Email</th>
+                                <th className="px-4 py-3 font-semibold text-gray-600">Joined</th>
+                                <th className="px-4 py-3 font-semibold text-gray-600">Role</th>
+                                <th className="px-4 py-3 font-semibold text-gray-600">Change Role</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {users.map(u => (
+                                <tr key={u.id} className="border-t hover:bg-gray-50/50 transition">
+                                    <td className="px-4 py-3 font-medium text-gray-800">{u.email}</td>
+                                    <td className="px-4 py-3 text-gray-500">
+                                        {new Date(u.created_at).toLocaleDateString()}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <span
+                                            className="px-2 py-0.5 rounded-full text-xs font-semibold"
+                                            style={roleBadgeStyle[u.role] || roleBadgeStyle.user}
+                                        >
+                                            {u.role}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        {u.id === currentUserId ? (
+                                            <span className="text-xs text-gray-400 italic">can't change own role</span>
+                                        ) : (
+                                            <div className="flex gap-1 flex-wrap">
+                                                {ROLES.map(role => (
+                                                    <button
+                                                        key={role}
+                                                        onClick={() => onRoleChange(u.id, role)}
+                                                        disabled={u.role === role || saving === u.id}
+                                                        className={`px-2.5 py-1 rounded border text-xs font-medium transition ${
+                                                            u.role === role
+                                                                ? 'opacity-40 cursor-default'
+                                                                : 'bg-white hover:bg-gray-100 border-gray-300 text-gray-700'
+                                                        }`}
+                                                    >
+                                                        {saving === u.id && u.role !== role ? '…' : role}
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            <div className="mt-6 p-4 rounded-lg border bg-amber-50 border-amber-200">
+                <p className="text-sm text-amber-800 font-semibold mb-1">Role permissions</p>
+                <ul className="text-xs text-amber-700 space-y-1">
+                    <li><strong>admin</strong> — full access: edit/delete any vehicle or test, manage users, toggle visibility, change site settings</li>
+                    <li><strong>contributor</strong> — edit any public vehicle or test, plus anything they submitted; can toggle visibility</li>
+                    <li><strong>user</strong> — edit only vehicles and tests they submitted; visibility locked</li>
+                    <li><em>Unauthenticated</em> — read-only access to public content</li>
+                </ul>
+            </div>
+        </>
+    );
+}

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -14,7 +14,7 @@ import CuratorField from './CuratorField';
 import DerivedValues from './DerivedValues';
 import TestPhaseEditor from './TestPhaseEditor';
 import AuditHistory from './AuditHistory';
-import { ASSUMED_CHARGER_EFF, DEFAULT_ACCESSORY_W } from '../../utils/epaDerivations';
+import { ASSUMED_CHARGER_EFF, DEFAULT_ACCESSORY_W } from '../../constants/epa';
 
 function Section({ title, children }) {
     return (

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -10,7 +10,10 @@
 import { useState } from 'react';
 import CuratorField from './CuratorField';
 import InfoIcon from '../InfoIcon';
-import { PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75 } from '../../utils/epaDerivations';
+import {
+    PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75,
+    HWFET_MI, UDDS_MI, CYCLE_DIST_TOL as DIST_TOL,
+} from '../../constants/epa';
 
 const PROC_OPTIONS = [
     { v: PROC_MCT,     label: '77 — Multi-Cycle Test' },
@@ -22,10 +25,6 @@ const PHASE_TYPES   = ['UDDS', 'HWY', 'SS', 'Cold-UDDS', 'US06', 'SC03'];
 const SOURCE_OPTS   = ['csv', 'j1634', 'csi_pdf', 'manual'];
 const ORIGINATORS   = ['MFR', 'EPA'];
 
-// Standard cycle distances (miles) for phase-type auto-suggestion.
-const HWFET_MI  = 10.26;
-const UDDS_MI   = 7.45;
-const DIST_TOL  = 0.7;   // ± tolerance around the standard distance
 
 const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
 

--- a/src/constants/epa.js
+++ b/src/constants/epa.js
@@ -1,0 +1,61 @@
+/**
+ * EPA model constants — the single place to tune the EPA math.
+ *
+ * Physical constants, tunable assumptions, sanity bands, drive-cycle definitions
+ * and unit-detection thresholds for the EPA subsystem. Leaf module: imports only
+ * from constants/units (no app deps), so it can't create import cycles even
+ * though epaPhysics / epaDerivations / the parsers all depend on it.
+ */
+import { MPG_E_CONVERSION } from './units';
+import { resolve } from './overrides';
+export { MPG_E_CONVERSION };
+
+// ── Physical constants (NOT tunable — physical/definitional facts) ───────────
+/** lbf·mile → kWh: 4.44822 N/lbf × 1609.34 m/mi ÷ 3.6e6 J/kWh. */
+export const LBF_MILE_TO_KWH  = 0.001989;
+export const HWFET_AVG_MPH    = 48.3;        // HWFET cycle average speed (η anchor)
+export const US06_AVG_MPH     = 48.4;
+export const HIGHWAY_BAND_MPH = [65, 75];    // reference band drawn on the curve
+
+// ── Tunable knobs: pristine defaults ────────────────────────────────────────
+// Single source of truth for the adjustable model assumptions and sanity bands.
+// The Admin "Model Constants" panel (src/components/admin/ConstantsKnobs.jsx)
+// reads these as the reset baseline and writes per-browser overrides via
+// constants/overrides.js. Each export below is the default UNLESS a local
+// override is set (applied on page reload).
+export const EPA_DEFAULTS = {
+    // assumptions
+    DEFAULT_ETA:         0.88,        // fallback drivetrain efficiency
+    DEFAULT_ACCESSORY_W: 300,         // constant accessory draw, watts
+    ASSUMED_CHARGER_EFF: 0.88,        // when AC recharge is unavailable (CSI obs ~0.87–0.89)
+    // sanity bands (Section-8 flags) + curve extent
+    ETA_BAND:          [0.75, 0.92],
+    CHARGER_EFF_BAND:  [0.80, 0.92],
+    SS_SPEED_BAND:     [55, 70],      // mph
+    CURVE_SPEED_RANGE: [5, 120],      // mph, inclusive
+};
+
+// Resolved values (override ∥ default). These are what the math imports.
+export const DEFAULT_ETA         = resolve('DEFAULT_ETA',         EPA_DEFAULTS.DEFAULT_ETA);
+export const DEFAULT_ACCESSORY_W = resolve('DEFAULT_ACCESSORY_W', EPA_DEFAULTS.DEFAULT_ACCESSORY_W);
+export const ACCESSORY_LOAD_KW   = DEFAULT_ACCESSORY_W / 1000;  // derived (kW)
+export const ASSUMED_CHARGER_EFF = resolve('ASSUMED_CHARGER_EFF', EPA_DEFAULTS.ASSUMED_CHARGER_EFF);
+export const ETA_BAND          = resolve('ETA_BAND',          EPA_DEFAULTS.ETA_BAND);
+export const CHARGER_EFF_BAND  = resolve('CHARGER_EFF_BAND',  EPA_DEFAULTS.CHARGER_EFF_BAND);
+export const SS_SPEED_BAND     = resolve('SS_SPEED_BAND',     EPA_DEFAULTS.SS_SPEED_BAND);
+export const CURVE_SPEED_RANGE = resolve('CURVE_SPEED_RANGE', EPA_DEFAULTS.CURVE_SPEED_RANGE);
+
+// ── EPA test procedure codes ────────────────────────────────────────────────
+export const PROC_MCT     = 77; // Multi-Cycle Test — city + highway + totals in one run
+export const PROC_CD_HWY  = 84; // Charge Depleting Highway — η fallback
+export const PROC_CD_UDDS = 81; // Charge Depleting UDDS — stored, excluded from derivation
+export const PROC_FTP75   = 2;
+
+// ── Drive-cycle distances (phase-type inference) ────────────────────────────
+export const HWFET_MI       = 10.26;  // HWFET cycle distance (→ HWY)
+export const UDDS_MI        = 7.45;   // UDDS cycle distance (→ UDDS)
+export const CYCLE_DIST_TOL = 0.7;    // ± match tolerance, miles
+
+// ── MPGe unit detection (CSV/PDF disambiguation) ────────────────────────────
+export const MPGE_MAGNITUDE_THRESHOLD = 60;  // ≥ ⇒ value is MPGe, else kWh/100mi
+export const MPGE_PLACEHOLDER_MIN     = 400; // ≥ ⇒ EPA "no data" sentinel

--- a/src/constants/knobs.js
+++ b/src/constants/knobs.js
@@ -1,0 +1,54 @@
+/**
+ * UI metadata for the tunable-constant "knobs" shown in the Admin panel.
+ *
+ * Defaults are NOT redefined here — they come from EPA_DEFAULTS in constants/epa.js
+ * (single source of truth). This file only describes how to render and bound each
+ * knob (label, help text, input kind, min/max/step).
+ *
+ * kind:
+ *   'number' → single scalar (an input[type=number])
+ *   'range'  → a [min, max] pair (two number inputs)
+ */
+import { EPA_DEFAULTS } from './epa';
+
+export const KNOB_GROUPS = [
+    {
+        title: 'EPA model assumptions',
+        blurb: 'The genuine tunables in the efficiency back-solve. Changing these shifts every derived curve.',
+        knobs: [
+            { key: 'DEFAULT_ETA', label: 'Drivetrain efficiency η (fallback)', kind: 'number',
+              min: 0.50, max: 1.00, step: 0.01, unit: '',
+              help: 'Used when no HWFET/DC phase data is available to back-solve η.' },
+            { key: 'DEFAULT_ACCESSORY_W', label: 'Accessory load', kind: 'number',
+              min: 0, max: 2000, step: 25, unit: 'W',
+              help: 'Constant parasitic draw (HVAC, electronics) assumed in the back-solve.' },
+            { key: 'ASSUMED_CHARGER_EFF', label: 'Assumed charger efficiency', kind: 'number',
+              min: 0.50, max: 1.00, step: 0.01, unit: '',
+              help: 'AC→DC charging efficiency when measured AC recharge energy is unavailable.' },
+        ],
+    },
+    {
+        title: 'Sanity bands & curve extent',
+        blurb: 'Bounds for the Section-8 "out of band" flags and the speed range the curve is plotted over.',
+        knobs: [
+            { key: 'ETA_BAND', label: 'η valid band', kind: 'range',
+              min: 0.50, max: 1.00, step: 0.01, unit: '',
+              help: 'A derived η outside this range is flagged.' },
+            { key: 'CHARGER_EFF_BAND', label: 'Charger-efficiency valid band', kind: 'range',
+              min: 0.50, max: 1.00, step: 0.01, unit: '',
+              help: 'A derived charger efficiency outside this range is flagged.' },
+            { key: 'SS_SPEED_BAND', label: 'Steady-state speed band', kind: 'range',
+              min: 30, max: 90, step: 1, unit: 'mph',
+              help: 'An implied steady-state cycle speed outside this range is flagged.' },
+            { key: 'CURVE_SPEED_RANGE', label: 'Curve speed range', kind: 'range',
+              min: 0, max: 160, step: 5, unit: 'mph',
+              help: 'Lowest/highest speed the efficiency curve is computed over.' },
+        ],
+    },
+];
+
+/** All knob keys, flattened. */
+export const KNOB_KEYS = KNOB_GROUPS.flatMap(g => g.knobs.map(k => k.key));
+
+/** Pristine default for a knob key (from EPA_DEFAULTS). */
+export const knobDefault = (key) => EPA_DEFAULTS[key];

--- a/src/constants/overrides.js
+++ b/src/constants/overrides.js
@@ -1,0 +1,55 @@
+/**
+ * Local override store for tunable constants — a developer/admin sandbox.
+ *
+ * Overrides live in localStorage on THIS browser only (never the DB, never other
+ * users). They are read ONCE at module load by constants/epa.js, so changing a
+ * knob requires a page reload to take effect — that keeps the math modules as
+ * plain static imports (no runtime store, no re-render plumbing).
+ *
+ * Leaf module: depends only on localStorage, so any constant module can import it
+ * without circular-dependency risk.
+ */
+const KEY = 'evbench.constants.overrides';
+
+let cache = null;
+
+function load() {
+    if (cache) return cache;
+    try {
+        cache = JSON.parse(localStorage.getItem(KEY)) || {};
+    } catch {
+        cache = {};
+    }
+    return cache;
+}
+
+/** Resolve a constant: the local override if one is set, otherwise the default. */
+export function resolve(key, defaultValue) {
+    const ov = load();
+    return key in ov && ov[key] != null ? ov[key] : defaultValue;
+}
+
+/** Current overrides map (copy). Empty object means "all defaults". */
+export function getOverrides() {
+    return { ...load() };
+}
+
+/** Set (or clear, when value == null) one override. Persists immediately.
+ *  Takes effect on next page reload. */
+export function setOverride(key, value) {
+    const ov = load();
+    if (value == null) delete ov[key];
+    else ov[key] = value;
+    cache = ov;
+    try {
+        localStorage.setItem(KEY, JSON.stringify(ov));
+    } catch { /* storage unavailable — keep in-memory only */ }
+}
+
+/** Drop all overrides (reset to defaults). Takes effect on next page reload. */
+export function clearOverrides() {
+    cache = {};
+    try {
+        localStorage.removeItem(KEY);
+    } catch { /* ignore */ }
+}

--- a/src/constants/units.js
+++ b/src/constants/units.js
@@ -1,0 +1,16 @@
+/**
+ * Unit-conversion factors — single source of truth.
+ *
+ * Leaf module: imports nothing from the app, so any module can import it without
+ * circular-dependency risk. Edit a factor here and every consumer follows.
+ */
+export const MI_TO_KM   = 1.60934;   // miles → km
+export const IN_TO_MM   = 25.4;      // inches → mm
+export const LBS_TO_KG  = 0.453592;  // pounds → kilograms
+export const CUFT_TO_L  = 28.3168;   // cubic feet → litres
+export const LBFT_TO_NM = 1.35582;   // lb-ft → newton-metres
+export const FT_TO_M    = 0.3048;    // feet → metres
+export const HP_TO_KW   = 0.7457;    // horsepower → kilowatts
+
+/** kWh per gallon of gasoline-equivalent — the MPGe basis. */
+export const MPG_E_CONVERSION = 33.705;

--- a/src/index.css
+++ b/src/index.css
@@ -295,6 +295,26 @@ body {
     @apply text-lg font-bold;
 }
 
+/* Smaller heading for a group within a card (h4) */
+.subsection-title {
+    @apply text-sm font-semibold;
+    color: var(--color-text-primary);
+}
+
+/* Theme-aware text-color helpers. Headings/body inherit --color-text-primary
+   from <body>; these set the dimmer tiers. Prefer these over Tailwind text-gray-*
+   so text adapts to dark mode. */
+.text-secondary { color: var(--color-text-secondary); }
+.text-muted     { color: var(--color-text-muted); }
+.text-faint     { color: var(--color-text-faint); }
+
+/* Inline info/notice banner (theme-aware) */
+.notice-info {
+    background-color: var(--color-primary-light);
+    border: 1px solid var(--color-primary);
+    color: var(--color-text-primary);
+}
+
 /* Horizontal inline group — flex row with standard gap */
 .inline-row {
     @apply flex items-center gap-2;

--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,16 @@
     color: var(--color-primary-text);
 }
 
+/* Admin sub-tab nav (Roles / EPA Data / Model Constants / Interface) */
+.admin-subtabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.5rem;
+}
+
 /* Tighten Tailwind's default line-height (1.5 feels too spacious) */
 html {
     line-height: 1.4;

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -38,30 +38,23 @@
  * efficiency is 'assumed' on the same record.
  */
 
+import { roadLoadForce } from './epaPhysics';
+
+// EPA constants live in src/constants/epa.js (single source of truth). Imported
+// here for use, and re-exported so existing `… from './epaDerivations'` imports
+// (TestPhaseEditor, EpaCuratorEditor, etc.) keep working.
 import {
-    LBF_MILE_TO_KWH,
-    DEFAULT_ETA,
-    HWFET_AVG_MPH,
-    MPG_E_CONVERSION,
-    CURVE_SPEED_RANGE,
-    roadLoadForce,
-} from './epaPhysics';
+    LBF_MILE_TO_KWH, DEFAULT_ETA, HWFET_AVG_MPH, MPG_E_CONVERSION, CURVE_SPEED_RANGE,
+    PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75,
+    ETA_BAND, CHARGER_EFF_BAND, SS_SPEED_BAND,
+    DEFAULT_ACCESSORY_W, ASSUMED_CHARGER_EFF,
+} from '../constants/epa';
 
-// ── Procedure codes ─────────────────────────────────────────────────────────
-export const PROC_MCT       = 77; // Multi-Cycle Test — city + highway + totals in one run
-export const PROC_CD_HWY    = 84; // Charge Depleting Highway — η fallback
-export const PROC_CD_UDDS   = 81; // Charge Depleting UDDS — stored, excluded from derivation
-export const PROC_FTP75     = 2;
-
-// ── Sanity bands (spec Section 8) ───────────────────────────────────────────
-export const ETA_BAND          = [0.75, 0.92];
-export const CHARGER_EFF_BAND  = [0.80, 0.92];
-export const SS_SPEED_BAND     = [55, 70];   // mph
-
-/** Default constant accessory draw (W) when no override is set. */
-export const DEFAULT_ACCESSORY_W = 300;
-/** Charger efficiency assumed when AC recharge energy is unavailable. */
-export const ASSUMED_CHARGER_EFF = 0.88;  // observed CSI range ~0.87–0.89 (one OEM at 0.90)
+export {
+    PROC_MCT, PROC_CD_HWY, PROC_CD_UDDS, PROC_FTP75,
+    ETA_BAND, CHARGER_EFF_BAND, SS_SPEED_BAND,
+    DEFAULT_ACCESSORY_W, ASSUMED_CHARGER_EFF,
+};
 
 // ── Small helpers ───────────────────────────────────────────────────────────
 

--- a/src/utils/epaPhysics.js
+++ b/src/utils/epaPhysics.js
@@ -22,33 +22,17 @@
  */
 
 // ── Physical constants ────────────────────────────────────────────────────────
+// Defined in src/constants/epa.js (single source of truth); re-exported here so
+// existing `import { … } from './epaPhysics'` call sites keep working.
+import {
+    HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH, ACCESSORY_LOAD_KW,
+    MPG_E_CONVERSION, LBF_MILE_TO_KWH, DEFAULT_ETA, CURVE_SPEED_RANGE,
+} from '../constants/epa';
 
-/** Average speed of the HWFET (Highway Fuel Economy Test) drive cycle, mph. */
-export const HWFET_AVG_MPH = 48.3;
-
-/** Average speed of the US06 (Supplemental Federal Test Procedure) cycle, mph.
- *  Note: US06 includes aggressive transients up to 80+ mph; the 48.4 avg understates peak loads. */
-export const US06_AVG_MPH = 48.4;
-
-/** Speed band considered "real highway" for reference overlay on the chart. */
-export const HIGHWAY_BAND_MPH = [65, 75];
-
-/** Constant accessory load assumed for all EVs (HVAC, lighting, electronics). kW. */
-export const ACCESSORY_LOAD_KW = 0.3;
-
-/** EPA's kWh-per-gallon-of-gasoline-equivalent constant, used to compute MPGe. */
-export const MPG_E_CONVERSION = 33.705;
-
-/** Unit conversion: lbf-force × 1 mile of travel → kWh of energy.
- *  Derivation: 4.44822 N/lbf × 1609.34 m/mi / 3,600,000 J/kWh = 0.001989.
- *  Exported so the derivation engine (epaDerivations.js) shares one source of truth. */
-export const LBF_MILE_TO_KWH = 0.001989;
-
-/** Fallback drivetrain efficiency when no HWFET/DC phase data is available. */
-export const DEFAULT_ETA = 0.88;
-
-/** Speed range for the curve, mph, inclusive. */
-export const CURVE_SPEED_RANGE = [5, 120];
+export {
+    HWFET_AVG_MPH, US06_AVG_MPH, HIGHWAY_BAND_MPH, ACCESSORY_LOAD_KW,
+    MPG_E_CONVERSION, LBF_MILE_TO_KWH, DEFAULT_ETA, CURVE_SPEED_RANGE,
+};
 
 // ── Coefficient resolution ────────────────────────────────────────────────────
 

--- a/src/utils/parseEpaCsiPdf.js
+++ b/src/utils/parseEpaCsiPdf.js
@@ -20,7 +20,7 @@
  * form's auto-suggest. Everything is editable post-import.
  */
 
-const HWFET_MI = 10.26, UDDS_MI = 7.45, DIST_TOL = 0.7;
+import { HWFET_MI, UDDS_MI, CYCLE_DIST_TOL as DIST_TOL } from '../constants/epa';
 
 /** MM/DD/YYYY → YYYY-MM-DD (Postgres date); pass through anything else. */
 function toIsoDate(s) {

--- a/src/utils/parseEpaTestCarSheet.js
+++ b/src/utils/parseEpaTestCarSheet.js
@@ -22,13 +22,9 @@
  *   MEL — one row per emission/region; has `Certification Region`, no energy.
  */
 
-const MPG_E_CONVERSION = 33.705; // kWh per gallon gasoline equivalent
-
-/** A bare RND_ADJ_FE at/above this is MPGe (not kWh/100mi) when FE_UNIT is silent.
- *  EV consumption is ~15–50 kWh/100mi; MPGe ~65–250; crossover ~58, so 60 splits. */
-const MPGE_MAGNITUDE_THRESHOLD = 60;
-/** MPGe at/above this is an EPA "no data" placeholder (999, near-999, etc.). */
-const MPGE_PLACEHOLDER_MIN = 400;
+import {
+    MPG_E_CONVERSION, MPGE_MAGNITUDE_THRESHOLD, MPGE_PLACEHOLDER_MIN,
+} from '../constants/epa';
 
 function numOrNull(str) {
     if (str == null || !String(str).trim()) return null;

--- a/src/utils/unitConversions.js
+++ b/src/utils/unitConversions.js
@@ -1,10 +1,14 @@
-// Conversion factors
-export const MI_TO_KM   = 1.60934;
-export const IN_TO_MM   = 25.4;
-export const LBS_TO_KG  = 0.453592;
-export const CUFT_TO_L  = 28.3168;
-export const LBFT_TO_NM = 1.35582;
-export const FT_TO_M    = 0.3048;
+// Conversion factors live in src/constants/units.js (single source of truth);
+// re-exported here so existing `… from './unitConversions'` imports keep working.
+import {
+    MI_TO_KM, IN_TO_MM, LBS_TO_KG, CUFT_TO_L, LBFT_TO_NM, FT_TO_M, HP_TO_KW,
+    MPG_E_CONVERSION,
+} from '../constants/units';
+
+export {
+    MI_TO_KM, IN_TO_MM, LBS_TO_KG, CUFT_TO_L, LBFT_TO_NM, FT_TO_M, HP_TO_KW,
+    MPG_E_CONVERSION,
+};
 
 // ── Formatted strings (value + unit label) ────────────────────────────────
 
@@ -15,7 +19,7 @@ export const fmtWeight    = (lbs,  sys) => sys === 'metric' ? `${r1(lbs * LBS_TO
 export const fmtVolume    = (cuft, sys) => sys === 'metric' ? `${r1(cuft * CUFT_TO_L)} L`          : `${cuft} cu ft`;
 export const fmtDimension = (in_,  sys) => sys === 'metric' ? `${Math.round(in_ * IN_TO_MM)} mm`   : `${in_} in`;
 export const fmtTorque    = (lbft, sys) => sys === 'metric' ? `${r1(lbft * LBFT_TO_NM)} Nm`       : `${lbft} lb-ft`;
-export const fmtPower     = (hp,   sys) => sys === 'metric' ? `${r1(hp * 0.7457)} kW`              : `${hp} hp`;
+export const fmtPower     = (hp,   sys) => sys === 'metric' ? `${r1(hp * HP_TO_KW)} kW`             : `${hp} hp`;
 
 // ── Raw conversions (no label) — for chart data values ────────────────────
 
@@ -66,7 +70,7 @@ export function convValue(value, unitGroup, sys) {
         case 'volume':    return r1(value * CUFT_TO_L);
         case 'dimension': return Math.round(value * IN_TO_MM);
         case 'torque':    return r1(value * LBFT_TO_NM);
-        case 'power':     return r1(value * 0.7457);
+        case 'power':     return r1(value * HP_TO_KW);
         case 'feet':      return r1(value * FT_TO_M);
         default:          return value;
     }
@@ -90,9 +94,6 @@ export function formatSpecValue(value, unitGroup, sys) {
 }
 
 // ── MPGe (Miles Per Gallon equivalent) ───────────────────────────────────────
-
-/** EPA's kWh per gallon of gasoline equivalent (used to compute MPGe). */
-export const MPG_E_CONVERSION = 33.705;
 
 /**
  * Convert mi/kWh to MPGe (Miles Per Gallon equivalent).


### PR DESCRIPTION
## Why
The UI had a hardcoded `0.88` placeholder decoupled from the calculation constant — a drift hazard. Audit confirmed real duplication: `MPG_E_CONVERSION` in 3 files, accessory load in 2, phase distances in 2, plus inline conversion factors. This establishes a single source of truth, adds live tuning on top, and reorganizes the (now busier) Admin panel into sub-tabs.

Stacked on #123 (base = `docs/epa-label-mpge-and-charger-default`) to avoid a same-constant conflict on `ASSUMED_CHARGER_EFF = 0.88`. Retarget to `main` after #123 merges.

## 1. `src/constants/` — single source of truth
- `units.js` — unit-conversion factors (were duplicated in `unitConversions.js`; `0.7457` was inline in `fmtPower`/`convValue`) + `MPG_E_CONVERSION`.
- `epa.js` — EPA physical facts (fixed) + `EPA_DEFAULTS` for the tunables, resolved through local overrides; procedure codes, cycle distances, MPGe unit-detection thresholds.
- `overrides.js` — leaf localStorage store, read once at load via `resolve()`.
- `knobs.js` — UI metadata (defaults sourced from `EPA_DEFAULTS`, never redefined).

Consumers (`epaPhysics`, `epaDerivations`, `unitConversions`) import from `constants/` and **re-export for back-compat**; the drifted duplicate definitions are deleted.

## 2. Admin → "Model Constants" knobs
Number/range inputs for EPA assumptions (η, accessory load, charger efficiency) and sanity bands (η/charger/SS-speed bands, curve speed range). Overrides are **this-browser-only** (never DB/other users) and apply on **reload** — chosen so the math stays plain static imports (no runtime store). Per-knob + global reset, "modified" badges, reload prompt.

## 3. Admin panel → sub-tabs
Reorganized into four sub-tabs (chart-mode pill style):
- **Roles & Permissions** — user list + role assignment + legend (extracted to `admin/RolesPermissions.jsx`)
- **EPA Data** — `EpaDataCard`
- **Model Constants** — the knobs panel
- **Interface Settings** — site header-image management; notes theme/units are per-browser prefs (new `admin/InterfaceSettings.jsx`)

Export / Import▾ toolbar stays global above the tabs; Refresh shows only on Roles.

## Scope decisions (confirmed with maintainer)
- Persistence: local (localStorage), reload-to-apply. Knobs: EPA assumptions + sanity bands (physical facts stay fixed).

## Verification
- `npm run build` green.
- No duplicate constant definitions remain outside `src/constants/` (grep verified).
- Parser values unchanged (relocated only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)