### PR TITLE
Live Typography knobs (Admin → Interface Settings)

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -77,10 +77,20 @@ deliberately `text-[13px]`, 1px smaller than the `text-sm` rows for hierarchy) i
 *not* drift — keep it. Only migrate sizes that are incidental/inconsistent. The
 color migration (gray → semantic) still applies regardless of size.
 
-## Future: live style knobs
+## Live style knobs (implemented)
 
-Once text styling flows through these classes/variables, exposing them as
-live-tunable knobs (a "Typography" group in Admin → Interface Settings) reuses
-the same machinery as the EPA Model Constants panel
-(`src/constants/overrides.js`, `knobs.js`, `components/admin/ConstantsKnobs.jsx`).
-Deferred until after the migration.
+Admin → **Interface Settings → Typography** tunes the type system live. Each role
+class reads its font-size/weight from a CSS variable (default = the shipped value,
+so an unset var is a no-op), and the root font-size carries a global `--ui-scale`
+that scales every rem-based size site-wide.
+
+- Defaults + knob metadata + the localStorage store: `src/styles/typographyKnobs.js`
+  (separate store key from the EPA constants, so the two panels are independent).
+- Overrides apply **live** as CSS custom properties on `:root` (no reload), and are
+  re-applied before first paint in `src/main.jsx` via `applyTypographyOverrides()`.
+- Panel: `src/components/admin/TypographyKnobs.jsx` (with a live preview).
+- Per-browser only — never the DB or other users.
+
+To expose a new tunable: variable-ize the property in the role class here, then add
+a knob entry to `TYPO_GROUPS`. Colour tiers are not yet knobs (they're theme-specific
+— a future extension).

--- a/src/components/admin/InterfaceSettings.jsx
+++ b/src/components/admin/InterfaceSettings.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
+import TypographyKnobs from './TypographyKnobs';
 
 /**
  * Admin sub-tab: site-wide interface settings.
@@ -53,6 +54,8 @@ export default function InterfaceSettings() {
                     />
                 </label>
             </div>
+
+            <TypographyKnobs />
 
             <div className="card p-5">
                 <h3 className="section-title">Personal preferences</h3>

--- a/src/components/admin/TypographyKnobs.jsx
+++ b/src/components/admin/TypographyKnobs.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import {
+    TYPO_GROUPS, WEIGHT_OPTIONS,
+    getTypographyOverrides, setTypographyOverride, clearTypographyOverrides,
+} from '../../styles/typographyKnobs';
+
+/**
+ * Admin panel for tuning the semantic type system live.
+ *
+ * Writes per-browser overrides (localStorage) and applies them as CSS variables
+ * on :root instantly — changes are visible across the whole app as you type, no
+ * reload. Pure local sandbox; never touches the DB or other users.
+ */
+export default function TypographyKnobs() {
+    // bump forces a re-render after live writes so values/badges refresh
+    const [, force] = useState(0);
+    const ov = getTypographyOverrides();
+
+    const valueOf = (k) => (k.var in ov ? ov[k.var] : k.default);
+    const isModified = (k) => k.var in ov && ov[k.var] !== k.default;
+    const anyModified = TYPO_GROUPS.some(g => g.knobs.some(isModified));
+
+    function set(k, value) {
+        setTypographyOverride(k.var, value == null || value === k.default ? null : value);
+        force(n => n + 1);
+    }
+    function resetAll() {
+        clearTypographyOverrides();
+        force(n => n + 1);
+    }
+
+    return (
+        <div className="card p-5">
+            <div className="flex items-start justify-between gap-4 mb-1">
+                <div>
+                    <h3 className="section-title">Typography</h3>
+                    <p className="text-sm text-secondary mt-0.5">
+                        Tune the type system on <strong>this browser only</strong>, applied live.
+                        Never affects the database or other users.
+                    </p>
+                </div>
+                <button onClick={resetAll} disabled={!anyModified}
+                    className="btn btn-secondary text-sm whitespace-nowrap disabled:opacity-40">
+                    Reset all
+                </button>
+            </div>
+
+            {/* Live preview */}
+            <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-muted)] p-4 my-3 space-y-1">
+                <p className="page-title">Page title</p>
+                <p className="section-title">Section title</p>
+                <p className="subsection-title">Subsection title</p>
+                <p className="text-body">Body — the quick brown fox jumps over the lazy dog.</p>
+                <p className="text-caption text-secondary">Caption — secondary supporting copy.</p>
+                <p className="text-label">Field label</p>
+                <p className="text-hint">Hint — helper text under a control.</p>
+                <p className="text-data">Data 1,234.56 kWh · 3.1 mi/kWh</p>
+            </div>
+
+            {TYPO_GROUPS.map(group => (
+                <div key={group.title} className="mt-4">
+                    <h4 className="subsection-title">{group.title}</h4>
+                    {group.blurb && <p className="text-xs text-faint mb-2">{group.blurb}</p>}
+                    <div className="divide-y divide-[var(--color-border)] border-t border-[var(--color-border)]">
+                        {group.knobs.map(k => (
+                            <KnobRow key={k.var} knob={k} value={valueOf(k)}
+                                modified={isModified(k)} onChange={(v) => set(k, v)} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+const unitFor = (kind) => (kind === 'size' ? 'px' : kind === 'scale' ? '×' : '');
+
+function KnobRow({ knob, value, modified, onChange }) {
+    const { label, kind, var: cssVar, min, max, step, default: def } = knob;
+    return (
+        <div className="py-2.5 flex items-center justify-between gap-4">
+            <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm font-medium">{label}</span>
+                    <code className="text-[11px] text-muted bg-[var(--color-surface-sunken)] px-1.5 py-0.5 rounded">{cssVar}</code>
+                    {modified && (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-700 border border-amber-200">
+                            modified
+                        </span>
+                    )}
+                </div>
+                <p className="text-[11px] text-faint mt-0.5">
+                    default: <code>{def}{unitFor(kind)}</code>
+                </p>
+            </div>
+
+            <div className="flex items-center gap-2 shrink-0">
+                {kind === 'weight' ? (
+                    <select value={value} onChange={(e) => onChange(Number(e.target.value))}
+                        className="form-input w-24 text-sm">
+                        {WEIGHT_OPTIONS.map(w => <option key={w} value={w}>{w}</option>)}
+                    </select>
+                ) : (
+                    <input type="number" min={min} max={max} step={step} value={value}
+                        onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+                        className="form-input w-24 text-sm" />
+                )}
+                <span className="text-xs text-faint w-5">{unitFor(kind)}</span>
+                <button onClick={() => onChange(null)} disabled={!modified} title="Reset to default"
+                    className="text-xs text-faint hover:text-secondary disabled:opacity-30 px-1">
+                    ↺
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -236,9 +236,12 @@
     padding-bottom: 0.5rem;
 }
 
-/* Tighten Tailwind's default line-height (1.5 feels too spacious) */
+/* Tighten Tailwind's default line-height (1.5 feels too spacious).
+   font-size carries the global UI scale knob (--ui-scale, default 1): scaling the
+   root font-size scales every rem-based size site-wide. See src/styles/typographyKnobs.js. */
 html {
     line-height: 1.4;
+    font-size: calc(100% * var(--ui-scale, 1));
 }
 
 /* Background and Card Styles */
@@ -308,14 +311,17 @@ body {
    ============================================================================ */
 
 /* — Roles ————————————————————————————————————————————————————————————————— */
-.page-title       { @apply text-2xl font-bold; }
-.section-title    { @apply text-lg font-bold; }
-.subsection-title { @apply text-sm font-semibold; color: var(--color-text-primary); }
-.text-body        { @apply text-sm; }
-.text-caption     { @apply text-xs; }
-.text-label       { @apply text-xs font-medium; color: var(--color-text-secondary); }
-.text-hint        { @apply text-xs; color: var(--color-text-faint); }
-.text-data        { @apply text-sm font-mono tabular-nums; }
+/* @apply keeps each role's line-height; the explicit font-size/font-weight below
+   override it and are knob-tunable via CSS vars (defaults = the @apply values, so
+   an unset var is a no-op). See src/styles/typographyKnobs.js. */
+.page-title       { @apply text-2xl; font-size: var(--fs-page-title, 1.5rem);       font-weight: var(--fw-page-title, 700); }
+.section-title    { @apply text-lg;  font-size: var(--fs-section-title, 1.125rem);   font-weight: var(--fw-section-title, 700); }
+.subsection-title { @apply text-sm;  font-size: var(--fs-subsection-title, 0.875rem); font-weight: var(--fw-subsection-title, 600); color: var(--color-text-primary); }
+.text-body        { @apply text-sm;  font-size: var(--fs-body, 0.875rem); }
+.text-caption     { @apply text-xs;  font-size: var(--fs-caption, 0.75rem); }
+.text-label       { @apply text-xs;  font-size: var(--fs-label, 0.75rem);  font-weight: var(--fw-label, 500); color: var(--color-text-secondary); }
+.text-hint        { @apply text-xs;  font-size: var(--fs-hint, 0.75rem);   color: var(--color-text-faint); }
+.text-data        { @apply text-sm font-mono tabular-nums; font-size: var(--fs-data, 0.875rem); }
 
 /* — Color tiers (compose with a role) ——————————————————————————————————————— */
 .text-secondary { color: var(--color-text-secondary); }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import { AppProvider } from './context/AppContext';
 import App from './App';
 import './index.css';
+import { applyTypographyOverrides } from './styles/typographyKnobs';
+
+// Apply per-browser typography overrides before first paint (no-op if none set).
+applyTypographyOverrides();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/src/styles/typographyKnobs.js
+++ b/src/styles/typographyKnobs.js
@@ -1,0 +1,107 @@
+/**
+ * Live typography knobs — a per-browser sandbox for tuning the semantic type
+ * system (src/index.css TYPOGRAPHY SYSTEM banner).
+ *
+ * Each knob maps to a CSS custom property on :root. Overrides are stored in
+ * localStorage (a SEPARATE key from the EPA constants store so the two panels'
+ * "Reset all" don't clobber each other) and applied LIVE — setting a CSS var on
+ * document.documentElement cascades instantly, no reload needed. Defaults live
+ * here (single source of truth) and match the unmodified values in index.css, so
+ * an unset knob == the shipped design.
+ *
+ * Leaf module: depends only on localStorage + the DOM. Apply once at startup
+ * (main.jsx) so vars are set before first paint.
+ */
+const KEY = 'evbench.typography.overrides';
+
+// kind: 'scale' → unitless multiplier; 'size' → px in UI, stored as rem var;
+//       'weight' → CSS font-weight (100–900).
+export const TYPO_GROUPS = [
+    {
+        title: 'Global',
+        blurb: 'Scales every rem-based size on the site at once (text, spacing, controls) — like a UI zoom.',
+        knobs: [
+            { var: '--ui-scale', label: 'UI scale', kind: 'scale', min: 0.8, max: 1.4, step: 0.05, default: 1 },
+        ],
+    },
+    {
+        title: 'Role sizes',
+        blurb: 'Font size of each semantic text role. Affects elements using the role classes (.page-title, .text-body, …).',
+        knobs: [
+            { var: '--fs-page-title',       label: 'Page title',       kind: 'size', min: 14, max: 48, step: 1, default: 24 },
+            { var: '--fs-section-title',    label: 'Section title',    kind: 'size', min: 12, max: 36, step: 1, default: 18 },
+            { var: '--fs-subsection-title', label: 'Subsection title', kind: 'size', min: 10, max: 28, step: 1, default: 14 },
+            { var: '--fs-body',             label: 'Body',             kind: 'size', min: 11, max: 22, step: 1, default: 14 },
+            { var: '--fs-caption',          label: 'Caption',          kind: 'size', min: 9,  max: 18, step: 1, default: 12 },
+            { var: '--fs-label',            label: 'Label',            kind: 'size', min: 9,  max: 18, step: 1, default: 12 },
+            { var: '--fs-hint',             label: 'Hint',             kind: 'size', min: 9,  max: 18, step: 1, default: 12 },
+            { var: '--fs-data',             label: 'Data (mono)',      kind: 'size', min: 11, max: 22, step: 1, default: 14 },
+        ],
+    },
+    {
+        title: 'Role weights',
+        blurb: 'Font weight of the heading and label roles.',
+        knobs: [
+            { var: '--fw-page-title',       label: 'Page title',       kind: 'weight', default: 700 },
+            { var: '--fw-section-title',    label: 'Section title',    kind: 'weight', default: 700 },
+            { var: '--fw-subsection-title', label: 'Subsection title', kind: 'weight', default: 600 },
+            { var: '--fw-label',            label: 'Label',            kind: 'weight', default: 500 },
+        ],
+    },
+];
+
+export const WEIGHT_OPTIONS = [400, 500, 600, 700, 800];
+
+/** Flat list of all knobs. */
+export const TYPO_KNOBS = TYPO_GROUPS.flatMap(g => g.knobs);
+
+/** The CSS value to write for a knob's numeric value (px→rem for sizes). */
+export function cssValueFor(knob, value) {
+    if (knob.kind === 'size') return `${value / 16}rem`;
+    return String(value); // scale (unitless) + weight
+}
+
+// ── Override store (localStorage) ───────────────────────────────────────────
+let cache = null;
+function load() {
+    if (cache) return cache;
+    try { cache = JSON.parse(localStorage.getItem(KEY)) || {}; }
+    catch { cache = {}; }
+    return cache;
+}
+
+/** Current overrides keyed by CSS var name (copy). */
+export function getTypographyOverrides() {
+    return { ...load() };
+}
+
+/** Set (value==null clears) one override, persist, and apply it live. */
+export function setTypographyOverride(cssVar, value) {
+    const ov = load();
+    if (value == null) delete ov[cssVar];
+    else ov[cssVar] = value;
+    cache = ov;
+    try { localStorage.setItem(KEY, JSON.stringify(ov)); } catch { /* ignore */ }
+    applyOne(cssVar, value);
+}
+
+/** Drop all overrides, persist, and revert every var live. */
+export function clearTypographyOverrides() {
+    const prev = Object.keys(load());
+    cache = {};
+    try { localStorage.removeItem(KEY); } catch { /* ignore */ }
+    prev.forEach(v => document.documentElement.style.removeProperty(v));
+}
+
+function applyOne(cssVar, value) {
+    const root = document.documentElement;
+    if (value == null) { root.style.removeProperty(cssVar); return; }
+    const knob = TYPO_KNOBS.find(k => k.var === cssVar);
+    if (knob) root.style.setProperty(cssVar, cssValueFor(knob, value));
+}
+
+/** Apply all stored overrides to :root. Call once at startup. */
+export function applyTypographyOverrides() {
+    const ov = load();
+    for (const [cssVar, value] of Object.entries(ov)) applyOne(cssVar, value);
+}


### PR DESCRIPTION
The follow-on to the typography migration: tune the semantic type system **live** from Admin → Interface Settings → **Typography**. Reuses the per-browser override pattern from the EPA Model Constants panel, but applied as **live CSS variables** (no reload — CSS vars cascade instantly).

## How it works
- **`index.css`** — each role class now reads its font-size/weight from a CSS var whose *default equals the shipped value*, so an unset var is a no-op (zero visual change until you turn a knob). The root font-size carries a global `--ui-scale` that scales every rem-based size site-wide.
- **`src/styles/typographyKnobs.js`** — knob metadata + a localStorage store under its **own key** (independent of the EPA constants store, so the two panels' "Reset all" don't collide) + `applyTypographyOverrides()`.
- **`main.jsx`** — applies overrides before first paint (no flash).
- **`admin/TypographyKnobs.jsx`** — panel with a **live preview**, per-knob ↺ + global Reset, "modified" badges, and the exact CSS var name shown for each knob.

## Knobs
- **Global UI scale** (root font-size — affects everything)
- **Per-role font sizes** (8 roles)
- **Per-role weights** (4 heading/label roles)

Colour tiers are intentionally not knobs yet (they're theme-specific — noted as a future extension in `docs/typography.md`).

## Scope
Per-browser sandbox only — never the DB or other users. Same philosophy as the Model Constants panel.

## Verification
- `npm run build` green.
- Verified the CSS plumbing live in the browser: per-role size 18→32px, per-role weight 700→400, global scale (root) 16→20px, and a clean revert to defaults. Role-class defaults unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)