### PR TITLE
Fix timestamp import for elapsed clock / SMPTE timecode columns

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -12,6 +12,7 @@ import ViewSpecsModal from './ViewSpecsModal';
 import { RunVoteButtons } from './VoteButtons';
 import EpaVehicleSection from './EpaVehicleSection';
 import { deriveChargingAxis } from '../utils/deriveChargingAxis';
+import { isTimestampValue, timestampToMs } from '../utils/parseElapsedTime';
 
 // ── Data-type flag definitions ────────────────────────────────────────────────
 // Each flag represents a data domain that can independently be present in a run.
@@ -558,19 +559,13 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     };
 
     /**
-     * Return true when a single CSV cell value looks like a wall-clock timestamp
-     * rather than a plain number (seconds / minutes).
-     */
-    const isTimestampValue = (val) =>
-        val != null && typeof val === 'string' && val.trim() !== '' &&
-        isNaN(Number(val)) && !isNaN(Date.parse(val));
-
-    /**
      * After field mapping, detect timestamp columns and convert them to elapsed
-     * minutes from the first data point.
+     * minutes from the first data point. Handles wall-clock datetimes as well as
+     * elapsed clock / SMPTE timecode strings (HH:MM:SS, MM:SS, HH:MM:SS:FF) via
+     * {@link timestampToMs} — see src/utils/parseElapsedTime.js.
      *
      * Two cases handled:
-     *   A. `timestamp` field is mapped (explicit wall-clock column).
+     *   A. `timestamp` field is mapped (explicit wall-clock/timecode column).
      *      → compute `time` from it if `time` is not already mapped.
      *   B. `time` field is mapped but the first non-null value is a timestamp
      *      string, not a number.
@@ -584,31 +579,33 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
 
         // Case A: explicit timestamp column mapped
         if (firstWithTs && isTimestampValue(firstWithTs.timestamp)) {
-            const t0 = new Date(firstWithTs.timestamp).getTime();
+            const t0 = timestampToMs(firstWithTs.timestamp);
             return {
-                rows: rows.map(row => ({
-                    ...row,
-                    // Only fill `time` when it wasn't already supplied
-                    time: row.time != null ? row.time
-                        : row.timestamp != null
-                            ? roundTo((new Date(row.timestamp).getTime() - t0) / 60000, 3)
-                            : null,
-                })),
+                rows: rows.map(row => {
+                    const ms = row.timestamp != null ? timestampToMs(row.timestamp) : null;
+                    return {
+                        ...row,
+                        // Only fill `time` when it wasn't already supplied
+                        time: row.time != null ? row.time
+                            : ms != null ? roundTo((ms - t0) / 60000, 3) : null,
+                    };
+                }),
                 converted: true,
             };
         }
 
         // Case B: `time` column contains timestamp strings
         if (firstWithTime && isTimestampValue(firstWithTime.time)) {
-            const t0 = new Date(firstWithTime.time).getTime();
+            const t0 = timestampToMs(firstWithTime.time);
             return {
-                rows: rows.map(row => ({
-                    ...row,
-                    timestamp: row.timestamp ?? row.time,   // save original
-                    time: row.time != null
-                        ? roundTo((new Date(row.time).getTime() - t0) / 60000, 3)
-                        : null,
-                })),
+                rows: rows.map(row => {
+                    const ms = row.time != null ? timestampToMs(row.time) : null;
+                    return {
+                        ...row,
+                        timestamp: row.timestamp ?? row.time,   // save original
+                        time: ms != null ? roundTo((ms - t0) / 60000, 3) : null,
+                    };
+                }),
                 converted: true,
             };
         }

--- a/src/utils/parseElapsedTime.js
+++ b/src/utils/parseElapsedTime.js
@@ -1,0 +1,70 @@
+/**
+ * Parsing helpers for time-like CSV columns.
+ *
+ * Charging exports frequently use colon-delimited *elapsed clock* strings that
+ * are NOT valid to `Date.parse()`:
+ *   - "MM:SS"          e.g. "05:30"
+ *   - "HH:MM:SS"       e.g. "00:01:04"
+ *   - "HH:MM:SS:FF"    SMPTE-style timecode with a trailing frame count
+ * These must be read as durations, not wall-clock dates.
+ */
+
+// Frame rate assumed when a timecode carries a trailing frame field (HH:MM:SS:FF).
+// Frames are sub-second, so an imperfect guess only perturbs the result by a
+// fraction of a second — negligible at minute resolution.
+const ASSUMED_FPS = 30;
+
+/**
+ * Parse a colon-delimited elapsed-clock / timecode string to seconds.
+ * Accepts 2–4 integer (or decimal-second) parts; returns null for anything
+ * that isn't a clean clock string (single tokens, >4 parts, non-numeric parts).
+ *
+ * @param {string|number} val
+ * @returns {number|null} seconds, or null if not a clock string
+ */
+export const clockToSeconds = (val) => {
+    if (typeof val !== 'string') return null;
+    const s = val.trim();
+    if (s === '') return null;
+
+    const parts = s.split(':');
+    if (parts.length < 2 || parts.length > 4) return null;
+    if (!parts.every(p => /^\d+(\.\d+)?$/.test(p.trim()))) return null;
+
+    const n = parts.map(Number);
+    let h = 0, m = 0, sec = 0, frames = 0, hasFrames = false;
+    if (parts.length === 2)      { [m, sec] = n; }
+    else if (parts.length === 3) { [h, m, sec] = n; }
+    else                         { [h, m, sec, frames] = n; hasFrames = true; }
+
+    return h * 3600 + m * 60 + sec + (hasFrames ? frames / ASSUMED_FPS : 0);
+};
+
+/**
+ * Convert a time-like cell to epoch-milliseconds for elapsed-time math.
+ * Handles elapsed clock/timecode strings first, then falls back to real
+ * wall-clock datetime strings (ISO, "2024-01-01 10:00:00", …).
+ *
+ * @param {string|number} val
+ * @returns {number|null} milliseconds, or null if unparseable
+ */
+export const timestampToMs = (val) => {
+    const secs = clockToSeconds(val);
+    if (secs != null) return secs * 1000;
+    if (typeof val !== 'string') return null;
+    const s = val.trim();
+    // A "bare clock" (only digits, dots, colons) either parsed above or is
+    // malformed — never let Date.parse loosely reinterpret it (e.g. "51" or
+    // "1:2:3:4:5"). Real datetimes carry a date separator (-, /, T, letters).
+    if (s === '' || /^[\d.:]+$/.test(s)) return null;
+    const ms = Date.parse(s);
+    return isNaN(ms) ? null : ms;
+};
+
+/**
+ * True when a cell looks like a wall-clock timestamp or elapsed clock/timecode
+ * string rather than a plain number (which dynamicTyping would already have
+ * turned into a JS number).
+ */
+export const isTimestampValue = (val) =>
+    typeof val === 'string' && val.trim() !== '' && timestampToMs(val) != null;


### PR DESCRIPTION
## Problem

CSV charging imports with colon-delimited **elapsed clock / timecode** time columns produced a **blank `time`** after import:

```
Asdf,ChargeRate,SoC,Timestamp
00:00:51:10,108,2,00:00:51      # Asdf = HH:MM:SS:FF timecode, Timestamp = HH:MM:SS
00:01:04:19,108,3,00:01:04
```

`isTimestampValue` gated on `Date.parse()`, but `Date.parse("00:00:51")` and `Date.parse("00:00:51:10")` both return `NaN` in V8 — these are *durations*, not wall-clock dates. Detection failed, no conversion ran, and the string `time` later coerced to `NaN`.

## Fix

New `src/utils/parseElapsedTime.js`:
- **`clockToSeconds`** — parses 2–4 part colon clocks: `MM:SS`, `HH:MM:SS`, and `HH:MM:SS:FF` (SMPTE timecode; the sub-second frame field uses an assumed 30 fps, which perturbs the result by only a fraction of a second at minute resolution).
- **`timestampToMs`** — layers a real-datetime `Date.parse` fallback on top, but never lets it loosely reinterpret a bare digit/colon string (so `"51"` and `"1:2:3:4:5"` correctly reject while ISO datetimes still parse).
- **`isTimestampValue`** — unchanged contract, now backed by the above.

`RunsView`'s timestamp conversion uses these helpers for both mapping cases (explicit `timestamp` column, or a `time` column holding clock strings).

## Verification

- Unit-tested against the exact sample: both the `HH:MM:SS` and `HH:MM:SS:FF` columns now convert to correct elapsed minutes (0, 0.217, 0.667, 1.217, 1.55, 2.0 …).
- Edge cases pass: bare numbers (`"51"`, `51`), malformed (`"1:2:3:4:5"`, `"ab:cd"`), blank, and ISO datetimes all behave correctly.
- `npm run build` green; app boots with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)