### PR TITLE
Typography migration: final 3 chart sub-views

### DIFF
--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -574,7 +574,7 @@ export default function ChargeCompareView({
             {!presentationMode && <div className="card mb-6">
                 {loading && <LoadingSpinner message="Loading charging data…" />}
                 <div className="flex flex-wrap items-center gap-6">
-                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-slate-200">
+                    <label className="flex items-center gap-2 text-sm font-medium text-secondary">
                         Starting SoC (%):
                         <input
                             type="number"
@@ -585,7 +585,7 @@ export default function ChargeCompareView({
                             className="w-20 px-2 py-1 border rounded text-sm"
                         />
                     </label>
-                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-slate-200">
+                    <label className="flex items-center gap-2 text-sm font-medium text-secondary">
                         Charging Time (minutes):
                         <input
                             type="number"
@@ -596,7 +596,7 @@ export default function ChargeCompareView({
                             className="w-20 px-2 py-1 border rounded text-sm"
                         />
                     </label>
-                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-slate-200">
+                    <label className="flex items-center gap-2 text-sm font-medium text-secondary">
                         Range to add ({distanceLabel(units)}):
                         <input
                             type="number"
@@ -636,7 +636,7 @@ export default function ChargeCompareView({
                         renderRunMeta={run => (
                             <>
                                 {run.speed_mph != null && (
-                                    <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{fmtSpeed(run.speed_mph, units)}</span>
+                                    <span className="text-xs bg-[var(--color-surface-sunken)] text-secondary px-1.5 py-0.5 rounded">{fmtSpeed(run.speed_mph, units)}</span>
                                 )}
                                 {run.temperature_f != null && (
                                     <span className="text-xs bg-orange-50 text-orange-700 px-1.5 py-0.5 rounded border border-orange-200">{fmtTemp(run.temperature_f, units)}</span>
@@ -648,7 +648,7 @@ export default function ChargeCompareView({
             </div>}
 
             {!hasRangeRuns ? (
-                <div className="card text-center py-12 text-gray-400">
+                <div className="card text-center py-12 text-faint">
                     <p className="text-lg font-medium">No range test runs found for selected vehicles</p>
                     <p className="text-sm mt-1">Add range test records in Tests &amp; Data to use this chart.</p>
                 </div>
@@ -657,7 +657,7 @@ export default function ChargeCompareView({
                     {/* ── Chart 1: Range Added in X Minutes ── */}
                     <div className="card mb-6">
                         <h4 className="text-base font-semibold mb-3">
-                            Range Added in {xMinutes} Minutes <span className="text-gray-400 font-normal">(from ~{startSoc}% SoC, in {distanceLabel(units)})</span>
+                            Range Added in {xMinutes} Minutes <span className="text-faint font-normal">(from ~{startSoc}% SoC, in {distanceLabel(units)})</span>
                         </h4>
                         <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activeResolvedRuns.length * 48)}px` : '450px', position: 'relative' }}>
                             <canvas ref={chart1Ref} />
@@ -667,7 +667,7 @@ export default function ChargeCompareView({
                     {/* ── Chart 2: Time to Add M Miles ── */}
                     <div className="card mb-6">
                         <h4 className="text-base font-semibold mb-3">
-                            Time to Add {units === 'metric' ? Math.round(mMiles * MI_TO_KM) : mMiles} {distanceLabel(units)} of Range <span className="text-gray-400 font-normal">(from ~{startSoc}% SoC)</span>
+                            Time to Add {units === 'metric' ? Math.round(mMiles * MI_TO_KM) : mMiles} {distanceLabel(units)} of Range <span className="text-faint font-normal">(from ~{startSoc}% SoC)</span>
                         </h4>
                         <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activeResolvedRuns.length * 48)}px` : '450px', position: 'relative' }}>
                             <canvas ref={chart2Ref} />

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -43,9 +43,9 @@ export default function RunSelector({
             >
                 <span style={{ display: 'inline-block', transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
                 Select Vehicle Tests to Display
-                <span className="text-sm font-normal text-gray-500">({selectedCount} selected)</span>
+                <span className="text-sm font-normal text-muted">({selectedCount} selected)</span>
                 {expanded && (
-                    <span className="text-xs font-normal text-gray-400 ml-2">· Drag the pills above to reorder</span>
+                    <span className="text-xs font-normal text-faint ml-2">· Drag the pills above to reorder</span>
                 )}
             </button>
 
@@ -63,14 +63,14 @@ export default function RunSelector({
                                             className="flex items-center gap-1.5 text-left group"
                                             title={isVehicleExpanded(vehicle.id) ? 'Collapse' : 'Expand'}
                                         >
-                                            <span style={{ display: 'inline-block', transform: isVehicleExpanded(vehicle.id) ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }} className="text-gray-400 group-hover:text-gray-600">&#9660;</span>
-                                            <h4 className="text-sm font-semibold text-gray-700">{vehicle.name}</h4>
+                                            <span style={{ display: 'inline-block', transform: isVehicleExpanded(vehicle.id) ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }} className="text-faint group-hover:text-secondary">&#9660;</span>
+                                            <h4 className="text-sm font-semibold text-secondary">{vehicle.name}</h4>
                                         </button>
                                     </div>
 
                                     {isVehicleExpanded(vehicle.id) && (
                                         filteredRuns.length === 0 ? (
-                                            <p className="text-sm text-gray-400 italic">{emptyMessage}</p>
+                                            <p className="text-sm text-faint italic">{emptyMessage}</p>
                                         ) : (
                                             <div className="run-items">
                                                 {filteredRuns.map(run => (
@@ -188,7 +188,7 @@ function RunRow({ run, vehicle, isChecked, onToggle, onUpdateRunColor, renderRun
                             onClick={e => e.stopPropagation()}
                             className="text-blue-400 hover:text-blue-600 transition-colors ml-0.5">↗</a>
                     )}
-                    <span className="text-sm text-gray-500"> ({run.date})</span>
+                    <span className="text-sm text-muted"> ({run.date})</span>
                 </span>
                 {renderRunMeta?.(run)}
             </span>

--- a/src/components/SpecsScatterView.jsx
+++ b/src/components/SpecsScatterView.jsx
@@ -263,7 +263,7 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
         <>
         <div className="specs-chart-card">
             <div className="specs-chart-controls">
-                <label className="text-sm font-medium text-gray-600">X-Axis:</label>
+                <label className="text-sm font-medium text-secondary">X-Axis:</label>
                 <select
                     className="specs-chart-field-select"
                     value={xField}
@@ -278,7 +278,7 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
                     ))}
                 </select>
 
-                <label className="text-sm font-medium text-gray-600 ml-3">Y-Axis:</label>
+                <label className="text-sm font-medium text-secondary ml-3">Y-Axis:</label>
                 <select
                     className="specs-chart-field-select"
                     value={yField}
@@ -326,8 +326,8 @@ export default function SpecsScatterView({ vehicles, xField: xProp, yField: yPro
             </div>
             {chartImage && (
                 <div className="mt-3">
-                    <p className="text-xs text-gray-400 mb-1.5">Right-click or long-press to copy / save</p>
-                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-gray-200" />
+                    <p className="text-xs text-faint mb-1.5">Right-click or long-press to copy / save</p>
+                    <img src={chartImage} alt="Chart export" className="w-full rounded border border-[var(--color-border)]" />
                 </div>
             )}
         </div>


### PR DESCRIPTION
The last piece of the typography migration (#126). Migrates the three views that were deferred to avoid colliding with the chart pop-out/consistency work (issue #128 / fix #129, now merged):

- **ChargeCompareView**, **SpecsScatterView**, **RunSelector**

## Changes
- text → `.text-secondary` / `.text-muted` / `.text-faint`, dropping redundant `dark:text-slate-*` overrides (incl. `group-hover:` compounds)
- speed-badge `bg-gray-100` + image-preview `border-gray-200` → `var(--color-*)`

## Result
Completes the site-wide migration started in #126 — **0 non-intentional `text-gray-*` remain** (only the deliberate fixed-surface exceptions: AuthModal brand buttons, DeleteQueueBar dark toast).

## Verification
- `npm run build` green.
- Browser-verified Charge Compare + Spec Scatter in **dark mode**: axis labels, empty states, and RunSelector all render correctly; no light-mode regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)