### PR TITLE
Typography migration: site-wide (off text-gray-*)

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -71,6 +71,12 @@ Rough mapping when migrating a file:
 | `text-[10px]` / `[11px]` / `[13px]` | nearest role / `text-xs` |
 | `bg-gray-*`, `border-gray-*` | `var(--color-surface-*)`, `var(--color-border)` |
 
+**Exception — leave intentional arbitrary sizes alone.** An arbitrary `text-[..px]`
+with a documented rationale (e.g. the test-count badges in `VehiclesView` are
+deliberately `text-[13px]`, 1px smaller than the `text-sm` rows for hierarchy) is
+*not* drift — keep it. Only migrate sizes that are incidental/inconsistent. The
+color migration (gray → semantic) still applies regardless of size.
+
 ## Future: live style knobs
 
 Once text styling flows through these classes/variables, exposing them as

--- a/src/components/AuthModal.jsx
+++ b/src/components/AuthModal.jsx
@@ -34,7 +34,7 @@ export default function AuthModal({ onClose, onAuthSuccess }) {
             <div className="modal-panel rounded-lg p-8 max-w-md" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header mb-6">
                     <h2 className="text-2xl font-bold">Sign In</h2>
-                    <button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl">&times;</button>
+                    <button onClick={onClose} className="text-muted hover:text-secondary text-2xl">&times;</button>
                 </div>
 
                 {error && (
@@ -77,7 +77,7 @@ export default function AuthModal({ onClose, onAuthSuccess }) {
                     </button>
                 </div>
 
-                <p className="text-xs text-gray-500 text-center mt-6">
+                <p className="text-xs text-muted text-center mt-6">
                     By signing in, you agree to our terms of service and privacy policy
                 </p>
             </div>

--- a/src/components/AxisScaleControls.jsx
+++ b/src/components/AxisScaleControls.jsx
@@ -40,11 +40,11 @@ export default function AxisScaleControls({
             {/* ── Y-Axis Scale ─────────────────────────────────────────────── */}
             <div>
                 <div className="flex items-baseline gap-3 mb-2">
-                    <p className="text-sm font-medium text-gray-500">{yAxisLabel}</p>
+                    <p className="text-sm font-medium text-muted">{yAxisLabel}</p>
                     {(yMin != null || yMax != null) && (
                         <button
                             onClick={() => { onChange('yMin', null); onChange('yMax', null); }}
-                            className="text-xs text-gray-400 hover:text-gray-700 transition-colors"
+                            className="text-xs text-faint hover:text-secondary transition-colors"
                         >
                             Reset
                         </button>
@@ -52,7 +52,7 @@ export default function AxisScaleControls({
                 </div>
                 <div className="axis-scale-group">
                     <div className="flex items-center gap-2">
-                        <span className="text-xs text-gray-400 w-7 text-right">Max</span>
+                        <span className="text-xs text-faint w-7 text-right">Max</span>
                         <input
                             type="number"
                             placeholder="Auto"
@@ -62,7 +62,7 @@ export default function AxisScaleControls({
                         />
                     </div>
                     <div className="flex items-center gap-2">
-                        <span className="text-xs text-gray-400 w-7 text-right">Min</span>
+                        <span className="text-xs text-faint w-7 text-right">Min</span>
                         <input
                             type="number"
                             placeholder="Auto"
@@ -78,11 +78,11 @@ export default function AxisScaleControls({
             {showX && (
                 <div>
                     <div className="flex items-baseline gap-3 mb-2">
-                        <p className="text-sm font-medium text-gray-500">{xAxisLabel}</p>
+                        <p className="text-sm font-medium text-muted">{xAxisLabel}</p>
                         {(xMin != null || xMax != null) && (
                             <button
                                 onClick={() => { onChange('xMin', null); onChange('xMax', null); }}
-                                className="text-xs text-gray-400 hover:text-gray-700 transition-colors"
+                                className="text-xs text-faint hover:text-secondary transition-colors"
                             >
                                 Reset
                             </button>
@@ -90,7 +90,7 @@ export default function AxisScaleControls({
                     </div>
                     <div className="axis-scale-group">
                         <div className="inline-row">
-                            <span className="text-xs text-gray-400 w-7 text-right">Max</span>
+                            <span className="text-xs text-faint w-7 text-right">Max</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
@@ -100,7 +100,7 @@ export default function AxisScaleControls({
                             />
                         </div>
                         <div className="inline-row">
-                            <span className="text-xs text-gray-400 w-7 text-right">Min</span>
+                            <span className="text-xs text-faint w-7 text-right">Min</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
@@ -117,17 +117,17 @@ export default function AxisScaleControls({
             {showY2 && (
                 <div>
                     <div className="flex items-baseline gap-3 mb-2">
-                        <p className="text-sm font-medium text-gray-500">Right Axis Scale</p>
+                        <p className="text-sm font-medium text-muted">Right Axis Scale</p>
                         <button
                             onClick={() => { onChange('y2Min', null); onChange('y2Max', null); }}
-                            className="text-xs text-gray-400 hover:text-gray-700 transition-colors"
+                            className="text-xs text-faint hover:text-secondary transition-colors"
                         >
                             Reset
                         </button>
                     </div>
                     <div className="axis-scale-group">
                         <div className="inline-row">
-                            <span className="text-xs text-gray-400 w-7 text-right">Max</span>
+                            <span className="text-xs text-faint w-7 text-right">Max</span>
                             <input
                                 type="number"
                                 placeholder="Auto"
@@ -137,7 +137,7 @@ export default function AxisScaleControls({
                             />
                         </div>
                         <div className="inline-row">
-                            <span className="text-xs text-gray-400 w-7 text-right">Min</span>
+                            <span className="text-xs text-faint w-7 text-right">Min</span>
                             <input
                                 type="number"
                                 placeholder="Auto"

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -691,7 +691,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                             no offset
                                         </span>
                                     ) : (
-                                        <span className="badge-status bg-gray-100 text-gray-500 border-gray-200" title={`${offset} min of pre-threshold data trimmed`}>
+                                        <span className="badge-status bg-[var(--color-surface-sunken)] text-muted border-[var(--color-border)]" title={`${offset} min of pre-threshold data trimmed`}>
                                             −{offset} min offset
                                         </span>
                                     )
@@ -705,7 +705,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             {/* ── Chart canvas ── */}
             <div className="card mb-4">
                 {loadingData && (
-                    <div className="text-center py-4 text-gray-500 dark:text-slate-300 text-sm">Loading run data...</div>
+                    <div className="text-center py-4 text-secondary text-sm">Loading run data...</div>
                 )}
                 <div style={{ height: presentationMode ? 'calc(100vh - 2rem)' : '500px' }}>
                     <canvas ref={chartRef}></canvas>
@@ -749,16 +749,16 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     )}
                 </div>
 
-                <p className="text-xs text-gray-400 mt-1">Drag to box-zoom · Reset Zoom to restore</p>
+                <p className="text-xs text-faint mt-1">Drag to box-zoom · Reset Zoom to restore</p>
 
                 {/* Inline image preview — right-click/long-press to copy or save */}
                 {chartImage && (
                     <div className="mt-3">
-                        <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
+                        <p className="text-xs text-faint mb-1.5">Right-click or long-press to copy / save</p>
                         <img
                             src={chartImage}
                             alt="Chart export"
-                            className="w-full rounded border border-gray-200"
+                            className="w-full rounded border border-[var(--color-border)]"
                         />
                     </div>
                 )}
@@ -778,7 +778,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
 
                 {/* ── Race mode panel — only visible when X = Time ── */}
                 {chartConfig.xAxis === 'time' && (
-                    <div className={`race-mode-panel ${chartConfig.raceMode ? 'bg-indigo-50 border-indigo-200' : 'bg-gray-50 border-gray-200'}`}>
+                    <div className={`race-mode-panel ${chartConfig.raceMode ? 'bg-indigo-50 border-indigo-200' : 'bg-[var(--color-surface-muted)] border-[var(--color-border)]'}`}>
                         <div className="flex flex-wrap items-center gap-3">
                             <label className="toggle-label">
                                 <input
@@ -792,7 +792,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
 
                             {chartConfig.raceMode && (
                                 <>
-                                    <span className="text-sm text-gray-600 dark:text-slate-300">Start at:</span>
+                                    <span className="text-sm text-secondary">Start at:</span>
                                     {/* Quick-select chips */}
                                     <div className="flex gap-1 flex-wrap">
                                         {[5, 10, 15, 20].map(pct => (
@@ -802,7 +802,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                                 className={`px-2 py-0.5 text-xs rounded border transition-colors ${
                                                     chartConfig.raceThreshold === pct
                                                         ? 'bg-indigo-600 text-white border-indigo-600'
-                                                        : 'bg-white dark:bg-slate-700 text-gray-600 dark:text-slate-200 border-gray-300 dark:border-slate-500 hover:border-indigo-400'
+                                                        : 'bg-[var(--color-surface-input)] text-secondary border-[var(--color-border-strong)] hover:border-indigo-400'
                                                 }`}
                                             >
                                                 {pct}%
@@ -822,7 +822,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                                 className="w-14 px-1 py-0.5 border rounded text-xs text-center [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                                                 min="0" max="100"
                                             />
-                                            <span className="text-xs text-gray-500 dark:text-slate-400">%</span>
+                                            <span className="text-xs text-muted">%</span>
                                         </div>
                                     </div>
                                 </>
@@ -839,7 +839,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             </div>}
 
             {!presentationMode && chartConfig.selectedRuns.length === 0 && (
-                <div className="text-center py-12 text-gray-500 dark:text-slate-300">
+                <div className="text-center py-12 text-secondary">
                     <p className="text-lg">Select runs to display on the chart</p>
                 </div>
             )}

--- a/src/components/EditSpecsForm.jsx
+++ b/src/components/EditSpecsForm.jsx
@@ -347,7 +347,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                     <h3 className="section-title mb-0">Edit Specs — {vehicle.name}</h3>
                     <button
                         onClick={onClose}
-                        className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+                        className="text-faint hover:text-secondary text-xl leading-none"
                         aria-label="Close"
                     >
                         ×
@@ -360,7 +360,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                     {/* ── Inherit from selector (combobox) ── */}
                     <div className="mb-4 pb-4 border-b">
                         <div className="flex items-center gap-3">
-                            <label className="text-sm font-medium text-gray-600 whitespace-nowrap">Inherit from:</label>
+                            <label className="text-sm font-medium text-secondary whitespace-nowrap">Inherit from:</label>
                             <div className="relative flex-1">
                                 {showParentDropdown ? (
                                     <input
@@ -378,13 +378,13 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                         onClick={() => { setParentSearch(''); setShowParentDropdown(true); }}
                                         className="form-input text-sm w-full text-left truncate"
                                     >
-                                        {selectedParentLabel || <span className="text-gray-400">— None —</span>}
+                                        {selectedParentLabel || <span className="text-faint">— None —</span>}
                                     </button>
                                 )}
                                 {showParentDropdown && (
-                                    <ul className="absolute z-50 mt-1 w-full max-h-52 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
+                                    <ul className="absolute z-50 mt-1 w-full max-h-52 overflow-y-auto rounded-lg border shadow-lg bg-[var(--color-surface-input)] border-[var(--color-border)]">
                                         <li
-                                            className="px-3 py-2 text-sm cursor-pointer text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700"
+                                            className="px-3 py-2 text-sm cursor-pointer text-faint hover:bg-[var(--color-surface-sunken)]"
                                             onMouseDown={() => {
                                                 setInheritFromId('');
                                                 setShowParentDropdown(false);
@@ -407,7 +407,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                             </li>
                                         ))}
                                         {filteredParents.length === 0 && (
-                                            <li className="px-3 py-2 text-sm text-gray-400 italic">No matches</li>
+                                            <li className="px-3 py-2 text-sm text-faint italic">No matches</li>
                                         )}
                                     </ul>
                                 )}
@@ -416,7 +416,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                 <button
                                     type="button"
                                     onClick={() => setInheritFromId('')}
-                                    className="text-gray-400 hover:text-gray-600 text-lg leading-none flex-shrink-0"
+                                    className="text-faint hover:text-secondary text-lg leading-none flex-shrink-0"
                                     title="Clear inheritance"
                                 >×</button>
                             )}
@@ -429,7 +429,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                     </div>
 
                     <div className="flex items-center justify-between mb-4">
-                        <p className="text-sm text-gray-500">Fields left blank are not saved.</p>
+                        <p className="text-sm text-muted">Fields left blank are not saved.</p>
                         <button
                             type="button"
                             onClick={() => {
@@ -478,7 +478,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                                     : undefined;
                                                 return (
                                                     <div key={field.key}>
-                                                        <label className="block text-xs text-gray-500 mb-0.5 flex items-center gap-1">
+                                                        <label className="block text-xs text-muted mb-0.5 flex items-center gap-1">
                                                             {field.label}
                                                             {isFlagged && (
                                                                 <SpecFieldFlagButton
@@ -502,10 +502,10 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                         {/* Custom fields */}
                                         {(customEntries.length > 0 || true) && (
                                             <div className="mt-3 pt-2 border-t">
-                                                <p className="text-xs text-gray-400 mb-1.5">Custom fields</p>
+                                                <p className="text-xs text-faint mb-1.5">Custom fields</p>
                                                 {customEntries.map(([key, val]) => (
                                                     <div key={key} className="specs-custom-row mb-1.5">
-                                                        <span className="text-xs text-gray-500 w-32 flex-shrink-0 truncate" title={formatCustomKey(key)}>
+                                                        <span className="text-xs text-muted w-32 flex-shrink-0 truncate" title={formatCustomKey(key)}>
                                                             {formatCustomKey(key)}
                                                         </span>
                                                         <input
@@ -553,7 +553,7 @@ export default function EditSpecsForm({ vehicle, specCustomFieldSuggestions, onS
                                                     <button
                                                         type="button"
                                                         onClick={() => addCustomField(cat.key)}
-                                                        className="px-2 py-1 rounded text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 flex-shrink-0"
+                                                        className="px-2 py-1 rounded text-xs bg-[var(--color-surface-sunken)] hover:bg-[var(--color-surface-muted)] text-secondary flex-shrink-0"
                                                     >
                                                         Add
                                                     </button>

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -299,7 +299,7 @@ export default function EditVehicleForm({
                                 disabled={imageUploading}
                             />
                         </label>
-                        <p className="text-xs text-gray-400 mt-1">16:9 crop · max 1600×900 · saved as JPEG</p>
+                        <p className="text-xs text-faint mt-1">16:9 crop · max 1600×900 · saved as JPEG</p>
                     </div>
                 )}
 
@@ -322,7 +322,7 @@ export default function EditVehicleForm({
                     <div className="crop-modal-panel">
                         <div className="crop-modal-header">
                             <h3 className="font-semibold text-base">Crop Image (16:9)</h3>
-                            <p className="text-xs text-gray-500 mt-0.5">Drag to reposition · resize handles to adjust · max output 1600×900</p>
+                            <p className="text-xs text-muted mt-0.5">Drag to reposition · resize handles to adjust · max output 1600×900</p>
                         </div>
                         <div className="crop-modal-body">
                             <ReactCrop

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -173,7 +173,7 @@ function convertYValue(val, yAxis, units) {
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
     likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
-    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+    inferred: 'text-muted bg-[var(--color-surface-muted)] border-[var(--color-border)]',
 };
 
 function ConfidenceBadge({ confidence }) {
@@ -525,9 +525,9 @@ export default function EpaCurvesView({
                                 className="form-input text-sm py-1 w-24 text-right"
                                 aria-label="Elevation in feet"
                             />
-                            <span className="text-sm text-gray-400">ft</span>
+                            <span className="text-sm text-faint">ft</span>
                             <span
-                                className={`text-xs whitespace-nowrap ${altAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-400'}`}
+                                className={`text-xs whitespace-nowrap ${altAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
                                 title="Air-density ratio applied to the aerodynamic (C) term"
                             >
                                 → ρ {densityRatio.toFixed(2)}{altAdjusted ? ' ▲' : ''}
@@ -544,7 +544,7 @@ export default function EpaCurvesView({
                             >
                                 <span style={{ display: 'inline-block', transform: selectorExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
                                 Select Vehicle Tests to Display
-                                <span className="text-sm font-normal text-gray-500">({visibleCount} of {totalMappings} shown)</span>
+                                <span className="text-sm font-normal text-muted">({visibleCount} of {totalMappings} shown)</span>
                             </button>
 
                             {selectorExpanded && (
@@ -557,7 +557,7 @@ export default function EpaCurvesView({
                                             };
                                             return (
                                                 <div key={vehicle.id} className="vehicle-run-group" style={{ borderColor: 'var(--color-primary)' }}>
-                                                    <h4 className="text-sm font-semibold text-gray-700 dark:text-slate-300 mb-2">
+                                                    <h4 className="text-sm font-semibold text-secondary mb-2">
                                                         {vehicleLabel(vehicle)}
                                                     </h4>
                                                     <div className="run-items">
@@ -606,7 +606,7 @@ export default function EpaCurvesView({
                                                                     {/* Label + metadata */}
                                                                     <div className="run-label min-w-0">
                                                                         <span className="font-medium">{epaLabel}</span>
-                                                                        <span className="text-sm text-gray-500 dark:text-slate-400 ml-2">{epaGroup.model_year} · {epaGroup.test_group_id}</span>
+                                                                        <span className="text-sm text-muted ml-2">{epaGroup.model_year} · {epaGroup.test_group_id}</span>
                                                                         <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs" style={{ color: 'var(--color-text-muted)' }}>
                                                                             <ConfidenceBadge confidence={confidence} />
                                                                             {epaGroup.label_combined_mpge && epaGroup.label_combined_mpge < 500 ? (

--- a/src/components/EpaDataCard.jsx
+++ b/src/components/EpaDataCard.jsx
@@ -16,7 +16,7 @@ import { useState, useEffect } from 'react';
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
     likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
-    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+    inferred: 'text-muted bg-[var(--color-surface-muted)] border-[var(--color-border)]',
 };
 
 // Short labels keep the select narrow; full names shown in title tooltip
@@ -114,7 +114,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
             <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b">
                 <div>
                     <h3 className="font-semibold text-sm">EPA Test Groups</h3>
-                    <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                    <p className="text-xs text-muted mt-0.5">
                         {loading ? 'Loading…' : `${groups.length} imported · ${linkedCount} linked to vehicles`}
                     </p>
                 </div>
@@ -146,22 +146,22 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
 
             {/* Body */}
             {loading ? (
-                <div className="px-4 py-8 text-center text-sm text-gray-400">Loading…</div>
+                <div className="px-4 py-8 text-center text-sm text-faint">Loading…</div>
             ) : filtered.length === 0 ? (
-                <div className="px-4 py-8 text-center text-sm text-gray-400">
+                <div className="px-4 py-8 text-center text-sm text-faint">
                     {q ? 'No test groups match that filter.' : 'No EPA test groups imported yet. Use Import → EPA Test Car Data to add some.'}
                 </div>
             ) : (
                 <div className="overflow-x-auto">
                     <table className="w-full text-xs">
                         <thead>
-                            <tr className="border-b bg-gray-50 dark:bg-slate-800/50 text-left">
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Config ID</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold">Year · Make · Carline</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">A · B · C</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold whitespace-nowrap">MPGe</th>
-                                <th className="px-3 py-2 text-gray-500 font-semibold">Linked Vehicles</th>
+                            <tr className="border-b bg-[var(--color-surface-muted)] text-left">
+                                <th className="px-3 py-2 text-muted font-semibold whitespace-nowrap">Config ID</th>
+                                <th className="px-3 py-2 text-muted font-semibold">Year · Make · Carline</th>
+                                <th className="px-3 py-2 text-muted font-semibold whitespace-nowrap">Drive / ETW</th>
+                                <th className="px-3 py-2 text-muted font-semibold whitespace-nowrap">A · B · C</th>
+                                <th className="px-3 py-2 text-muted font-semibold whitespace-nowrap">MPGe</th>
+                                <th className="px-3 py-2 text-muted font-semibold">Linked Vehicles</th>
                                 <th className="px-3 py-2" />
                             </tr>
                         </thead>
@@ -176,13 +176,13 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                 return (
                                     <tr
                                         key={g.test_group_id}
-                                        className={`transition hover:bg-gray-50/50 dark:hover:bg-slate-800/30 ${isDel ? 'opacity-40 pointer-events-none' : ''}`}
+                                        className={`transition hover:bg-[var(--color-surface-muted)] ${isDel ? 'opacity-40 pointer-events-none' : ''}`}
                                     >
                                         {/* Config ID + family ID */}
                                         <td className="px-3 py-2 font-mono whitespace-nowrap">
-                                            <div className="text-gray-700 dark:text-slate-300">{g.test_group_id}</div>
+                                            <div className="text-secondary">{g.test_group_id}</div>
                                             {g.epa_test_family_id && g.epa_test_family_id !== g.test_group_id && (
-                                                <div className="text-[10px] text-gray-400 dark:text-slate-500 mt-0.5">
+                                                <div className="text-[10px] text-faint mt-0.5">
                                                     fam: {g.epa_test_family_id}
                                                 </div>
                                             )}
@@ -191,10 +191,10 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                         {/* Year / Make / Carline + inline display-name edit */}
                                         <td className="px-3 py-2 max-w-[200px]">
                                             {/* Carline name: wraps, no truncation */}
-                                            <div className="font-medium text-gray-700 dark:text-slate-300 leading-snug">
+                                            <div className="font-medium text-secondary leading-snug">
                                                 {g.epa_carline_name}
                                             </div>
-                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5 whitespace-nowrap">
+                                            <div className="text-faint mt-0.5 whitespace-nowrap">
                                                 {g.model_year}{g.make ? ` · ${g.make}` : ''}
                                             </div>
                                             {/* Display name input — inline below the carline */}
@@ -212,15 +212,15 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                                         e.target.blur();
                                                     }
                                                 }}
-                                                className="form-input text-xs py-0.5 mt-1.5 w-full disabled:opacity-50 placeholder:text-gray-300 dark:placeholder:text-slate-600 placeholder:italic"
+                                                className="form-input text-xs py-0.5 mt-1.5 w-full disabled:opacity-50 placeholder:text-[var(--color-text-faint)] placeholder:italic"
                                                 title="Friendly display name used in charts. Leave blank to use the EPA carline name."
                                             />
                                         </td>
 
                                         {/* Drive / ETW */}
-                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
+                                        <td className="px-3 py-2 whitespace-nowrap text-muted">
                                             <div>{g.drive || '—'}</div>
-                                            <div className="text-gray-400 dark:text-slate-500 mt-0.5">
+                                            <div className="text-faint mt-0.5">
                                                 {coeff.equiv_test_weight_lbs != null
                                                     ? `${Number(coeff.equiv_test_weight_lbs).toLocaleString()} lbs`
                                                     : '—'}
@@ -234,10 +234,10 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                                 const b = coeff.target_b ?? coeff.set_b;
                                                 const c = coeff.target_c ?? coeff.set_c;
                                                 const isTarget = coeff.target_a != null;
-                                                if (a == null) return <span className="text-gray-300 dark:text-slate-600">—</span>;
+                                                if (a == null) return <span className="text-faint">—</span>;
                                                 return (
                                                     <div
-                                                        className={`text-[11px] leading-tight ${isTarget ? 'text-gray-600 dark:text-slate-300' : 'text-gray-400 dark:text-slate-500'}`}
+                                                        className={`text-[11px] leading-tight ${isTarget ? 'text-secondary' : 'text-faint'}`}
                                                         title={isTarget ? 'Target coefficients (road load)' : 'Set coefficients (dyno-programmed)'}
                                                     >
                                                         <div>{Number(a).toFixed(2)}</div>
@@ -250,22 +250,22 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
                                         </td>
 
                                         {/* Label MPGe — combined, else highway-only (tagged) */}
-                                        <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-slate-400">
+                                        <td className="px-3 py-2 whitespace-nowrap text-muted">
                                             {g.label_combined_mpge != null && g.label_combined_mpge < 500 ? (
                                                 <span>{g.label_combined_mpge}</span>
                                             ) : g.label_hwy_mpge != null && g.label_hwy_mpge < 500 ? (
                                                 <span title="Highway-only (proc 84); no combined MCT test">
-                                                    {g.label_hwy_mpge}<span className="text-gray-400 ml-1 text-[10px]">hwy</span>
+                                                    {g.label_hwy_mpge}<span className="text-faint ml-1 text-[10px]">hwy</span>
                                                 </span>
                                             ) : (
-                                                <span className="text-gray-300 dark:text-slate-600">—</span>
+                                                <span className="text-faint">—</span>
                                             )}
                                         </td>
 
                                         {/* Linked vehicles with confidence badges */}
                                         <td className="px-3 py-2">
                                             {mappings.length === 0 ? (
-                                                <span className="text-gray-300 dark:text-slate-600 italic">none</span>
+                                                <span className="text-faint italic">none</span>
                                             ) : (
                                                 <div className="flex flex-wrap gap-1">
                                                     {mappings.map(m => (
@@ -302,7 +302,7 @@ export default function EpaDataCard({ getEpaTestGroupsAdmin, deleteEpaTestGroup,
 
             {/* Footer: row count when filter is active */}
             {!loading && groups.length > 0 && q && filtered.length !== groups.length && (
-                <div className="px-4 py-2 border-t text-xs text-gray-400 dark:text-slate-500">
+                <div className="px-4 py-2 border-t text-xs text-faint">
                     Showing {filtered.length} of {groups.length} test groups
                 </div>
             )}

--- a/src/components/EpaImportModal.jsx
+++ b/src/components/EpaImportModal.jsx
@@ -100,11 +100,11 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                 <div className="modal-header flex items-center justify-between">
                     <div>
                         <h2 className="text-lg font-semibold">Import EPA Test Car Data</h2>
-                        <p className="text-sm text-gray-500 mt-0.5">
+                        <p className="text-sm text-muted mt-0.5">
                             Upload a pre-filtered EPA testcar sheet (TSV) to add road-load coefficients.
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none ml-4">&times;</button>
+                    <button onClick={onClose} className="text-faint hover:text-secondary text-2xl leading-none ml-4">&times;</button>
                 </div>
 
                 {/* Body — scrollable */}
@@ -115,15 +115,15 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                         <div className="flex flex-col items-center">
                             <div
                                 className={`w-full border-2 border-dashed rounded-xl p-12 text-center cursor-pointer transition
-                                    ${dragOver ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-gray-300 dark:border-slate-600 hover:border-indigo-400'}`}
+                                    ${dragOver ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-[var(--color-border)] hover:border-indigo-400'}`}
                                 onClick={() => fileRef.current?.click()}
                                 onDrop={handleDrop}
                                 onDragOver={handleDragOver}
                                 onDragLeave={handleDragLeave}
                             >
                                 <div className="text-4xl mb-3">📂</div>
-                                <p className="font-medium text-gray-700 dark:text-slate-300">Drop the EPA testcar TSV here, or click to browse</p>
-                                <p className="text-sm text-gray-400 mt-1">Accepts .csv (Excel) or .txt / .tsv (tab-separated) · Pre-filter to your vehicles of interest</p>
+                                <p className="font-medium text-secondary">Drop the EPA testcar TSV here, or click to browse</p>
+                                <p className="text-sm text-faint mt-1">Accepts .csv (Excel) or .txt / .tsv (tab-separated) · Pre-filter to your vehicles of interest</p>
                                 <input ref={fileRef} type="file" accept=".txt,.tsv,.csv" className="hidden" onChange={handleFilePick} />
                             </div>
                             {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
@@ -148,10 +148,10 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                 <span><strong>{summary.total}</strong> test group{summary.total !== 1 ? 's' : ''} found</span>
                                 {summary.yearMin && <span>MY {summary.yearMin}{summary.yearMax !== summary.yearMin ? `–${summary.yearMax}` : ''}</span>}
                                 <span>{summary.makes.join(', ')}</span>
-                                <span className="text-gray-400">·</span>
+                                <span className="text-faint">·</span>
                                 <span>{summary.withCoeffs} with A/B/C coefficients</span>
                                 <span>{summary.withMpge} with combined MPGe</span>
-                                <span className="text-gray-400">·</span>
+                                <span className="text-faint">·</span>
                                 <span>File: <span className="font-mono text-xs">{fileName}</span></span>
                                 {summary.isMasterList && (
                                     <span className="text-amber-700 dark:text-amber-400 font-medium">
@@ -175,12 +175,12 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                                     onChange={e => toggleAll(e.target.checked)}
                                                 />
                                             </th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Test Group</th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Year · Make · Carline</th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Drive / ETW</th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">A / B / C</th>
-                                            <th className="pb-2 pr-3 text-gray-500 font-semibold whitespace-nowrap">Combined MPGe</th>
-                                            <th className="pb-2 text-gray-500 font-semibold">Link to Vehicle</th>
+                                            <th className="pb-2 pr-3 text-muted font-semibold whitespace-nowrap">Test Group</th>
+                                            <th className="pb-2 pr-3 text-muted font-semibold whitespace-nowrap">Year · Make · Carline</th>
+                                            <th className="pb-2 pr-3 text-muted font-semibold whitespace-nowrap">Drive / ETW</th>
+                                            <th className="pb-2 pr-3 text-muted font-semibold whitespace-nowrap">A / B / C</th>
+                                            <th className="pb-2 pr-3 text-muted font-semibold whitespace-nowrap">Combined MPGe</th>
+                                            <th className="pb-2 text-muted font-semibold">Link to Vehicle</th>
                                         </tr>
                                     </thead>
                                     <tbody className="divide-y">
@@ -198,31 +198,31 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                                         <input type="checkbox" checked={isSelected}
                                                             onChange={e => toggleOne(g.test_group_id, e.target.checked)} />
                                                     </td>
-                                                    <td className="py-2 pr-3 font-mono text-gray-600 dark:text-slate-400 whitespace-nowrap">
+                                                    <td className="py-2 pr-3 font-mono text-secondary whitespace-nowrap">
                                                         {g.test_group_id}
                                                     </td>
                                                     <td className="py-2 pr-3">
                                                         <span className="font-medium">{g.model_year}</span>
-                                                        <span className="text-gray-400 mx-1">·</span>
+                                                        <span className="text-faint mx-1">·</span>
                                                         <span>{g.make}</span>
-                                                        <div className="text-gray-500 mt-0.5 max-w-[200px] truncate" title={g.epa_carline_name}>
+                                                        <div className="text-muted mt-0.5 max-w-[200px] truncate" title={g.epa_carline_name}>
                                                             {g.epa_carline_name}
                                                         </div>
                                                     </td>
                                                     <td className="py-2 pr-3 whitespace-nowrap">
                                                         <div>{g.drive ?? '—'}</div>
-                                                        <div className="text-gray-400">{cs.equiv_test_weight_lbs != null ? `${cs.equiv_test_weight_lbs.toLocaleString()} lbs` : '—'}</div>
+                                                        <div className="text-faint">{cs.equiv_test_weight_lbs != null ? `${cs.equiv_test_weight_lbs.toLocaleString()} lbs` : '—'}</div>
                                                     </td>
                                                     <td className="py-2 pr-3 font-mono whitespace-nowrap">
                                                         {a != null ? (
                                                             <div>
-                                                                <span className={cs.set_a != null ? '' : 'text-gray-400'}>{a?.toFixed(2)}</span>
-                                                                <span className="text-gray-300 mx-1">/</span>
-                                                                <span className={cs.set_b != null ? '' : 'text-gray-400'}>{b?.toFixed(4)}</span>
-                                                                <span className="text-gray-300 mx-1">/</span>
-                                                                <span className={cs.set_c != null ? '' : 'text-gray-400'}>{c?.toFixed(5)}</span>
+                                                                <span className={cs.set_a != null ? '' : 'text-faint'}>{a?.toFixed(2)}</span>
+                                                                <span className="text-faint mx-1">/</span>
+                                                                <span className={cs.set_b != null ? '' : 'text-faint'}>{b?.toFixed(4)}</span>
+                                                                <span className="text-faint mx-1">/</span>
+                                                                <span className={cs.set_c != null ? '' : 'text-faint'}>{c?.toFixed(5)}</span>
                                                             </div>
-                                                        ) : <span className="text-gray-300">—</span>}
+                                                        ) : <span className="text-faint">—</span>}
                                                         {cs.set_a == null && a != null && (
                                                             <div className="text-amber-500 text-[10px]">target only</div>
                                                         )}
@@ -233,10 +233,10 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                                                         ) : g.label_hwy_mpge != null ? (
                                                             <span title="Highway-only (proc 84); no combined MCT test in file">
                                                                 {g.label_hwy_mpge.toFixed(1)} MPGe
-                                                                <span className="text-gray-400 ml-1 text-[10px]">hwy</span>
+                                                                <span className="text-faint ml-1 text-[10px]">hwy</span>
                                                             </span>
                                                         ) : (
-                                                            <span className="text-gray-300">—</span>
+                                                            <span className="text-faint">—</span>
                                                         )}
                                                     </td>
                                                     <td className="py-2">
@@ -266,11 +266,11 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
                         <div className="flex flex-col items-center py-8 text-center">
                             <div className="text-5xl mb-4">✅</div>
                             <p className="text-lg font-semibold mb-2">Import complete</p>
-                            <p className="text-gray-600">
+                            <p className="text-secondary">
                                 <strong>{result.testGroupsCount}</strong> test group{result.testGroupsCount !== 1 ? 's' : ''} upserted
                                 {result.mappingsCount > 0 && <>, <strong>{result.mappingsCount}</strong> vehicle link{result.mappingsCount !== 1 ? 's' : ''} created</>}
                             </p>
-                            <p className="text-sm text-gray-400 mt-2">
+                            <p className="text-sm text-faint mt-2">
                                 Vehicles with new EPA data will show a dashed curve on the EPA Curves chart tab.
                                 Confidence is set to "likely" — update it to "verified" via the vehicle edit form if confirmed.
                             </p>
@@ -281,7 +281,7 @@ export default function EpaImportModal({ vehicles, onImport, onClose }) {
 
                 {/* Footer */}
                 <div className="modal-footer flex justify-between items-center">
-                    <div className="text-sm text-gray-500">
+                    <div className="text-sm text-muted">
                         {step === 'map' && (
                             <span>
                                 {selectedCount} of {parsed.length} selected

--- a/src/components/EpaPdfImportModal.jsx
+++ b/src/components/EpaPdfImportModal.jsx
@@ -112,7 +112,7 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                     <h3 className="text-lg font-bold">
                         Import EPA Lab PDF{targetVehicle ? ` → ${targetVehicle.name}` : ''}
                     </h3>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">×</button>
+                    <button onClick={onClose} className="text-faint hover:text-secondary text-xl leading-none">×</button>
                 </div>
 
                 {error && <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm">⚠️ {error}</div>}
@@ -122,9 +122,9 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                         onDrop={onDrop}
                         onDragOver={e => { e.preventDefault(); setDragOver(true); }}
                         onDragLeave={() => setDragOver(false)}
-                        className={`border-2 border-dashed rounded-lg p-10 text-center ${dragOver ? 'border-indigo-400 bg-indigo-50/40' : 'border-gray-300'}`}
+                        className={`border-2 border-dashed rounded-lg p-10 text-center ${dragOver ? 'border-indigo-400 bg-indigo-50/40' : 'border-[var(--color-border)]'}`}
                     >
-                        <p className="text-sm text-gray-500 mb-3">
+                        <p className="text-sm text-muted mb-3">
                             {busy ? 'Reading PDF…' : 'Drop an EPA Certification Summary (CSI) PDF here, or'}
                         </p>
                         <label className="btn btn-secondary text-sm cursor-pointer">
@@ -132,19 +132,19 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                             <input type="file" accept=".pdf" className="hidden"
                                 onChange={e => processFile(e.target.files[0])} />
                         </label>
-                        <p className="text-xs text-gray-400 mt-3">Parsed entirely in your browser — nothing is uploaded.</p>
+                        <p className="text-xs text-faint mt-3">Parsed entirely in your browser — nothing is uploaded.</p>
                     </div>
                 )}
 
                 {step === 'review' && (
                     <>
-                        <p className="text-sm text-gray-500 mb-2">
+                        <p className="text-sm text-muted mb-2">
                             <span className="font-medium">{fileName}</span> — {groups.length} configuration(s) found.
                         </p>
                         <div className="max-h-80 overflow-y-auto border rounded-lg">
                             <table className="w-full text-xs">
-                                <thead className="bg-gray-50 dark:bg-slate-800 sticky top-0">
-                                    <tr className="text-left text-gray-500">
+                                <thead className="bg-[var(--color-surface-muted)] sticky top-0">
+                                    <tr className="text-left text-muted">
                                         <th className="p-2" title="Select all / none">
                                             <input type="checkbox" checked={allSelected} onChange={toggleAllSelect} />
                                         </th>
@@ -174,8 +174,8 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                                                     </td>
                                                 )}
                                                 <td className="p-2 font-mono">{id}</td>
-                                                <td className="p-2">{g.make} · <span className="text-gray-500">{g.epa_carline_name}</span></td>
-                                                <td className="p-2 font-mono text-gray-500">{g.coefficient_sets.length} / {g.tests.length} / {phaseCount}</td>
+                                                <td className="p-2">{g.make} · <span className="text-muted">{g.epa_carline_name}</span></td>
+                                                <td className="p-2 font-mono text-muted">{g.coefficient_sets.length} / {g.tests.length} / {phaseCount}</td>
                                                 <td className="p-2">
                                                     {existing.has(id)
                                                         ? <span className="text-amber-600 dark:text-amber-400">⟳ overwrite</span>
@@ -195,7 +195,7 @@ export default function EpaPdfImportModal({ targetVehicle = null, onImport, getE
                         )}
 
                         <div className="flex items-center gap-2 mt-4">
-                            <span className="text-xs text-gray-500 flex-1">
+                            <span className="text-xs text-muted flex-1">
                                 {selected.size} selected{overwriteCount ? ` · ${overwriteCount} overwrite` : ''}
                                 {targetVehicle && linkIds.size ? ` · linking ${linkIds.size} to ${targetVehicle.name}` : ''}
                             </span>

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -17,7 +17,7 @@ import { useAppContext } from '../context/AppContext';
 const CONFIDENCE_COLORS = {
     verified: 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700',
     likely:   'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700',
-    inferred: 'text-gray-500 bg-gray-50 border-gray-200 dark:text-gray-400 dark:bg-gray-800/40 dark:border-gray-600',
+    inferred: 'text-muted bg-[var(--color-surface-muted)] border-[var(--color-border)]',
 };
 
 function ConfidenceBadge({ confidence }) {
@@ -33,8 +33,8 @@ function DataRow({ label, value, muted }) {
     if (value == null) return null;
     return (
         <div className="flex justify-between gap-4 py-0.5">
-            <span className="text-gray-500 dark:text-slate-400 shrink-0">{label}</span>
-            <span className={`font-mono text-right ${muted ? 'text-gray-400 dark:text-slate-500' : ''}`}>{value}</span>
+            <span className="text-muted shrink-0">{label}</span>
+            <span className={`font-mono text-right ${muted ? 'text-faint' : ''}`}>{value}</span>
         </div>
     );
 }
@@ -128,7 +128,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
                             onChange={e => setDraftName(e.target.value)}
                             onBlur={handleNameSave}
                             onKeyDown={handleNameKeyDown}
-                            className="form-input text-sm font-semibold py-0.5 w-full disabled:opacity-50 placeholder:text-gray-400 dark:placeholder:text-slate-500 placeholder:font-normal placeholder:italic"
+                            className="form-input text-sm font-semibold py-0.5 w-full disabled:opacity-50 placeholder:text-[var(--color-text-faint)] placeholder:font-normal placeholder:italic"
                             title="Friendly display name used in charts. Leave blank to use the EPA carline name."
                         />
                     ) : (
@@ -138,16 +138,16 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
                     )}
                     {/* Show raw EPA name as subtitle when a display name is set or being edited */}
                     {(g.display_name || draftName !== null) && (
-                        <div className="text-xs text-gray-400 dark:text-slate-500 italic truncate mt-0.5">{g.epa_carline_name}</div>
+                        <div className="text-xs text-faint italic truncate mt-0.5">{g.epa_carline_name}</div>
                     )}
-                    <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                    <div className="text-xs text-muted mt-0.5">
                         {g.model_year}{g.make ? ` · ${g.make}` : ''}{g.drive ? ` · ${g.drive}` : ''}
                         {g.transmission ? ` · ${g.transmission}` : ''}
                     </div>
-                    <div className="font-mono text-xs text-gray-400 mt-0.5">
+                    <div className="font-mono text-xs text-faint mt-0.5">
                         {g.test_group_id}
                         {g.epa_test_family_id && g.epa_test_family_id !== g.test_group_id && (
-                            <span className="ml-1 text-gray-300 dark:text-slate-600">· family: {g.epa_test_family_id}</span>
+                            <span className="ml-1 text-faint">· family: {g.epa_test_family_id}</span>
                         )}
                     </div>
                 </div>
@@ -195,7 +195,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
 
                 {/* Physical */}
                 <div>
-                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                    <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                         Test Setup
                     </div>
                     <DataRow label="Test weight" value={coeff.equiv_test_weight_lbs != null ? coeff.equiv_test_weight_lbs.toLocaleString() + ' lbs' : null} />
@@ -205,7 +205,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
 
                 {/* Road-load coefficients (primary set) */}
                 <div>
-                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
+                    <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold flex items-center gap-1">
                         Road-Load Coefficients
                         <InfoIcon text={EPA_EXPLAINERS.roadLoad} position="right" />
                     </div>
@@ -222,14 +222,14 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
                             <DataRow label="Set C" value={fmt(coeff.set_c, 6) + ' lbf/mph²'} muted />
                         </>
                     ) : (
-                        <p className="text-gray-400 text-[10px] italic">No coefficients yet</p>
+                        <p className="text-faint text-[10px] italic">No coefficients yet</p>
                     )}
                 </div>
 
                 {/* Label results + live derivations */}
                 <div className="space-y-2">
                     <div>
-                        <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                        <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                             Label Results
                         </div>
                         {g.label_combined_mpge != null && g.label_combined_mpge < 500 && (
@@ -242,7 +242,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
                             <DataRow label="Label range" value={g.label_range_published.toFixed(0) + ' mi'} />
                         )}
                         {g.label_combined_mpge == null && g.label_hwy_mpge == null && (
-                            <p className="text-gray-400 text-[10px] italic">No label data</p>
+                            <p className="text-faint text-[10px] italic">No label data</p>
                         )}
                     </div>
                     <DerivedValues group={g} />
@@ -250,7 +250,7 @@ function EpaGroupCard({ mapping, canEdit, onUnlink, onDelete, onUpdateConfidence
             </div>
 
             {mapping.notes && (
-                <p className="mt-2 text-xs text-gray-500 dark:text-slate-400 italic border-t pt-2">{mapping.notes}</p>
+                <p className="mt-2 text-xs text-muted italic border-t pt-2">{mapping.notes}</p>
             )}
 
             {/* Curator form — contributor/admin only */}
@@ -376,7 +376,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
 
             {/* Existing mappings */}
             {mappings.length === 0 ? (
-                <p className="text-sm text-gray-500 dark:text-slate-400 mb-3">
+                <p className="text-sm text-muted mb-3">
                     No EPA test group linked yet.
                     {canEdit && ' Use the search below to assign one.'}
                 </p>
@@ -409,12 +409,12 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                             className="form-input text-sm w-full"
                         />
                         {linking && (
-                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">Linking…</span>
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-faint">Linking…</span>
                         )}
                         {showDropdown && (results.length > 0 || searching || searchError) && (
-                            <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border shadow-lg bg-white dark:bg-slate-800 dark:border-slate-600">
+                            <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border shadow-lg bg-[var(--color-surface-input)] border-[var(--color-border)]">
                                 {searching && (
-                                    <li className="px-3 py-2 text-sm text-gray-400 italic">Searching…</li>
+                                    <li className="px-3 py-2 text-sm text-faint italic">Searching…</li>
                                 )}
                                 {!searching && searchError && (
                                     <li className="px-3 py-2 text-sm text-red-500">Error: {searchError}</li>
@@ -426,18 +426,18 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                         onMouseDown={e => { e.preventDefault(); handleSelect(g); }}
                                     >
                                         <span className="font-medium">{g.make} · {g.epa_carline_name}</span>
-                                        <span className="text-gray-400 ml-2 text-xs">
+                                        <span className="text-faint ml-2 text-xs">
                                             {g.model_year}{g.drive ? ` · ${g.drive}` : ''} · {g.test_group_id}
                                         </span>
                                     </li>
                                 ))}
                                 {!searching && !searchError && results.length === 0 && query.trim() && (
-                                    <li className="px-3 py-2 text-sm text-gray-400 italic">No results</li>
+                                    <li className="px-3 py-2 text-sm text-faint italic">No results</li>
                                 )}
                             </ul>
                         )}
                     </div>
-                    <p className="text-xs text-gray-400 mt-1">
+                    <p className="text-xs text-faint mt-1">
                         Import an EPA lab PDF, the Test Car Data CSV (Admin), or create one by hand below.
                     </p>
 
@@ -468,7 +468,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                             + Create EPA test group from scratch
                         </button>
                     ) : (
-                        <div className="mt-2 border rounded-lg p-3 border-gray-200 dark:border-slate-700">
+                        <div className="mt-2 border rounded-lg p-3 border-[var(--color-border)]">
                             <div className="flex items-center justify-between mb-2">
                                 <span className="text-xs font-semibold">New EPA test group</span>
                                 <a href={EPA_SOURCE_URL} target="_blank" rel="noopener noreferrer"
@@ -478,7 +478,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                             </div>
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                                 <label className="text-xs">
-                                    <span className="text-gray-500 dark:text-slate-400">Test Group ID *</span>
+                                    <span className="text-muted">Test Group ID *</span>
                                     <input
                                         type="text" autoFocus
                                         value={createDraft.test_group_id}
@@ -488,7 +488,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                     />
                                 </label>
                                 <label className="text-xs">
-                                    <span className="text-gray-500 dark:text-slate-400">Model year</span>
+                                    <span className="text-muted">Model year</span>
                                     <input
                                         type="number"
                                         value={createDraft.model_year}
@@ -497,7 +497,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                     />
                                 </label>
                                 <label className="text-xs">
-                                    <span className="text-gray-500 dark:text-slate-400">Manufacturer</span>
+                                    <span className="text-muted">Manufacturer</span>
                                     <input
                                         type="text"
                                         value={createDraft.make}
@@ -507,7 +507,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                     />
                                 </label>
                                 <label className="text-xs">
-                                    <span className="text-gray-500 dark:text-slate-400">Carline</span>
+                                    <span className="text-muted">Carline</span>
                                     <input
                                         type="text"
                                         value={createDraft.epa_carline_name}
@@ -518,7 +518,7 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                                 </label>
                             </div>
                             {createError && <p className="text-xs text-red-500 mt-1">{createError}</p>}
-                            <p className="text-[11px] text-gray-400 mt-1">
+                            <p className="text-[11px] text-faint mt-1">
                                 Creates and links the group; add coefficients, tests and phases in the curator fields afterward.
                             </p>
                             <div className="flex gap-2 mt-2">

--- a/src/components/ImportTableauModal.jsx
+++ b/src/components/ImportTableauModal.jsx
@@ -145,14 +145,14 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                 <div className="modal-header px-6 py-4 border-b flex-shrink-0">
                     <div>
                         <h2 className="text-xl font-bold">Import Tableau CSV</h2>
-                        <p className="text-sm text-gray-500 mt-0.5">
+                        <p className="text-sm text-muted mt-0.5">
                             {step === 'upload'    && 'Select an exported Tableau charging curve CSV'}
                             {step === 'mapping'   && `${sessions.length} sessions found — review and map below`}
                             {step === 'importing' && 'Importing…'}
                             {step === 'done'      && 'Import complete'}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">&times;</button>
+                    <button onClick={onClose} className="text-faint hover:text-secondary text-2xl leading-none">&times;</button>
                 </div>
 
                 {/* Body */}
@@ -162,7 +162,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                     {step === 'upload' && (
                         <div className="flex flex-col items-center justify-center py-12 gap-4">
                             <div className="text-5xl">📂</div>
-                            <p className="text-gray-600 text-center max-w-sm">
+                            <p className="text-secondary text-center max-w-sm">
                                 Export your Tableau workbook as <strong>CSV</strong> and upload it here.
                                 Columns should include <em>Date of charging test</em>, <em>Optimized</em>,
                                 <em>Vehicle</em>, and numeric SoC columns (0–100).
@@ -206,7 +206,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                 <button
                                     type="button"
                                     onClick={() => setSkipSet(new Set(uniqueVehicles.map(v => v.raw)))}
-                                    className="px-3 py-1 rounded text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition"
+                                    className="px-3 py-1 rounded text-xs font-medium bg-[var(--color-surface-sunken)] text-secondary hover:bg-[var(--color-surface-muted)] transition"
                                 >
                                     Skip all
                                 </button>
@@ -220,8 +220,8 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                             </div>
 
                             {/* Global prefix */}
-                            <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border">
-                                <label className="text-sm font-medium text-gray-700 whitespace-nowrap">
+                            <div className="flex items-center gap-3 p-3 bg-[var(--color-surface-muted)] rounded-lg border">
+                                <label className="text-sm font-medium text-secondary whitespace-nowrap">
                                     Run name prefix:
                                 </label>
                                 <input
@@ -255,7 +255,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                                 title={skipped ? 'Include this vehicle' : 'Skip this vehicle'}
                                                 className={`flex-shrink-0 px-2 py-0.5 rounded text-xs font-medium border transition ${
                                                     skipped
-                                                        ? 'bg-gray-200 text-gray-500 border-gray-300'
+                                                        ? 'bg-[var(--color-surface-muted)] text-muted border-[var(--color-border)]'
                                                         : 'bg-red-50 text-red-600 border-red-200 hover:bg-red-100'
                                                 }`}
                                             >
@@ -263,8 +263,8 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                             </button>
                                             <div className="flex-1 min-w-0">
                                                 <span className="font-semibold">{vehicleName}</span>
-                                                {year && <span className="text-gray-400 text-sm ml-1">({year})</span>}
-                                                <span className="text-gray-400 text-xs ml-2">
+                                                {year && <span className="text-faint text-sm ml-1">({year})</span>}
+                                                <span className="text-faint text-xs ml-2">
                                                     {vehicleSessions.length} session{vehicleSessions.length !== 1 ? 's' : ''}
                                                 </span>
                                             </div>
@@ -295,7 +295,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                                             onChange={e => handleNameChange(idx, e.target.value)}
                                                             className="border rounded px-2 py-1 text-sm flex-1"
                                                         />
-                                                        <span className="text-xs text-gray-400 whitespace-nowrap flex-shrink-0">
+                                                        <span className="text-xs text-faint whitespace-nowrap flex-shrink-0">
                                                             {date}
                                                         </span>
                                                         {synthetic && (
@@ -304,7 +304,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                                             </span>
                                                         )}
                                                         {globalPrefix && (
-                                                            <span className="text-xs text-gray-400 italic flex-shrink-0 hidden lg:block" title="Final run name">
+                                                            <span className="text-xs text-faint italic flex-shrink-0 hidden lg:block" title="Final run name">
                                                                 → {finalName(idx)}
                                                             </span>
                                                         )}
@@ -313,8 +313,8 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
 
                                                 {/* Existing runs in mapped vehicle */}
                                                 {existingRuns.length > 0 && (
-                                                    <div className="px-4 py-2 bg-gray-50">
-                                                        <p className="text-xs text-gray-400 font-medium mb-1">
+                                                    <div className="px-4 py-2 bg-[var(--color-surface-muted)]">
+                                                        <p className="text-xs text-faint font-medium mb-1">
                                                             Existing runs in "{mappedVehicle.name}":
                                                         </p>
                                                         <ul className="space-y-0.5">
@@ -323,7 +323,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                                                 return (
                                                                     <li
                                                                         key={run.id}
-                                                                        className={`text-xs ${clash ? 'font-bold text-red-600' : 'text-gray-500'}`}
+                                                                        className={`text-xs ${clash ? 'font-bold text-red-600' : 'text-muted'}`}
                                                                     >
                                                                         {clash ? '⚠ ' : '• '}{run.name}
                                                                         {run.date && <span className="ml-1 font-normal opacity-70">({run.date})</span>}
@@ -347,8 +347,8 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                     {step === 'importing' && (
                         <div className="flex flex-col items-center justify-center py-16 gap-4">
                             <div className="w-10 h-10 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin" />
-                            <p className="text-gray-600">Importing {activeSessions.length} sessions…</p>
-                            <p className="text-xs text-gray-400">This may take a moment for large datasets</p>
+                            <p className="text-secondary">Importing {activeSessions.length} sessions…</p>
+                            <p className="text-xs text-faint">This may take a moment for large datasets</p>
                         </div>
                     )}
 
@@ -371,7 +371,7 @@ export default function ImportTableauModal({ vehicles, onImport, onClose }) {
                                         {result.runsSkipped} duplicate{result.runsSkipped !== 1 ? 's' : ''} skipped
                                     </span>
                                 )}
-                                <span className="px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-600">
+                                <span className="px-3 py-1 rounded-full text-sm font-medium bg-[var(--color-surface-sunken)] text-secondary">
                                     {result.pointsImported.toLocaleString()} data points
                                 </span>
                             </div>

--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -4,8 +4,8 @@
  */
 export default function LoadingSpinner({ message = 'Loading…', className = '' }) {
     return (
-        <div className={`flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400 mb-4 ${className}`}>
-            <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin shrink-0" />
+        <div className={`flex items-center gap-2 text-sm text-muted mb-4 ${className}`}>
+            <span className="inline-block w-4 h-4 border-2 border-[var(--color-border)] border-t-blue-500 rounded-full animate-spin shrink-0" />
             {message}
         </div>
     );

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -466,7 +466,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                             key={key}
                             type="button"
                             onClick={() => setEffUnit(key)}
-                            className={`px-3 py-1 rounded text-sm font-medium transition-colors ${effUnit === key ? 'bg-white shadow text-gray-900' : 'text-gray-500 dark:text-slate-300 hover:text-gray-700 dark:hover:text-slate-100'}`}
+                            className={`px-3 py-1 rounded text-sm font-medium transition-colors ${effUnit === key ? 'bg-[var(--color-card)] shadow text-[var(--color-text-primary)]' : 'text-secondary hover:text-[var(--color-text-primary)]'}`}
                         >
                             {label}
                         </button>
@@ -538,7 +538,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                         return (
                             <>
                                 {run.speed_mph != null && (
-                                    <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{fmtSpeed(run.speed_mph, units)}</span>
+                                    <span className="text-xs bg-[var(--color-surface-sunken)] text-secondary px-1.5 py-0.5 rounded">{fmtSpeed(run.speed_mph, units)}</span>
                                 )}
                                 {run.temperature_f != null && (
                                     <span className="text-xs bg-orange-50 text-orange-700 px-1.5 py-0.5 rounded border border-orange-200">{fmtTemp(run.temperature_f, units)}</span>
@@ -572,7 +572,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                         style={{ display: plottableRuns.length > 0 ? 'block' : 'none' }}
                     />
                     {plottableRuns.length === 0 && (
-                        <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+                        <div className="absolute inset-0 flex items-center justify-center text-faint">
                             <div className="text-center">
                                 <p className="text-lg font-medium">
                                     {selectedRangeRuns.length === 0
@@ -580,7 +580,7 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                         : 'Selected runs are missing required fields for this chart type'}
                                 </p>
                                 {selectedRangeRuns.length > 0 && (
-                                    <p className="text-sm mt-1 text-gray-400">
+                                    <p className="text-sm mt-1 text-faint">
                                         {CHART_TYPES.find(t => t.key === chartType)?.desc}
                                     </p>
                                 )}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1246,7 +1246,7 @@ export default function RoadTripView({
                     {/* Toggles row */}
                     <div className="flex flex-wrap gap-6 mb-4">
                         <div>
-                            <span className="text-xs font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wide block mb-1">Simulation</span>
+                            <span className="text-xs font-semibold text-secondary uppercase tracking-wide block mb-1">Simulation</span>
                             <div className="flex gap-1">
                                 <button
                                     className={`btn btn-sm ${mode === 'distance' ? 'btn-primary' : 'btn-secondary'}`}
@@ -1263,7 +1263,7 @@ export default function RoadTripView({
                             </div>
                         </div>
                         <div>
-                            <span className="text-xs font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wide block mb-1">X Axis</span>
+                            <span className="text-xs font-semibold text-secondary uppercase tracking-wide block mb-1">X Axis</span>
                             <div className="flex gap-1">
                                 <button className={`btn btn-sm ${xAxis === 'totalTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'totalTime')}>Total Time</button>
                                 <button className={`btn btn-sm ${xAxis === 'driveTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('xAxis', 'driveTime')}>Drive Time</button>
@@ -1274,7 +1274,7 @@ export default function RoadTripView({
                         <div>
                             {isSweepMode ? (
                                 <>
-                                    <span className="text-xs font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wide block mb-1">Y Axis</span>
+                                    <span className="text-xs font-semibold text-secondary uppercase tracking-wide block mb-1">Y Axis</span>
                                     <div className="flex gap-1">
                                         <button className={`btn btn-sm ${sweepYAxis === 'totalTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('sweepYAxis', 'totalTime')}>Total Time</button>
                                         <button className={`btn btn-sm ${sweepYAxis === 'driveTime'  ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('sweepYAxis', 'driveTime')}>Drive Time</button>
@@ -1283,7 +1283,7 @@ export default function RoadTripView({
                                 </>
                             ) : (
                                 <>
-                                    <span className="text-xs font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wide block mb-1">Y Axis</span>
+                                    <span className="text-xs font-semibold text-secondary uppercase tracking-wide block mb-1">Y Axis</span>
                                     <div className="flex gap-1">
                                         <button className={`btn btn-sm ${yAxis === 'distance'   ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('yAxis', 'distance')}>Distance</button>
                                         <button className={`btn btn-sm ${yAxis === 'chargeTime' ? 'btn-primary' : 'btn-secondary'}`} onClick={() => setField('yAxis', 'chargeTime')}>Charge Time</button>
@@ -1293,7 +1293,7 @@ export default function RoadTripView({
                             )}
                         </div>
                         <div>
-                            <span className="text-xs font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wide block mb-1">Mode</span>
+                            <span className="text-xs font-semibold text-secondary uppercase tracking-wide block mb-1">Mode</span>
                             <button
                                 className={`btn btn-sm ${towingMode ? 'btn-primary' : 'btn-secondary'}`}
                                 onClick={() => setField('towingMode', !towingMode)}
@@ -1450,7 +1450,7 @@ export default function RoadTripView({
                                     ? `${fmtSpeed(info.testSpeedMph, units)}`
                                     : '70 mph (assumed)';
                                 return (
-                                    <span className="text-xs text-gray-400 ml-1">
+                                    <span className="text-xs text-faint ml-1">
                                         {eff} {units === 'metric' ? 'km/kWh' : 'mi/kWh'} @ {spd}
                                         {info.efficiencyNote && ` · ${info.efficiencyNote}`}
                                     </span>
@@ -1477,13 +1477,13 @@ export default function RoadTripView({
 
             {/* ── Chart ────────────────────────────────────────────────── */}
             {loading && (
-                <div className="text-center py-8 text-gray-500">Loading charging data…</div>
+                <div className="text-center py-8 text-muted">Loading charging data…</div>
             )}
 
             {!loading && validEntries.length === 0 && (
                 <div className="empty-state">
                     <p className="text-lg">No runs with usable charging and efficiency data.</p>
-                    <p className="text-sm text-gray-500 mt-2">
+                    <p className="text-sm text-muted mt-2">
                         Each run needs charging data, and either its own range test result
                         or another run from the same vehicle with distance &amp; energy data.
                     </p>
@@ -1543,11 +1543,11 @@ export default function RoadTripView({
                             </button>
                         )}
                     </div>
-                    <p className="text-xs text-gray-400 mt-1">Drag to box-zoom · Reset Zoom to restore</p>
+                    <p className="text-xs text-faint mt-1">Drag to box-zoom · Reset Zoom to restore</p>
                     {chartImage && (
                         <div className="mt-3">
-                            <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
-                            <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                            <p className="text-xs text-faint mb-1.5">Right-click or long-press to copy / save</p>
+                            <img src={chartImage} alt="Chart export" className="w-full rounded border border-[var(--color-border)]" />
                         </div>
                     )}
                 </div>
@@ -1582,12 +1582,12 @@ export default function RoadTripView({
                                 const arrow = active ? (sortDir === 'asc' ? '↑' : '↓') : '↕';
                                 return (
                                     <th
-                                        className={`px-3 py-2 text-left font-semibold cursor-pointer select-none hover:bg-gray-100 whitespace-nowrap ${active ? 'text-blue-600' : ''} ${className}`}
+                                        className={`px-3 py-2 text-left font-semibold cursor-pointer select-none hover:bg-[var(--color-surface-sunken)] whitespace-nowrap ${active ? 'text-blue-600' : ''} ${className}`}
                                         onClick={() => handleSort(col)}
                                     >
                                         <span className="flex items-center gap-1">
                                             {children}
-                                            <span className={`text-xs ${active ? 'text-blue-500' : 'text-gray-300'}`}>{arrow}</span>
+                                            <span className={`text-xs ${active ? 'text-blue-500' : 'text-faint'}`}>{arrow}</span>
                                         </span>
                                     </th>
                                 );
@@ -1635,7 +1635,7 @@ export default function RoadTripView({
 
                             return (
                         <table className="w-full text-sm">
-                            <thead className="bg-gray-50 dark:bg-slate-700 dark:text-slate-100">
+                            <thead className="bg-[var(--color-surface-muted)]">
                                 <tr>
                                     <SortTh col="vehicle">Vehicle / Run</SortTh>
                                     <SortTh col="totalTime">Total Time</SortTh>
@@ -1658,7 +1658,7 @@ export default function RoadTripView({
                                                           style={{ backgroundColor: entry.color }} />
                                                     <div>
                                                         <div className="font-medium">{vehicleLabel(entry.vehicle)}</div>
-                                                        <div className="text-xs text-gray-400">{entry.run.name}</div>
+                                                        <div className="text-xs text-faint">{entry.run.name}</div>
                                                     </div>
                                                 </div>
                                             </td>
@@ -1675,12 +1675,12 @@ export default function RoadTripView({
                                                     <>
                                                         {entry.miPerKwh.toFixed(1)} {effLabel}
                                                         {entry.testSpeedMph ? (
-                                                            <span className="text-gray-400 ml-1">@ {fmtSpeed(entry.testSpeedMph, units)}</span>
+                                                            <span className="text-faint ml-1">@ {fmtSpeed(entry.testSpeedMph, units)}</span>
                                                         ) : (
                                                             <span className="text-amber-500 ml-1" title="Set Speed (mph) on the run in Tests &amp; Data for accurate speed correction">@ 70 mph (assumed)</span>
                                                         )}
                                                         {entry.efficiencyNote && (
-                                                            <span className="block text-xs text-gray-400">{entry.efficiencyNote}</span>
+                                                            <span className="block text-xs text-faint">{entry.efficiencyNote}</span>
                                                         )}
                                                     </>
                                                 )}

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -47,10 +47,10 @@ const FIELD_META = [
  */
 function RunRangeMetaLine({ run, units }) {
     const rangeFlag = DATA_FLAGS.find(f => f.key === 'range');
-    const dot = <span className="mx-1.5 text-gray-300 select-none">·</span>;
+    const dot = <span className="mx-1.5 text-faint select-none">·</span>;
     const items = [];
     if (run.speed_mph != null) {
-        items.push(<span key="spd" className="text-gray-600">{fmtSpeed(run.speed_mph, units)}</span>);
+        items.push(<span key="spd" className="text-secondary">{fmtSpeed(run.speed_mph, units)}</span>);
     } else {
         items.push(<span key="spd" className="text-amber-600" title="Set Speed (mph) in run metadata for accurate efficiency">{fmtSpeed(70, units)} (est.)</span>);
     }
@@ -60,7 +60,7 @@ function RunRangeMetaLine({ run, units }) {
         items.push(<span key="eff" className="text-blue-700">{calcEff(run.distance_miles, run.energy_kwh, 'mi_kwh', units)} {getEffLabel('mi_kwh', units)}</span>);
     if (run.temperature_f != null) items.push(<span key="tmp" className="text-orange-700">{fmtTemp(run.temperature_f, units)}</span>);
     if (run.start_soc != null && run.end_soc != null)
-        items.push(<span key="soc" className="text-gray-600">SoC {run.start_soc}→{run.end_soc}%</span>);
+        items.push(<span key="soc" className="text-secondary">SoC {run.start_soc}→{run.end_soc}%</span>);
     if (run.url)
         items.push(<a key="url" href={run.url} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">{run.name} ↗</a>);
     return (
@@ -84,12 +84,12 @@ function RunRangeMetaLine({ run, units }) {
  */
 function RunChargingMetaLine({ run, calcKwhByRun, onCheckKwh }) {
     const chargingFlag = DATA_FLAGS.find(f => f.key === 'charging');
-    const dot        = <span className="mx-1.5 text-gray-300 select-none">·</span>;
+    const dot        = <span className="mx-1.5 text-faint select-none">·</span>;
     const fields     = run.populated_fields  || [];
     const calcFields = run.calculated_fields || [];
     const items = [];
 
-    items.push(<span key="pts" className="text-gray-600">Data Points: {run.dataPointCount ?? run.data?.length ?? 0}</span>);
+    items.push(<span key="pts" className="text-secondary">Data Points: {run.dataPointCount ?? run.data?.length ?? 0}</span>);
     if (run.energy_kwh != null && !inferRunFlags(run).includes('range'))
         items.push(<span key="kwh" className="text-blue-700" title="Energy in (measured at charger or vehicle)">{run.energy_kwh} kWh in</span>);
 
@@ -113,11 +113,11 @@ function RunChargingMetaLine({ run, calcKwhByRun, onCheckKwh }) {
         if (!check) {
             items.push(
                 <button key="cmp" onClick={() => onCheckKwh(run)}
-                    className="text-gray-400 hover:text-gray-600 border border-gray-200 rounded px-1.5 py-0.5 transition-colors text-xs"
+                    className="text-faint hover:text-secondary border border-[var(--color-border)] rounded px-1.5 py-0.5 transition-colors text-xs"
                     title="Calculate kWh from data points and compare">Compare ↔</button>
             );
         } else if (check.loading) {
-            items.push(<span key="cmp" className="text-gray-400 text-xs">Calculating…</span>);
+            items.push(<span key="cmp" className="text-faint text-xs">Calculating…</span>);
         } else if (check.kwh != null) {
             const pct = Math.abs(run.energy_kwh - check.kwh) / Math.max(run.energy_kwh, check.kwh) * 100;
             items.push(
@@ -154,17 +154,17 @@ const EstimateTimePanel = ({
     const canPreview = !batteryMissing && validAnchors.length >= 2 && editData !== null && !editDataLoading;
 
     return (
-        <div className="mt-2 border rounded bg-gray-50 p-3 space-y-3">
+        <div className="mt-2 border rounded bg-[var(--color-surface-muted)] p-3 space-y-3">
             {batteryMissing && (
                 <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
                     ⚠ Set the battery capacity (kWh) on this vehicle to use time estimation.
                 </p>
             )}
-            {editDataLoading && <p className="text-xs text-gray-400">Loading data…</p>}
+            {editDataLoading && <p className="text-xs text-faint">Loading data…</p>}
             {!editDataLoading && (
                 <>
                     <div>
-                        <div className="grid grid-cols-[76px_96px_24px] gap-1 text-xs text-gray-500 px-1 mb-1">
+                        <div className="grid grid-cols-[76px_96px_24px] gap-1 text-xs text-muted px-1 mb-1">
                             <span>SoC (%)</span><span>Elapsed (min)</span>
                         </div>
                         <div className="space-y-1">
@@ -195,7 +195,7 @@ const EstimateTimePanel = ({
                                     <button
                                         type="button"
                                         onClick={() => onChangeAnchors(anchors.filter((_, j) => j !== i))}
-                                        className="text-gray-400 hover:text-red-500 font-bold leading-none"
+                                        className="text-faint hover:text-red-500 font-bold leading-none"
                                         title="Remove anchor"
                                     >✕</button>
                                 </div>
@@ -208,7 +208,7 @@ const EstimateTimePanel = ({
                         >+ Add anchor</button>
                     </div>
 
-                    <label className="flex items-center gap-2 text-xs text-gray-600 cursor-pointer">
+                    <label className="flex items-center gap-2 text-xs text-secondary cursor-pointer">
                         <input
                             type="checkbox"
                             checked={shiftToZero}
@@ -231,7 +231,7 @@ const EstimateTimePanel = ({
                             className="btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed text-xs"
                         >{applying ? 'Applying…' : 'Apply'}</button>
                         {!batteryMissing && validAnchors.length < 2 && anchors.length >= 1 && (
-                            <span className="text-xs text-gray-400">Need ≥2 anchors to preview</span>
+                            <span className="text-xs text-faint">Need ≥2 anchors to preview</span>
                         )}
                     </div>
 
@@ -248,7 +248,7 @@ const EstimateTimePanel = ({
                             )}
                             <div className="max-h-64 overflow-y-auto border rounded">
                                 <table className="text-xs w-full">
-                                    <thead className="bg-gray-100 sticky top-0">
+                                    <thead className="bg-[var(--color-surface-sunken)] sticky top-0">
                                         <tr>
                                             <th className="px-2 py-1 text-left font-medium">SoC %</th>
                                             <th className="px-2 py-1 text-left font-medium">kW</th>
@@ -266,7 +266,7 @@ const EstimateTimePanel = ({
                                     </tbody>
                                 </table>
                             </div>
-                            <p className="text-xs text-gray-500 font-medium">
+                            <p className="text-xs text-muted font-medium">
                                 Apply will write {preview.points.length} time values to this run.
                             </p>
                         </div>
@@ -1043,8 +1043,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 </div>
                 <div className="flex-1 min-w-0">
                     <h3 className="font-bold text-lg leading-tight">{vehicle.name}</h3>
-                    <p className="text-gray-500 text-sm">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
-                    <div className="text-sm text-gray-600 mt-0.5 flex flex-wrap gap-x-3">
+                    <p className="text-muted text-sm">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
+                    <div className="text-sm text-secondary mt-0.5 flex flex-wrap gap-x-3">
                         {vehicle.battery && <span>Battery: {vehicle.battery} kWh</span>}
                         {vehicle.range && <span>Range: {vehicle.range} mi</span>}
                     </div>
@@ -1056,18 +1056,18 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                         return canPublish() ? (
                             <button
                                 onClick={() => onToggleVehicleVisibility(vehicle.id, isPublic ? 'private' : 'public')}
-                                className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200' : 'bg-gray-100 text-gray-500 border-gray-300 hover:bg-gray-200'}`}
+                                className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200' : 'bg-[var(--color-surface-sunken)] text-muted border-[var(--color-border)] hover:bg-[var(--color-surface-muted)]'}`}
                             >
                                 {isPublic ? '🌐 Public' : '🔒 Private'}
                             </button>
                         ) : (
-                            <span className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300' : 'bg-gray-100 text-gray-500 border-gray-300'}`}>
+                            <span className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300' : 'bg-[var(--color-surface-sunken)] text-muted border-[var(--color-border)]'}`}>
                                 {isPublic ? '🌐 Public' : '🔒 Private'}
                             </span>
                         );
                     })()}
                     {canEdit(vehicle) && (
-                        <button onClick={openEditVehicle} className="px-3 py-1 rounded-md text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition">
+                        <button onClick={openEditVehicle} className="px-3 py-1 rounded-md text-xs font-medium bg-[var(--color-surface-sunken)] text-secondary hover:bg-[var(--color-surface-muted)] transition">
                             Edit
                         </button>
                     )}
@@ -1103,7 +1103,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             <div className="runs-view-header">
                 <div>
                     <h2 className="page-title">{vehicle.name} - Tests &amp; Data</h2>
-                    <p className="text-gray-600">Manage charging test data for this vehicle</p>
+                    <p className="text-secondary">Manage charging test data for this vehicle</p>
                 </div>
                 <div className="flex gap-2">
                     <button
@@ -1160,7 +1160,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     <>
                                         {/* Data-type flags — multi-select, at least one must remain active */}
                                         <div>
-                                            <p className="text-xs text-gray-500 mb-1">Data types (select all that apply)</p>
+                                            <p className="text-xs text-muted mb-1">Data types (select all that apply)</p>
                                             <div className="data-type-flags">
                                                 {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                     const active = runMetadata.dataFlags.includes(key);
@@ -1175,7 +1175,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                     : [...m.dataFlags, key];
                                                                 return { ...m, dataFlags: next.length ? next : m.dataFlags };
                                                             })}
-                                                            className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-gray-100 text-gray-400 border-gray-200 hover:border-gray-300'}`}
+                                                            className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-[var(--color-surface-sunken)] text-faint border-[var(--color-border)] hover:border-[var(--color-border)]'}`}
                                                         >
                                                             {label}
                                                         </button>
@@ -1214,7 +1214,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         {/* Charging energy field (create mode) */}
                                         {runMetadata.dataFlags.includes('charging') && (
                                             <div className="data-subpanel p-3">
-                                                <p className="text-sm font-semibold text-gray-700 mb-2">Charging Energy <span className="font-normal text-gray-400">(optional)</span></p>
+                                                <p className="text-sm font-semibold text-secondary mb-2">Charging Energy <span className="font-normal text-faint">(optional)</span></p>
                                                 <input
                                                     type="number"
                                                     placeholder="Energy added (kWh)"
@@ -1223,7 +1223,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                     onChange={(e) => setRunMetadata({...runMetadata, energyKwh: e.target.value})}
                                                     className="form-input w-full"
                                                 />
-                                                <p className="text-xs text-gray-400 mt-1">
+                                                <p className="text-xs text-faint mt-1">
                                                     Energy measured at charger or vehicle — <em>energy in</em>
                                                 </p>
                                                 <input
@@ -1239,7 +1239,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         {/* Range test fields */}
                                         {runMetadata.dataFlags.includes('range') && (
                                             <div className="data-subpanel p-4 space-y-3">
-                                                <p className="text-sm font-semibold text-gray-700">Range Test Details</p>
+                                                <p className="text-sm font-semibold text-secondary">Range Test Details</p>
                                                 <div className="form-grid gap-3">
                                                     <input
                                                         placeholder="Source (e.g., Out of Spec)"
@@ -1318,7 +1318,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     </>
                                 )}
                                 <div>
-                                    <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer mb-2">
+                                    <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer mb-2">
                                         <input
                                             type="checkbox"
                                             checked={noHeaders}
@@ -1336,7 +1336,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     <div className="csv-drop-zone">
                                         <label className="cursor-pointer">
                                             <span className="text-blue-600 font-medium">Click to upload CSV file</span>
-                                            <span className="block text-xs text-gray-400 mt-1">Optional — attach data points to this record</span>
+                                            <span className="block text-xs text-faint mt-1">Optional — attach data points to this record</span>
                                             <input
                                                 type="file"
                                                 accept=".csv"
@@ -1346,7 +1346,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         </label>
                                     </div>
                                     <div className="mt-3">
-                                        <p className="text-xs text-gray-400 mb-1">Or paste CSV text directly:</p>
+                                        <p className="text-xs text-faint mb-1">Or paste CSV text directly:</p>
                                         <textarea
                                             rows={4}
                                             placeholder={"soc,chargeRate,time\n50,100,0\n80,75,15\n…"}
@@ -1377,11 +1377,11 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                     {uploadStep === 'mapping' && (
                         <div>
                             <h3 className="section-title mb-4">Map CSV Fields</h3>
-                            <p className="text-gray-600 mb-4">Match your CSV columns to standard fields. We've auto-detected some for you.</p>
+                            <p className="text-secondary mb-4">Match your CSV columns to standard fields. We've auto-detected some for you.</p>
 
                             {/* In create mode, allow editing metadata here too */}
                             {uploadMode === 'create' && (
-                                <div className="mb-6 p-4 bg-gray-50 rounded">
+                                <div className="mb-6 p-4 bg-[var(--color-surface-muted)] rounded">
                                     <h4 className="font-semibold mb-3">Test Metadata</h4>
                                     <div className="space-y-3">
                                         <input
@@ -1521,12 +1521,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 <label className="flex items-center gap-2 cursor-pointer text-sm">
                                                     <input type="radio" name="joinKey" value="soc" checked={joinKey === 'soc'} onChange={() => setJoinKey('soc')} />
                                                     <span className="font-medium">SoC</span>
-                                                    <span className="text-gray-500">(charging curves, SoC-based data)</span>
+                                                    <span className="text-muted">(charging curves, SoC-based data)</span>
                                                 </label>
                                                 <label className="flex items-center gap-2 cursor-pointer text-sm">
                                                     <input type="radio" name="joinKey" value="time" checked={joinKey === 'time'} onChange={() => setJoinKey('time')} />
                                                     <span className="font-medium">Time</span>
-                                                    <span className="text-gray-500">(time-series, e.g. Time+Power → Time+SoC)</span>
+                                                    <span className="text-muted">(time-series, e.g. Time+Power → Time+SoC)</span>
                                                 </label>
                                             </div>
                                         </>
@@ -1584,7 +1584,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                 <div className="space-y-3">
                                     {/* Data-type flags — multi-select, at least one must remain active */}
                                     <div>
-                                        <p className="text-xs text-gray-500 mb-1">Data types (select all that apply)</p>
+                                        <p className="text-xs text-muted mb-1">Data types (select all that apply)</p>
                                         <div className="data-type-flags">
                                             {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                 const active = (editFormData.dataFlags || ['charging']).includes(key);
@@ -1600,7 +1600,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                 : [...cur, key];
                                                             return { ...f, dataFlags: next.length ? next : cur };
                                                         })}
-                                                        className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-gray-100 text-gray-400 border-gray-200 hover:border-gray-300'}`}
+                                                        className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-[var(--color-surface-sunken)] text-faint border-[var(--color-border)] hover:border-[var(--color-border)]'}`}
                                                     >
                                                         {label}
                                                     </button>
@@ -1635,7 +1635,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     {/* Charging energy field — shows energy_kwh for charging runs */}
                                     {(editFormData.dataFlags || ['charging']).includes('charging') && (
                                         <div className="data-subpanel p-3">
-                                            <p className="text-sm font-semibold text-gray-700 mb-2">Charging Energy</p>
+                                            <p className="text-sm font-semibold text-secondary mb-2">Charging Energy</p>
                                             <input
                                                 type="number"
                                                 placeholder="Energy added (kWh)"
@@ -1643,7 +1643,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 onChange={(e) => setEditFormData({...editFormData, energyKwh: e.target.value})}
                                                 className="form-input w-full"
                                             />
-                                            <p className="text-xs text-gray-400 mt-1">
+                                            <p className="text-xs text-faint mt-1">
                                                 Energy measured at charger or vehicle — <em>energy in</em> (not equal to energy used driving due to charging losses)
                                             </p>
                                             <input
@@ -1662,7 +1662,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                             <button
                                                 type="button"
                                                 onClick={() => handleToggleEstimatePanel(run.id)}
-                                                className="text-sm text-gray-600 hover:text-gray-800 flex items-center gap-1 mt-1"
+                                                className="text-sm text-secondary hover:text-[var(--color-text-primary)] flex items-center gap-1 mt-1"
                                             >
                                                 <span className="font-semibold">
                                                     {showEstimatePanel ? '▴ Estimate time from power' : '▾ Estimate time from power'}
@@ -1690,7 +1690,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     {/* Range test fields */}
                                     {(editFormData.dataFlags || ['charging']).includes('range') && (
                                         <div className="data-subpanel p-4 space-y-3">
-                                            <p className="text-sm font-semibold text-gray-700">Range Test Details</p>
+                                            <p className="text-sm font-semibold text-secondary">Range Test Details</p>
                                             <div className="form-grid gap-3">
                                                 <input
                                                     placeholder="Source (e.g., Out of Spec)"
@@ -1788,11 +1788,11 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                 <div className="mt-4 border-t pt-3">
                                     <button
                                         onClick={() => handleToggleDataTable(run.id)}
-                                        className="text-sm text-gray-600 hover:text-gray-800 flex items-center gap-1"
+                                        className="text-sm text-secondary hover:text-[var(--color-text-primary)] flex items-center gap-1"
                                     >
                                         <span className="font-semibold">{showDataTable ? '▴ Hide data' : '▾ Show data'}</span>
                                         {editData !== null && !editDataLoading && (
-                                            <span className="text-xs text-gray-400">({editData.length} rows)</span>
+                                            <span className="text-xs text-faint">({editData.length} rows)</span>
                                         )}
                                         {editDataDirty && (
                                             <span className="ml-1 text-xs text-orange-500 font-medium">● unsaved changes</span>
@@ -1850,9 +1850,9 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                     : null;
                                                 return (
                                                     <div className={`mb-3 p-3 rounded-lg border flex flex-wrap items-center gap-3 ${pct != null && pct > 5 ? 'bg-amber-50 border-amber-200' : 'bg-green-50 border-green-200'}`}>
-                                                        <span className="text-xs text-gray-700">
+                                                        <span className="text-xs text-secondary">
                                                             ⚡ <strong>Data points → {editCalcKwh} kWh</strong>
-                                                            {hasManual && <span className="text-gray-500"> (entered: {manual} kWh)</span>}
+                                                            {hasManual && <span className="text-muted"> (entered: {manual} kWh)</span>}
                                                         </span>
                                                         {pct != null && pct > 5 && (
                                                             <span className="text-xs bg-amber-100 text-amber-800 border border-amber-300 px-2 py-0.5 rounded-full font-medium">
@@ -1865,23 +1865,23 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                             </span>
                                                         )}
                                                         {!hasManual && (
-                                                            <span className="text-xs text-gray-400">Enter energy (kWh) above to compare</span>
+                                                            <span className="text-xs text-faint">Enter energy (kWh) above to compare</span>
                                                         )}
                                                     </div>
                                                 );
                                             })()}
                                             {editDataLoading ? (
-                                                <p className="text-sm text-gray-500 py-4 text-center">Loading…</p>
+                                                <p className="text-sm text-muted py-4 text-center">Loading…</p>
                                             ) : (
                                                 <>
                                                     <div className="overflow-auto rounded border" style={{ maxHeight: 360 }}>
                                                         <table className="w-full text-xs border-collapse">
-                                                            <thead className="bg-gray-50 sticky top-0 z-10 border-b">
+                                                            <thead className="bg-[var(--color-surface-muted)] sticky top-0 z-10 border-b">
                                                                 <tr>
-                                                                    <th className="px-2 py-1.5 text-left text-gray-500 font-medium w-8">#</th>
+                                                                    <th className="px-2 py-1.5 text-left text-muted font-medium w-8">#</th>
                                                                     {/* Read-only timestamp column — only rendered when data has timestamps */}
                                                                     {editData?.some(r => r.timestamp != null) && (
-                                                                        <th className="px-2 py-1.5 text-left text-gray-500 font-medium whitespace-nowrap">
+                                                                        <th className="px-2 py-1.5 text-left text-muted font-medium whitespace-nowrap">
                                                                             Timestamp
                                                                         </th>
                                                                     )}
@@ -1890,12 +1890,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                         const isActive   = sortField === field;
                                                                         const indicator  = isActive ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
                                                                         return (
-                                                                        <th key={field} className="px-2 py-1.5 text-left text-gray-500 font-medium">
+                                                                        <th key={field} className="px-2 py-1.5 text-left text-muted font-medium">
                                                                             <div className="flex flex-col gap-0.5">
                                                                                 <button
                                                                                     onClick={() => handleSortByField(field)}
                                                                                     title={`Sort by ${label}`}
-                                                                                    className={`text-left hover:text-gray-800 transition-colors ${isActive ? 'text-blue-600 font-semibold' : ''}`}
+                                                                                    className={`text-left hover:text-[var(--color-text-primary)] transition-colors ${isActive ? 'text-blue-600 font-semibold' : ''}`}
                                                                                 >
                                                                                     {label}{indicator}
                                                                                 </button>
@@ -1919,7 +1919,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                                         <button
                                                                                             onClick={() => handleClearColumn(field)}
                                                                                             title={`Clear all ${label} values`}
-                                                                                            className="text-[10px] font-normal rounded px-1 leading-tight w-fit text-gray-400 border border-transparent hover:text-red-500 hover:bg-red-50 hover:border-red-200 transition-colors"
+                                                                                            className="text-[10px] font-normal rounded px-1 leading-tight w-fit text-faint border border-transparent hover:text-red-500 hover:bg-red-50 hover:border-red-200 transition-colors"
                                                                                         >
                                                                                             ×clr
                                                                                         </button>
@@ -1933,14 +1933,14 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                             </thead>
                                                             <tbody>
                                                                 {(editData || []).map((row, i) => (
-                                                                    <tr key={i} className={`border-t ${i % 2 !== 0 ? 'bg-gray-50/50' : ''}`}>
+                                                                    <tr key={i} className={`border-t ${i % 2 !== 0 ? 'bg-[var(--color-surface-muted)]' : ''}`}>
                                                                         {/* Row # + delete button share the first cell */}
-                                                                        <td className="px-1 py-0.5 text-gray-400 select-none whitespace-nowrap">
+                                                                        <td className="px-1 py-0.5 text-faint select-none whitespace-nowrap">
                                                                             <div className="flex items-center gap-1">
                                                                                 {canEdit(vehicle) && (
                                                                                     <button
                                                                                         onClick={() => handleDeleteDataRow(i)}
-                                                                                        className="w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors leading-none flex-shrink-0"
+                                                                                        className="w-5 h-5 flex items-center justify-center rounded text-faint hover:text-red-500 hover:bg-red-50 transition-colors leading-none flex-shrink-0"
                                                                                         title="Remove row"
                                                                                     >×</button>
                                                                                 )}
@@ -1949,10 +1949,10 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                         </td>
                                                                         {/* Timestamp cell — read-only, only rendered when column is visible */}
                                                                         {editData?.some(r => r.timestamp != null) && (
-                                                                            <td className="px-2 py-0.5 text-gray-500 whitespace-nowrap text-[11px] font-mono select-all">
+                                                                            <td className="px-2 py-0.5 text-muted whitespace-nowrap text-[11px] font-mono select-all">
                                                                                 {row.timestamp
                                                                                     ? new Date(row.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-                                                                                    : <span className="text-gray-300">—</span>}
+                                                                                    : <span className="text-faint">—</span>}
                                                                             </td>
                                                                         )}
                                                                         {['soc','chargeRate','time','range','temperature'].map(field => (
@@ -1966,7 +1966,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                                     className={`w-full text-xs p-0.5 rounded outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${
                                                                                         canEdit(vehicle)
                                                                                             ? 'bg-transparent hover:bg-white focus:bg-white focus:ring-1 focus:ring-blue-300'
-                                                                                            : 'bg-transparent text-gray-600 cursor-default'
+                                                                                            : 'bg-transparent text-secondary cursor-default'
                                                                                     }`}
                                                                                 />
                                                                             </td>
@@ -2041,7 +2041,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                             className={`text-sm px-2 py-1 rounded transition-colors ${
                                                 run.isDefault
                                                     ? 'bg-blue-100 text-blue-700 hover:bg-red-50 hover:text-red-600 border border-blue-200 hover:border-red-200'
-                                                    : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
+                                                    : 'text-faint hover:text-green-600 hover:bg-green-50'
                                             }${!canCreate ? ' opacity-50 cursor-not-allowed' : ''}`}
                                         >
                                             {run.isDefault
@@ -2107,7 +2107,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     </div>
                                     {/* Color picker — lower right */}
                                     <div className="run-actions-row">
-                                        <label className="flex items-center gap-1 text-xs text-gray-400 cursor-pointer">
+                                        <label className="flex items-center gap-1 text-xs text-faint cursor-pointer">
                                             <input
                                                 type="color"
                                                 value={run.color || '#3b82f6'}
@@ -2120,7 +2120,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 value={run.color || '#3b82f6'}
                                                 onChange={e => onUpdateRun(run.id, { color: e.target.value })}
                                                 onBlur={e => { if (!/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) onUpdateRun(run.id, { color: run.color || '#3b82f6' }); }}
-                                                className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-gray-600"
+                                                className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-secondary"
                                                 placeholder="#3b82f6"
                                                 maxLength={7}
                                             />
@@ -2144,7 +2144,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             {(inheritedRuns.length > 0 || (isContributor && canEdit(vehicle))) && (
                 <div className="mt-6">
                     <div className="flex items-center gap-3 mb-3">
-                        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">
+                        <h3 className="text-sm font-semibold text-muted uppercase tracking-wider">
                             Inherited Tests
                         </h3>
                         {isContributor && canEdit(vehicle) && !showAddLink && (
@@ -2176,7 +2176,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                 };
                                 const runColor = run.color || '#9ca3af';
                                 return (
-                                    <div key={run.id} className="card border border-dashed border-gray-300 bg-gray-50">
+                                    <div key={run.id} className="card border border-dashed border-[var(--color-border)] bg-[var(--color-surface-muted)]">
                                         <div className="run-card-header">
                                             <div className="flex-1">
                                                 <div className="flex items-center gap-2 flex-wrap">
@@ -2201,7 +2201,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                     <span className="text-xs bg-amber-100 text-amber-700 border border-amber-300 rounded-full px-2 py-0.5">Estimated</span>
                                                 </div>
                                                 <div className="run-meta">
-                                                    <p className="text-gray-500">Inherited from: <span className="font-medium text-gray-700">{srcName}</span></p>
+                                                    <p className="text-muted">Inherited from: <span className="font-medium text-secondary">{srcName}</span></p>
                                                     <p>Date: {run.date}</p>
                                                     {(run.softwareVersion || run.software_version) && <p>Software: {run.softwareVersion || run.software_version}</p>}
                                                     {run.conditions && <p>Notes: {run.conditions}</p>}
@@ -2241,7 +2241,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 </div>
                                                 {/* Row 2: Color Picker | Scale × */}
                                                 <div className="run-actions-row flex-wrap">
-                                                    <label className="flex items-center gap-1 text-xs text-gray-500">
+                                                    <label className="flex items-center gap-1 text-xs text-muted">
                                                         <input
                                                             type="color"
                                                             value={runColor}
@@ -2254,13 +2254,13 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                             value={runColor}
                                                             onChange={e => updateRunColor(vehicle.id, run.id, e.target.value)}
                                                             onBlur={e => { if (!/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) updateRunColor(vehicle.id, run.id, runColor); }}
-                                                            className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-gray-700"
+                                                            className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-secondary"
                                                             placeholder="#9ca3af"
                                                             maxLength={7}
                                                         />
                                                     </label>
                                                     {isContributor && canEdit(vehicle) ? (
-                                                        <label className="flex items-center gap-1 text-xs text-gray-500">
+                                                        <label className="flex items-center gap-1 text-xs text-muted">
                                                             <span>Scale ×</span>
                                                             <input
                                                                 type="number"
@@ -2271,13 +2271,13 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                 step="0.001"
                                                                 min="0.001"
                                                                 placeholder="1.0"
-                                                                className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-gray-700"
+                                                                className="w-20 px-1.5 py-0.5 border rounded text-xs font-mono text-secondary"
                                                                 title="Scaling factor (blank = 1.0)"
                                                             />
                                                         </label>
                                                     ) : (
                                                         sf !== 1 && sf != null && (
-                                                            <span className="text-xs font-mono text-gray-500">×{sf}</span>
+                                                            <span className="text-xs font-mono text-muted">×{sf}</span>
                                                         )
                                                     )}
                                                 </div>
@@ -2353,17 +2353,17 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     </select>
                                 </div>
                                 {sourceVehicles.length === 0 && (
-                                    <p className="text-xs text-gray-400 mt-1">
+                                    <p className="text-xs text-faint mt-1">
                                         No other vehicles have unlinked tests.
                                     </p>
                                 )}
                                 {selectedSrc && runsToLink.length === 0 && (
-                                    <p className="text-xs text-gray-400 mt-1">
+                                    <p className="text-xs text-faint mt-1">
                                         All tests from {selectedSrc.name} are already linked.
                                     </p>
                                 )}
                                 {selectedSrc && runsToLink.length > 0 && (
-                                    <p className="text-xs text-gray-500 mt-1">
+                                    <p className="text-xs text-muted mt-1">
                                         Will link {runsToLink.length} test{runsToLink.length !== 1 ? 's' : ''}: {runsToLink.map(r => r.name).join(', ')}
                                     </p>
                                 )}
@@ -2484,7 +2484,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                     <div className="copy-to-modal-panel">
                         <div className="modal-header px-5 py-4 border-b">
                             <h3 className="font-semibold text-base">Copy test to another vehicle</h3>
-                            <p className="text-xs text-gray-500 mt-0.5">"{copyToRun.name}" will be copied as an independent run</p>
+                            <p className="text-xs text-muted mt-0.5">"{copyToRun.name}" will be copied as an independent run</p>
                         </div>
                         <div className="px-5 py-4">
                             <label className="block text-sm font-medium mb-2">Select destination vehicle</label>

--- a/src/components/SpecsChartView.jsx
+++ b/src/components/SpecsChartView.jsx
@@ -216,7 +216,7 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
         <>
         <div className="specs-chart-card">
             <div className="specs-chart-controls">
-                <label className="text-sm font-medium text-gray-600">Compare:</label>
+                <label className="text-sm font-medium text-secondary">Compare:</label>
                 <select
                     className="specs-chart-field-select"
                     value={selectedField}
@@ -263,8 +263,8 @@ export default function SpecsChartView({ vehicles, selectedField: controlledFiel
             </div>
             {chartImage && (
                 <div className="mt-3">
-                    <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
-                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                    <p className="text-xs text-faint mb-1.5">Right-click or long-press to copy / save</p>
+                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-[var(--color-border)]" />
                 </div>
             )}
         </div>

--- a/src/components/SpecsView.jsx
+++ b/src/components/SpecsView.jsx
@@ -190,7 +190,7 @@ export default function SpecsView({ selectedVehicleIds }) {
 
         const customRows = customKeys.map(customKey => (
             <tr key={`${cat.key}--custom--${customKey}`}>
-                <td className="specs-table-cell font-medium text-sm text-gray-500 italic">
+                <td className="specs-table-cell font-medium text-sm text-muted italic">
                     {formatCustomKey(customKey)}
                 </td>
                 {resolvedVehicles.map(rv => {

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -24,9 +24,9 @@ function TestCountPills({ vehicle }) {
     return (
         <p className="flex flex-wrap items-baseline gap-x-1.5">
             <span>Tests:</span>
-            {chargingCount > 0 && <span className="text-xs font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
-            {rangeCount    > 0 && <span className="text-xs font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
-            {epaCount      > 0 && <span className="text-xs font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
+            {chargingCount > 0 && <span className="text-[13px] font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
+            {rangeCount    > 0 && <span className="text-[13px] font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
+            {epaCount      > 0 && <span className="text-[13px] font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
         </p>
     );
 }

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -24,9 +24,9 @@ function TestCountPills({ vehicle }) {
     return (
         <p className="flex flex-wrap items-baseline gap-x-1.5">
             <span>Tests:</span>
-            {chargingCount > 0 && <span className="text-[13px] font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
-            {rangeCount    > 0 && <span className="text-[13px] font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
-            {epaCount      > 0 && <span className="text-[13px] font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
+            {chargingCount > 0 && <span className="text-xs font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
+            {rangeCount    > 0 && <span className="text-xs font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
+            {epaCount      > 0 && <span className="text-xs font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
         </p>
     );
 }
@@ -308,7 +308,7 @@ export default function VehiclesView({
         if (!user) return null;
         const base = `flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full border transition${fullWidth ? ' w-full justify-center' : ''}`;
         const pubCls = 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200';
-        const privCls = 'bg-gray-100 text-gray-500 border-gray-300 hover:bg-gray-200';
+        const privCls = 'bg-[var(--color-surface-sunken)] text-muted border-[var(--color-border)] hover:bg-[var(--color-surface-muted)]';
         const isPublic = vehicle.visibility === 'public';
         if (canPublish()) {
             return (
@@ -322,7 +322,7 @@ export default function VehiclesView({
             );
         }
         return (
-            <span className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300' : 'bg-gray-100 text-gray-500 border-gray-300'}`}>
+            <span className={`${base} ${isPublic ? 'bg-green-100 text-green-700 border-green-300' : 'bg-[var(--color-surface-sunken)] text-muted border-[var(--color-border)]'}`}>
                 {isPublic ? '🌐 Public' : '🔒 Private'}
             </span>
         );
@@ -335,7 +335,7 @@ export default function VehiclesView({
                 {canEdit(vehicle) && (
                     <button
                         onClick={(e) => handleEdit(vehicle, e)}
-                        className="px-3 py-1 rounded-md text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition"
+                        className="px-3 py-1 rounded-md text-xs font-medium bg-[var(--color-surface-sunken)] text-secondary hover:bg-[var(--color-surface-muted)] transition"
                     >
                         Edit
                     </button>
@@ -505,14 +505,14 @@ export default function VehiclesView({
                         <button
                             onClick={() => setViewMode('card')}
                             title="Card view"
-                            className={`px-2 py-1.5 transition ${viewMode === 'card' ? 'bg-gray-200 text-gray-800' : 'hover:bg-gray-100'}`}
+                            className={`px-2 py-1.5 transition ${viewMode === 'card' ? 'bg-[var(--color-surface-muted)] text-[var(--color-text-primary)]' : 'hover:bg-[var(--color-surface-sunken)]'}`}
                         >
                             <CardViewIcon />
                         </button>
                         <button
                             onClick={() => setViewMode('list')}
                             title="List view"
-                            className={`px-2 py-1.5 transition ${viewMode === 'list' ? 'bg-gray-200 text-gray-800' : 'hover:bg-gray-100'}`}
+                            className={`px-2 py-1.5 transition ${viewMode === 'list' ? 'bg-[var(--color-surface-muted)] text-[var(--color-text-primary)]' : 'hover:bg-[var(--color-surface-sunken)]'}`}
                         >
                             <ListViewIcon />
                         </button>
@@ -559,7 +559,7 @@ export default function VehiclesView({
                         className={`text-sm px-3 py-2 rounded border transition flex-shrink-0 ${
                             editingOrder
                                 ? 'bg-blue-50 border-blue-300 text-blue-700'
-                                : 'bg-gray-50 border-gray-200 text-gray-500 hover:bg-gray-100'
+                                : 'bg-[var(--color-surface-muted)] border-[var(--color-border)] text-muted hover:bg-[var(--color-surface-sunken)]'
                         }`}
                         style={editingOrder ? { backgroundColor: 'var(--color-primary-light)', borderColor: 'var(--color-primary)', color: 'var(--color-primary-text)' } : {}}
                     >
@@ -571,7 +571,7 @@ export default function VehiclesView({
             {/* Tag filter bar — quad-state: N/A → OR (green) → AND (blue) → NOT (red) */}
             {tags.length > 0 && (
                 <div className="tag-filter-bar">
-                    <span className="text-sm font-medium text-gray-500 dark:text-slate-300 flex-shrink-0">Filter:</span>
+                    <span className="text-sm font-medium text-secondary flex-shrink-0">Filter:</span>
                     {tags.map(tag => {
                         const state = tagFilterStates[tag.id]; // undefined = 'na'
                         const stateClass = state === 'or' ? 'tag-filter-or'
@@ -596,7 +596,7 @@ export default function VehiclesView({
                     {Object.keys(tagFilterStates).length > 0 && (
                         <button
                             onClick={() => setTagFilterStates({})}
-                            className="text-xs text-gray-400 hover:text-gray-600 underline ml-1 flex-shrink-0"
+                            className="text-xs text-faint hover:text-secondary underline ml-1 flex-shrink-0"
                         >
                             Clear
                         </button>
@@ -611,7 +611,7 @@ export default function VehiclesView({
             {/* Manufacturer filter bar — tri-state: N/A → OR (green) → NOT (red) → N/A */}
             {manufacturers.length > 0 && (
                 <div className="tag-filter-bar">
-                    <span className="text-sm font-medium text-gray-500 dark:text-slate-300 flex-shrink-0">Brand:</span>
+                    <span className="text-sm font-medium text-secondary flex-shrink-0">Brand:</span>
                     {manufacturers.map(mfg => {
                         const state = mfgFilterStates[mfg.id];
                         const stateClass = state === 'or'  ? 'tag-filter-or'
@@ -634,7 +634,7 @@ export default function VehiclesView({
                     {Object.keys(mfgFilterStates).length > 0 && (
                         <button
                             onClick={() => { setMfgFilterStates({}); setModelFilter(new Set()); }}
-                            className="text-xs text-gray-400 hover:text-gray-600 underline ml-1 flex-shrink-0"
+                            className="text-xs text-faint hover:text-secondary underline ml-1 flex-shrink-0"
                         >
                             Clear
                         </button>
@@ -645,7 +645,7 @@ export default function VehiclesView({
             {/* Model filter bar — visible when a brand is selected and multiple models exist */}
             {availableModels.length > 1 && (
                 <div className="tag-filter-bar">
-                    <span className="text-sm font-medium text-gray-500 dark:text-slate-300 flex-shrink-0">Model:</span>
+                    <span className="text-sm font-medium text-secondary flex-shrink-0">Model:</span>
                     {availableModels.map(model => {
                         const active = modelFilter.has(model);
                         return (
@@ -666,7 +666,7 @@ export default function VehiclesView({
                     {modelFilter.size > 0 && (
                         <button
                             onClick={() => setModelFilter(new Set())}
-                            className="text-xs text-gray-400 hover:text-gray-600 underline ml-1 flex-shrink-0"
+                            className="text-xs text-faint hover:text-secondary underline ml-1 flex-shrink-0"
                         >
                             Clear
                         </button>
@@ -711,8 +711,8 @@ export default function VehiclesView({
                         return (
                             <div key={vehicle.id} className="contents">
                                 {showMfgHeader && (
-                                    <div className="col-span-full pt-2 pb-1 border-b border-gray-200 dark:border-slate-700 mb-1">
-                                        <h3 className="text-sm font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wider">{mfgName}</h3>
+                                    <div className="col-span-full pt-2 pb-1 border-b border-[var(--color-border)] mb-1">
+                                        <h3 className="text-sm font-semibold text-secondary uppercase tracking-wider">{mfgName}</h3>
                                     </div>
                                 )}
                                 <div
@@ -775,8 +775,8 @@ export default function VehiclesView({
                                             {/* Left: vehicle info */}
                                             <div className="flex-1 min-w-0">
                                                 <h3 className="text-xl font-bold mb-1">{vehicle.name}</h3>
-                                                <p className="text-gray-600 dark:text-slate-200 mb-2">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
-                                                <div className="text-sm text-gray-700 dark:text-slate-200 space-y-1">
+                                                <p className="text-secondary mb-2">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
+                                                <div className="text-sm text-secondary space-y-1">
                                                     {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                                     {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                                     <TestCountPills vehicle={vehicle} />
@@ -827,8 +827,8 @@ export default function VehiclesView({
                         return (
                             <div key={vehicle.id}>
                                 {showMfgHeader && (
-                                    <div className="pt-2 pb-1 border-b border-gray-200 dark:border-slate-700 mb-1">
-                                        <h3 className="text-sm font-semibold text-gray-500 dark:text-slate-300 uppercase tracking-wider">{mfgName}</h3>
+                                    <div className="pt-2 pb-1 border-b border-[var(--color-border)] mb-1">
+                                        <h3 className="text-sm font-semibold text-secondary uppercase tracking-wider">{mfgName}</h3>
                                     </div>
                                 )}
                                 <div
@@ -881,12 +881,12 @@ export default function VehiclesView({
                                     {/* Name + make + tags */}
                                     <div className="flex-1 min-w-0">
                                         <h3 className="font-bold text-lg leading-tight truncate">{vehicle.name}</h3>
-                                        <p className="text-gray-500 dark:text-slate-300 text-sm mb-1">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
+                                        <p className="text-secondary text-sm mb-1">{[vehicle.make, vehicle.model, vehicle.trim, vehicle.year].filter(Boolean).join(' · ')}</p>
                                         <TagPills vehicle={vehicle} />
                                     </div>
 
                                     {/* Specs */}
-                                    <div className="text-sm text-gray-600 dark:text-slate-200 space-y-0.5 w-36 flex-shrink-0 hidden sm:block">
+                                    <div className="text-sm text-secondary space-y-0.5 w-36 flex-shrink-0 hidden sm:block">
                                         {vehicle.battery && <p>Battery: {vehicle.battery} kWh</p>}
                                         {vehicle.range && <p>Range: {fmtDistance(vehicle.range, units)}</p>}
                                         {vehicle.power && <p>Power: {vehicle.power} kW</p>}
@@ -919,7 +919,7 @@ export default function VehiclesView({
                 <div className="vehicle-pagination">
                     <button onClick={() => setVehiclePage(1)} disabled={vehiclePage === 1} className="pagination-btn">«</button>
                     <button onClick={() => setVehiclePage(p => p - 1)} disabled={vehiclePage === 1} className="pagination-btn">‹</button>
-                    <span className="text-sm text-gray-600 dark:text-slate-300">Page {vehiclePage} of {totalPages}</span>
+                    <span className="text-sm text-secondary">Page {vehiclePage} of {totalPages}</span>
                     <button onClick={() => setVehiclePage(p => p + 1)} disabled={vehiclePage === totalPages} className="pagination-btn">›</button>
                     <button onClick={() => setVehiclePage(totalPages)} disabled={vehiclePage === totalPages} className="pagination-btn">»</button>
                 </div>

--- a/src/components/ViewSpecsModal.jsx
+++ b/src/components/ViewSpecsModal.jsx
@@ -64,7 +64,7 @@ export default function ViewSpecsModal({ vehicle, onClose }) {
                     <h3 className="section-title mb-0">Specs — {liveVehicle.name}</h3>
                     <button
                         onClick={handleClose}
-                        className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+                        className="text-faint hover:text-secondary text-xl leading-none"
                         aria-label="Close"
                     >
                         ×

--- a/src/components/admin/RolesPermissions.jsx
+++ b/src/components/admin/RolesPermissions.jsx
@@ -21,18 +21,18 @@ export default function RolesPermissions({ users, loading, saving, currentUserId
                 <div className="card p-0 overflow-hidden">
                     <table className="w-full text-sm">
                         <thead>
-                            <tr className="border-b bg-gray-50 text-left">
-                                <th className="px-4 py-3 font-semibold text-gray-600">Email</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Joined</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Role</th>
-                                <th className="px-4 py-3 font-semibold text-gray-600">Change Role</th>
+                            <tr className="border-b bg-[var(--color-surface-muted)] text-left">
+                                <th className="px-4 py-3 font-semibold text-secondary">Email</th>
+                                <th className="px-4 py-3 font-semibold text-secondary">Joined</th>
+                                <th className="px-4 py-3 font-semibold text-secondary">Role</th>
+                                <th className="px-4 py-3 font-semibold text-secondary">Change Role</th>
                             </tr>
                         </thead>
                         <tbody>
                             {users.map(u => (
-                                <tr key={u.id} className="border-t hover:bg-gray-50/50 transition">
-                                    <td className="px-4 py-3 font-medium text-gray-800">{u.email}</td>
-                                    <td className="px-4 py-3 text-gray-500">
+                                <tr key={u.id} className="border-t hover:bg-[var(--color-surface-muted)] transition">
+                                    <td className="px-4 py-3 font-medium text-[var(--color-text-primary)]">{u.email}</td>
+                                    <td className="px-4 py-3 text-muted">
                                         {new Date(u.created_at).toLocaleDateString()}
                                     </td>
                                     <td className="px-4 py-3">
@@ -45,7 +45,7 @@ export default function RolesPermissions({ users, loading, saving, currentUserId
                                     </td>
                                     <td className="px-4 py-3">
                                         {u.id === currentUserId ? (
-                                            <span className="text-xs text-gray-400 italic">can't change own role</span>
+                                            <span className="text-xs text-faint italic">can't change own role</span>
                                         ) : (
                                             <div className="flex gap-1 flex-wrap">
                                                 {ROLES.map(role => (
@@ -56,7 +56,7 @@ export default function RolesPermissions({ users, loading, saving, currentUserId
                                                         className={`px-2.5 py-1 rounded border text-xs font-medium transition ${
                                                             u.role === role
                                                                 ? 'opacity-40 cursor-default'
-                                                                : 'bg-white hover:bg-gray-100 border-gray-300 text-gray-700'
+                                                                : 'bg-[var(--color-surface-input)] hover:bg-[var(--color-surface-sunken)] border-[var(--color-border)] text-secondary'
                                                         }`}
                                                     >
                                                         {saving === u.id && u.role !== role ? '…' : role}

--- a/src/components/epa/AuditHistory.jsx
+++ b/src/components/epa/AuditHistory.jsx
@@ -48,26 +48,26 @@ export default function AuditHistory({ group, getEpaAuditForGroup }) {
     };
 
     return (
-        <div className="mt-3 border-t border-gray-100 dark:border-slate-700 pt-2">
+        <div className="mt-3 border-t border-[var(--color-border)] pt-2">
             <button
                 type="button"
                 onClick={toggle}
-                className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:underline"
+                className="text-xs font-medium text-muted hover:underline"
             >
                 {open ? '▾' : '▸'} Edit history{rows?.length ? ` (${rows.length})` : ''}
             </button>
             {open && (
                 <div className="mt-2 text-[11px]">
-                    {loading && <p className="text-gray-400 italic">Loading…</p>}
+                    {loading && <p className="text-faint italic">Loading…</p>}
                     {error && <p className="text-red-500">Error: {error}</p>}
                     {!loading && !error && rows && rows.length === 0 && (
-                        <p className="text-gray-400 italic">No edits recorded yet.</p>
+                        <p className="text-faint italic">No edits recorded yet.</p>
                     )}
                     {!loading && rows && rows.length > 0 && (
                         <div className="max-h-56 overflow-y-auto">
                             <table className="w-full">
                                 <thead>
-                                    <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
+                                    <tr className="text-faint text-[10px] uppercase tracking-wide text-left">
                                         <th className="font-semibold pr-2 py-0.5">When</th>
                                         <th className="font-semibold pr-2">Field</th>
                                         <th className="font-semibold pr-2">Change</th>
@@ -76,17 +76,17 @@ export default function AuditHistory({ group, getEpaAuditForGroup }) {
                                 </thead>
                                 <tbody className="font-mono">
                                     {rows.map(r => (
-                                        <tr key={r.id} className="border-t border-gray-100 dark:border-slate-800 align-top">
-                                            <td className="pr-2 py-0.5 text-gray-400 whitespace-nowrap">{timeAgo(r.edited_at)}</td>
+                                        <tr key={r.id} className="border-t border-[var(--color-border)] align-top">
+                                            <td className="pr-2 py-0.5 text-faint whitespace-nowrap">{timeAgo(r.edited_at)}</td>
                                             <td className="pr-2">
-                                                <span className="text-gray-400">{TABLE_LABEL[r.table_name] || r.table_name}·</span>{r.field}
+                                                <span className="text-faint">{TABLE_LABEL[r.table_name] || r.table_name}·</span>{r.field}
                                             </td>
                                             <td className="pr-2">
-                                                <span className="text-gray-400 line-through">{r.prior_value ?? '∅'}</span>
+                                                <span className="text-faint line-through">{r.prior_value ?? '∅'}</span>
                                                 {' → '}
-                                                <span className="text-gray-700 dark:text-slate-200">{r.new_value ?? '∅'}</span>
+                                                <span className="text-secondary">{r.new_value ?? '∅'}</span>
                                             </td>
-                                            <td className="text-gray-400 italic">{r.source_citation || '—'}</td>
+                                            <td className="text-faint italic">{r.source_citation || '—'}</td>
                                         </tr>
                                     ))}
                                 </tbody>

--- a/src/components/epa/CuratorField.jsx
+++ b/src/components/epa/CuratorField.jsx
@@ -48,7 +48,7 @@ export default function CuratorField({
 
     return (
         <div className="flex items-center justify-between gap-2 py-0.5">
-            <span className={`shrink-0 flex items-center gap-1 ${used ? 'text-gray-700 dark:text-slate-200 font-semibold' : 'text-gray-500 dark:text-slate-400'}`}>
+            <span className={`shrink-0 flex items-center gap-1 ${used ? 'text-secondary font-semibold' : 'text-muted'}`}>
                 {used && <span title="Used in a derived calculation" className="text-indigo-500">∗</span>}
                 {label}
                 {tooltip && <InfoIcon text={tooltip} position="right" />}
@@ -59,7 +59,7 @@ export default function CuratorField({
                     <span title="Curator-overridden value" className="text-amber-500 text-[9px] font-bold">●</span>
                 )}
                 {overrideSource === 'csv' && (
-                    <span title="Imported from CSV" className="text-gray-300 dark:text-slate-600 text-[9px]">csv</span>
+                    <span title="Imported from CSV" className="text-faint text-[9px]">csv</span>
                 )}
             </span>
             {/* Fixed-width input + always-present unit column so right edges align
@@ -81,7 +81,7 @@ export default function CuratorField({
                 ) : (
                     <span className="font-mono text-xs text-right w-28">{value ?? '—'}</span>
                 )}
-                <span className="text-gray-400 text-[10px] w-10 shrink-0">{unit || ''}</span>
+                <span className="text-faint text-[10px] w-10 shrink-0">{unit || ''}</span>
             </span>
         </div>
     );

--- a/src/components/epa/DerivedValues.jsx
+++ b/src/components/epa/DerivedValues.jsx
@@ -20,10 +20,10 @@ const SOURCE_LABEL = {
 
 function DerivedRow({ label, tooltip, result, format }) {
     const { value, source, certain, flags = [] } = result || {};
-    const meta = SOURCE_LABEL[source] || { text: source || '—', cls: 'text-gray-400' };
+    const meta = SOURCE_LABEL[source] || { text: source || '—', cls: 'text-faint' };
     return (
         <div className="flex items-center justify-between gap-2 py-0.5">
-            <span className="text-gray-500 dark:text-slate-400 flex items-center gap-1">
+            <span className="text-muted flex items-center gap-1">
                 {label}
                 {tooltip && <InfoIcon text={tooltip} position="right" />}
             </span>
@@ -44,7 +44,7 @@ export default function DerivedValues({ group }) {
     const d = deriveAll(group);
     return (
         <div>
-            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                 Derived Values
             </div>
             <DerivedRow
@@ -64,7 +64,7 @@ export default function DerivedValues({ group }) {
                 format={v => `${v.toFixed(0)} mph`}
             />
             {d.effectiveAdjustmentFactor?.basis?.method && (
-                <p className="text-[10px] text-gray-400 italic mt-1">
+                <p className="text-[10px] text-faint italic mt-1">
                     Method: {d.effectiveAdjustmentFactor.basis.method}
                 </p>
             )}

--- a/src/components/epa/EpaCuratorEditor.jsx
+++ b/src/components/epa/EpaCuratorEditor.jsx
@@ -19,7 +19,7 @@ import { ASSUMED_CHARGER_EFF, DEFAULT_ACCESSORY_W } from '../../constants/epa';
 function Section({ title, children }) {
     return (
         <div className="mb-4">
-            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">{title}</div>
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">{title}</div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">{children}</div>
         </div>
     );
@@ -118,7 +118,7 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
         return { ...dbGroup, ...edits.group, epa_coefficient_sets: sets, epa_tests: tests };
     }, [dbGroup, edits]);
 
-    if (loading) return <p className="text-xs text-gray-400 italic py-2">Loading curator data…</p>;
+    if (loading) return <p className="text-xs text-faint italic py-2">Loading curator data…</p>;
     if (error)   return <p className="text-xs text-red-500 py-2">Error: {error}</p>;
     if (!group)  return null;
 
@@ -214,9 +214,9 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
     };
 
     return (
-        <div className="border-t border-gray-100 dark:border-slate-700 mt-3 pt-3">
+        <div className="border-t border-[var(--color-border)] mt-3 pt-3">
             <div className="flex items-center justify-between gap-2 mb-2">
-                <p className="text-[10px] text-gray-400 italic">
+                <p className="text-[10px] text-faint italic">
                     Editing shared EPA reference data — changes apply to every vehicle linked to this test group.
                 </p>
                 <a
@@ -233,7 +233,7 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
             {/* Optional source citation applied to subsequent edits' audit entries */}
             {canEdit && (
                 <div className="flex items-center gap-2 mb-3 text-xs">
-                    <span className="text-gray-500 dark:text-slate-400 shrink-0">Source citation</span>
+                    <span className="text-muted shrink-0">Source citation</span>
                     <input
                         type="text"
                         value={citation}
@@ -292,13 +292,13 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
                 shown for reference. The steady-state curve uses the City/Highway set. */}
             {otherSets.length > 0 && (
                 <div className="mb-4">
-                    <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                    <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                         Other Coefficient Sets
                         <span className="normal-case font-normal"> — reference only (Cold-CO / US06; not used by the curve)</span>
                     </div>
                     <table className="w-full text-xs">
                         <thead>
-                            <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
+                            <tr className="text-faint text-[10px] uppercase tracking-wide text-left">
                                 <th className="font-semibold pr-3">Category</th>
                                 <th className="font-semibold pr-3">Target A / B / C</th>
                                 <th className="font-semibold">Set A / B / C</th>
@@ -306,10 +306,10 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
                         </thead>
                         <tbody className="font-mono">
                             {otherSets.map(s => (
-                                <tr key={s.id ?? s.category} className="border-t border-gray-100 dark:border-slate-800">
+                                <tr key={s.id ?? s.category} className="border-t border-[var(--color-border)]">
                                     <td className="pr-3 py-0.5 font-sans">{s.category}</td>
                                     <td className="pr-3">{coef(s.target_a)} / {coef(s.target_b)} / {coef(s.target_c)}</td>
-                                    <td className="text-gray-500 dark:text-slate-400">{coef(s.set_a)} / {coef(s.set_b)} / {coef(s.set_c)}</td>
+                                    <td className="text-muted">{coef(s.set_a)} / {coef(s.set_b)} / {coef(s.set_c)}</td>
                                 </tr>
                             ))}
                         </tbody>
@@ -354,7 +354,7 @@ export default function EpaCuratorEditor({ testGroupId, canEdit, onDirtyChange }
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
                 <DerivedValues group={group} />
             </div>
-            <p className="text-[10px] text-gray-400 mt-1">
+            <p className="text-[10px] text-faint mt-1">
                 <span className="text-indigo-500">∗</span> feeds a derived calculation below.
             </p>
 

--- a/src/components/epa/TestPhaseEditor.jsx
+++ b/src/components/epa/TestPhaseEditor.jsx
@@ -55,8 +55,8 @@ function PhaseRow({ phase, canEdit, onSave, onDelete }) {
     const set = (field) => (val) => onSave({ ...phase, [field]: val });
 
     return (
-        <tr className="border-t border-gray-100 dark:border-slate-700">
-            <td className="py-1 pr-2 text-gray-400 font-mono">{phase.phase_index}</td>
+        <tr className="border-t border-[var(--color-border)]">
+            <td className="py-1 pr-2 text-faint font-mono">{phase.phase_index}</td>
             <td className="py-1 pr-2">
                 {canEdit ? (
                     <select
@@ -75,7 +75,7 @@ function PhaseRow({ phase, canEdit, onSave, onDelete }) {
             <td className="py-1 pr-2">
                 <InlineNum value={phase.dc_energy_kwh} canEdit={canEdit} step="0.001" onSave={set('dc_energy_kwh')} />
             </td>
-            <td className="py-1 pr-2 text-right font-mono text-gray-500">{consumption ? `${consumption} Wh/mi` : '—'}</td>
+            <td className="py-1 pr-2 text-right font-mono text-muted">{consumption ? `${consumption} Wh/mi` : '—'}</td>
             <td className="py-1 text-right">
                 {canEdit && (
                     <button onClick={() => onDelete(phase)} className="text-red-500 hover:text-red-600 text-xs" title="Delete phase">✕</button>
@@ -134,7 +134,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
     });
 
     return (
-        <div className="border rounded-lg p-3 mb-2 border-gray-200 dark:border-slate-700">
+        <div className="border rounded-lg p-3 mb-2 border-[var(--color-border)]">
             <div className="flex items-center justify-between gap-2 mb-2">
                 <div className="flex items-center gap-2">
                     {canEdit ? (
@@ -150,7 +150,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                     ) : (
                         <span className="text-xs font-semibold">proc {test.procedure_code ?? '—'}</span>
                     )}
-                    <span className="font-mono text-xs text-gray-400">{test.test_number}</span>
+                    <span className="font-mono text-xs text-faint">{test.test_number}</span>
                 </div>
                 {canEdit && (
                     <button onClick={() => onDeleteTest(test)} className="btn btn-secondary text-xs py-0.5 px-2">Delete test</button>
@@ -173,7 +173,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
             {/* Phases */}
             <table className="w-full text-xs">
                 <thead>
-                    <tr className="text-gray-400 text-[10px] uppercase tracking-wide text-left">
+                    <tr className="text-faint text-[10px] uppercase tracking-wide text-left">
                         <th className="font-semibold pr-2" title="Position in the test sequence (Bag/Phase number). Identity comes from procedure order, not the data.">#</th>
                         <th className="font-semibold pr-2" title="UDDS / HWY / SS / Cold-UDDS / US06 / SC03. SS = steady-state depletion at a lab-chosen speed — stored for energy totals but NOT a valid efficiency anchor.">Phase</th>
                         <th className="font-semibold pr-2" title="Actual distance driven for this phase (miles).">Dist (mi)</th>
@@ -188,7 +188,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
                             onSave={handleSavePhase} onDelete={onDeletePhase} />
                     ))}
                     {phases.length === 0 && (
-                        <tr><td colSpan={6} className="py-1 text-gray-400 italic text-[11px]">No phases yet. Add the HWY phase to enable measured η.</td></tr>
+                        <tr><td colSpan={6} className="py-1 text-faint italic text-[11px]">No phases yet. Add the HWY phase to enable measured η.</td></tr>
                     )}
                 </tbody>
             </table>
@@ -226,7 +226,7 @@ function TestCard({ test, canEdit, onSaveTest, onDeleteTest, onSavePhase, onDele
 function EnumField({ label, value, options, tooltip, canEdit, onSave }) {
     return (
         <div className="flex items-center justify-between gap-2 py-0.5">
-            <span className="text-gray-500 dark:text-slate-400 flex items-center gap-1">
+            <span className="text-muted flex items-center gap-1">
                 {label}
                 {tooltip && <InfoIcon text={tooltip} position="right" />}
             </span>
@@ -248,7 +248,7 @@ export default function TestPhaseEditor({ tests, canEdit, onSaveTest, onDeleteTe
     const sorted = [...(tests || [])].sort((a, b) => (a.procedure_code ?? 99) - (b.procedure_code ?? 99));
     return (
         <div>
-            <div className="text-gray-400 text-[10px] uppercase tracking-wide mb-1 font-semibold">
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                 Tests &amp; Phases
             </div>
             {sorted.map(t => (
@@ -257,7 +257,7 @@ export default function TestPhaseEditor({ tests, canEdit, onSaveTest, onDeleteTe
                     onSavePhase={onSavePhase} onDeletePhase={onDeletePhase} onAddPhase={onAddPhase} />
             ))}
             {sorted.length === 0 && (
-                <p className="text-xs text-gray-400 italic mb-2">No tests entered. Add a Multi-Cycle Test (proc 77) and its HWY phase to compute a measured η.</p>
+                <p className="text-xs text-faint italic mb-2">No tests entered. Add a Multi-Cycle Test (proc 77) and its HWY phase to compute a measured η.</p>
             )}
             {canEdit && (
                 <button onClick={onAddTest} className="btn btn-secondary text-xs py-1 px-2">+ Add test</button>


### PR DESCRIPTION
Incremental migration off `text-gray-*` onto the semantic type system (#125, see [docs/typography.md](docs/typography.md)). One accumulating PR, rebased onto `main` after #127.

Took the codebase from **~339 → 27** `text-gray-*` / `bg-gray-*` / `border-gray-*` occurrences.

## Migrated
- **VehiclesView** (home) — kept the intentional `text-[13px]` count badges.
- **Charts cluster** — `ChargingView`, `RangeChartView`, `SpecsChartView`, `RoadTripView`, `AxisScaleControls`, `EpaCurvesView`; segmented toggles rethemed to a `var(--color-card)` raised chip.
- **RunsView** (Tests & Data, ~74).
- **EPA/import/curator + specs forms + admin** — `EpaImportModal`, `EpaVehicleSection`, `EpaDataCard`, `EpaPdfImportModal`, `ImportTableauModal`, `epa/*` (AuditHistory, TestPhaseEditor, EpaCuratorEditor, DerivedValues, CuratorField), `EditSpecsForm`, `EditVehicleForm`, `SpecsView`, `ViewSpecsModal`, `RolesPermissions`, `LoadingSpinner`, and the safe bits of `AuthModal`.

Throughout: text → `.text-secondary`/`.text-muted`/`.text-faint`; combined `gray dark:slate` pairs collapsed to the matching tier (dropping redundant overrides); bg/border grays → `var(--color-*)`; accent colors and intentional dense-table `text-[10/11px]` sizes preserved.

## Intentionally NOT migrated (the remaining 27)
- **AuthModal** brand provider buttons (Apple-dark / Google-white) and **DeleteQueueBar** (always-dark toast) — fixed surfaces, not theme tokens.
- `index.css:955` — a code comment.
- **ChargeCompareView, SpecsScatterView, RunSelector** (~19) — deferred to avoid overlap with the chart-consistency / pop-out work.

## Verification
- `npm run build` green at each step.
- Browser-verified in **dark mode**: Vehicles, Charging, Range & Efficiency, Tests & Data, and Compare Specs all render correctly with no console errors; no light-mode regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)