### PR TITLE
Fix pop-out chart routing (Spec Scatter, EPA Curves) + Range scale-control leak

### DIFF
--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -2,6 +2,7 @@ import ChargingView from './ChargingView';
 import ChargeCompareView from './ChargeCompareView';
 import RoadTripView from './RoadTripView';
 import SpecsChartView from './SpecsChartView';
+import SpecsScatterView from './SpecsScatterView';
 import EpaCurvesView from './EpaCurvesView';
 
 /**
@@ -31,6 +32,15 @@ export default function PopoutView({
                 />
             )}
 
+            {selectedVehicles.length > 0 && chartMode === 'specscatter' && (
+                <SpecsScatterView
+                    vehicles={vehicles.filter(v => selectedVehicles.includes(v.id))}
+                    xField={chartConfig.scatterXField}
+                    yField={chartConfig.scatterYField}
+                    presentationMode
+                />
+            )}
+
             {selectedVehicles.length > 0 && chartMode === 'roadtrip' && roadTripConfig && (
                 <RoadTripView
                     vehicles={vehicles}
@@ -41,7 +51,10 @@ export default function PopoutView({
                 />
             )}
 
-            {selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'roadtrip' && (
+            {/* Charging + Range only — ChargingView delegates to RangeChartView when
+                chartMode === 'range'. Other modes have their own explicit branches so
+                they no longer fall through to the charging chart. */}
+            {selectedVehicles.length > 0 && (chartMode === 'charging' || chartMode === 'range') && (
                 <ChargingView
                     vehicles={vehicles}
                     selectedVehicleIds={selectedVehicles}
@@ -64,7 +77,7 @@ export default function PopoutView({
                 />
             )}
 
-            {chartMode === 'epacurves' && (
+            {selectedVehicles.length > 0 && chartMode === 'epacurves' && (
                 <EpaCurvesView
                     vehicles={vehicles}
                     selectedVehicleIds={selectedVehicles}

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -611,13 +611,16 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                     </button>
                 </div>
             </div>
-            {/* ── Axis scale controls (card provided by AxisScaleControls) ── */}
-            <AxisScaleControls
-                xMin={xMin} xMax={xMax}
-                yMin={yMin} yMax={yMax}
-                onChange={handleScaleChange}
-                showX={CHART_TYPES.find(t => t.key === chartType)?.kind === 'line'}
-            />
+            {/* ── Axis scale controls (card provided by AxisScaleControls) ──
+                Hidden in presentation/pop-out mode — these belong on the main page. */}
+            {!presentationMode && (
+                <AxisScaleControls
+                    xMin={xMin} xMax={xMax}
+                    yMin={yMin} yMax={yMax}
+                    onChange={handleScaleChange}
+                    showX={CHART_TYPES.find(t => t.key === chartType)?.kind === 'line'}
+                />
+            )}
 
             {!presentationMode && <ChartInfoBubble chartKey="range" />}
         </div>


### PR DESCRIPTION
Fixes the pop-out (“Open Chart in New Window”) so each Charts sub-tab renders its own chart, and stops the Range chart's scale controls leaking into presentation mode.

## Pop-out routing — `PopoutView.jsx`
A catch-all branch rendered `ChargingView` for any mode it didn't explicitly handle. Result:
- **Spec Scatter** showed the **Charging** chart (`SpecsScatterView` wasn't even imported).
- **EPA Curves** rendered **twice** (matched the catch-all *and* its own branch).
- Range survived only because `ChargingView` delegates to `RangeChartView` for `chartMode === 'range'`.

Fix:
- Scope the `ChargingView` branch to `charging` / `range` only.
- Add an explicit `specscatter → SpecsScatterView` branch (`presentationMode`, fed by the broadcast `scatterXField` / `scatterYField`).
- Guard the `epacurves` branch on a non-empty selection.

## Range scale-control leak — `RangeChartView.jsx`
`<AxisScaleControls>` was rendered ungated, so the min/max scale inputs showed in the pop-out. Gated on `!presentationMode`, matching ChargingView / EpaCurvesView / RoadTripView. (Spotted in review — scale controls belong on the main page.)

## Verification (browser preview, pop-out loaded via URL params)
- **Spec Scatter** pop-out → renders the scatter (single canvas, trend line), not the Charging chart. ✅
- **EPA Curves** pop-out → single chart, no double-render. ✅
- **Charging / Range** pop-outs → still render correctly (1 canvas each). ✅
- **Range** → scale controls hidden in pop-out, still present on the main page. ✅
- `npm run build` green; no console errors.

## Scope
Addresses the **pop-out routing bug** in #128. The remaining #128 items (zoom parity, button/card consistency) are lower-priority housekeeping and are intentionally left open — this PR does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)