### PR TITLE
Add charging-loss factor to charging-axis derivation

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -177,6 +177,7 @@ const DeriveAxisPanel = ({
     mode, onChangeMode,
     calibrate, onChangeCalibrate,
     startSoc, onChangeStartSoc,
+    chargingLoss, onChangeChargingLoss,
     anchors, onChangeAnchors,
     shiftToZero, onShiftToZeroChange,
     preview, applying, error,
@@ -249,6 +250,23 @@ const DeriveAxisPanel = ({
                             onChange={e => onChangeStartSoc(e.target.value)}
                             className="form-input text-xs py-1 w-32"
                         />
+                    )}
+
+                    {/* Charging-loss factor — reported kW is charger-side; only η lands
+                        in the pack. Moot once anchors calibrate to measured values. */}
+                    {!usingAnchors && (
+                        <div className="flex items-center gap-2 text-xs text-secondary flex-wrap">
+                            <label htmlFor="derive-loss">Charging loss</label>
+                            <input
+                                id="derive-loss"
+                                type="number" min="0" max="50" step="0.5"
+                                value={chargingLoss}
+                                onChange={e => onChangeChargingLoss(e.target.value)}
+                                className="form-input text-xs py-1 w-16"
+                            />
+                            <span>%</span>
+                            <span className="text-faint">reported kW is charger-side; ~5% typical</span>
+                        </div>
                     )}
 
                     {/* Opt-in calibration toggle */}
@@ -502,6 +520,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     const [estimateMode, setEstimateMode]           = useState('time'); // 'time' | 'soc' | 'power'
     const [estimateCalibrate, setEstimateCalibrate] = useState(false);  // opt-in anchor calibration
     const [estimateStartSoc, setEstimateStartSoc]   = useState('');     // SoC-mode origin when none populated
+    const [estimateLoss, setEstimateLoss]           = useState('5');    // assumed charging loss %, charger→pack
     const [estimateAnchors, setEstimateAnchors]     = useState([]);   // [{x:'', y:''}] — x=domain, y=target
     const [estimateShift, setEstimateShift]         = useState(false);
     const [estimatePreview, setEstimatePreview]     = useState(null); // null | {points, warnings}
@@ -1045,11 +1064,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         setEstimatePreview(null);
         try {
             const result = deriveChargingAxis({
-                dataPoints:  editData,
-                batteryKwh:  vehicle.battery,
-                target:      estimateMode,
-                anchors:     buildDeriveAnchors(),
-                shiftToZero: estimateShift,
+                dataPoints:   editData,
+                batteryKwh:   vehicle.battery,
+                target:       estimateMode,
+                anchors:      buildDeriveAnchors(),
+                shiftToZero:  estimateShift,
+                chargingLoss: estimateLoss === '' ? 0 : Number(estimateLoss) / 100,
             });
             setEstimatePreview(result);
         } catch (err) {
@@ -1957,6 +1977,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 onChangeCalibrate={handleToggleCalibrate}
                                                 startSoc={estimateStartSoc}
                                                 onChangeStartSoc={setEstimateStartSoc}
+                                                chargingLoss={estimateLoss}
+                                                onChangeChargingLoss={setEstimateLoss}
                                                 anchors={estimateAnchors}
                                                 onChangeAnchors={setEstimateAnchors}
                                                 shiftToZero={estimateShift}

--- a/src/utils/deriveChargingAxis.js
+++ b/src/utils/deriveChargingAxis.js
@@ -35,7 +35,7 @@ import { roundTo } from './unitConversions';
  * @param {boolean} [opts.shiftToZero] - shift integration output so its min = 0
  * @returns {{ points: Array, warnings: string[], effectiveKwh: number|null }}
  */
-export function deriveChargingAxis({ dataPoints, batteryKwh, target, anchors = [], shiftToZero = false }) {
+export function deriveChargingAxis({ dataPoints, batteryKwh, target, anchors = [], shiftToZero = false, chargingLoss = 0.05 }) {
     if (!['time', 'soc', 'power'].includes(target))
         throw new Error(`Unknown derive target "${target}"`);
 
@@ -43,31 +43,39 @@ export function deriveChargingAxis({ dataPoints, batteryKwh, target, anchors = [
         throw new Error('Vehicle battery capacity (kWh) is required');
     const kWh = Number(batteryKwh);
 
-    if (target === 'power') return derivePowerCurve({ dataPoints, kWh });
-    return deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero });
+    // Charging efficiency η: reported kW is charger-side, but only η of it lands
+    // in the pack. Without it, times run ~5–10% optimistic vs. measured. Clamp
+    // the loss to a sane band so a fat-fingered value can't invert the physics.
+    const loss = isNaN(Number(chargingLoss)) ? 0 : Math.min(Math.max(Number(chargingLoss), 0), 0.5);
+    const eta = 1 - loss;
+
+    if (target === 'power') return derivePowerCurve({ dataPoints, kWh, eta });
+    return deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero, eta });
 }
 
 // ── Per-target field + formula config for the integration engine ───────────────
+// η is the charging efficiency (pack-side energy ÷ charger-side energy).
 const INTEGRAL = {
     time: {
         domain: 'soc', rate: 'chargeRate', out: 'time',
         domainLabel: 'SoC', targetLabel: 'time',
-        // dt in minutes from energy / power
-        delta: (dDomain, avgRate, kWh) => (avgRate > 0 ? (kWh * dDomain / 100) / avgRate * 60 : 0),
+        // dt in minutes from energy / (usable power). Losses shrink usable power,
+        // so time grows by 1/η.
+        delta: (dDomain, avgRate, kWh, eta) => (avgRate > 0 ? (kWh * dDomain / 100) / (avgRate * eta) * 60 : 0),
         // calibration scale s on a time curve means effective capacity = C·s
         effKwh: (kWh, scale) => kWh * scale,
     },
     soc: {
         domain: 'time', rate: 'chargeRate', out: 'soc',
         domainLabel: 'time', targetLabel: 'SoC',
-        // dSoC in percent from energy (power × hours) / capacity
-        delta: (dDomain, avgRate, kWh) => avgRate * (dDomain / 60) / kWh * 100,
+        // dSoC in percent from usable energy (η · power × hours) / capacity
+        delta: (dDomain, avgRate, kWh, eta) => (avgRate * eta) * (dDomain / 60) / kWh * 100,
         // calibration scale s on a SoC curve means effective capacity = C/s
         effKwh: (kWh, scale) => kWh / scale,
     },
 };
 
-function deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero }) {
+function deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero, eta }) {
     const cfg = INTEGRAL[target];
     const warnings = [];
 
@@ -96,7 +104,7 @@ function deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero }) {
     for (let i = 1; i < sorted.length; i++) {
         const dDomain = sorted[i][cfg.domain] - sorted[i - 1][cfg.domain];
         const avgRate = (sorted[i][cfg.rate] + sorted[i - 1][cfg.rate]) / 2;
-        cumRaw[i] = cumRaw[i - 1] + cfg.delta(dDomain, avgRate, kWh);
+        cumRaw[i] = cumRaw[i - 1] + cfg.delta(dDomain, avgRate, kWh, eta);
     }
     const curvePoints = sorted.map((p, i) => ({ d: p[cfg.domain], cumRaw: cumRaw[i] }));
     const cumRawAt = (d) => interpolate(curvePoints, 'd', 'cumRaw', d, true, true);
@@ -191,7 +199,7 @@ function deriveIntegral({ dataPoints, kWh, target, anchors, shiftToZero }) {
 }
 
 // ── Power from (SoC, time): differentiate energy w.r.t. time ───────────────────
-function derivePowerCurve({ dataPoints, kWh }) {
+function derivePowerCurve({ dataPoints, kWh, eta = 1 }) {
     const warnings = [];
 
     const valid = (dataPoints || [])
@@ -217,7 +225,8 @@ function derivePowerCurve({ dataPoints, kWh }) {
         if (dMin <= 0)
             warnings.push(`Non-increasing time between SoC ${sorted[i - 1].soc}% and ${sorted[i].soc}% — segment skipped`);
         else
-            segKw[i - 1] = (kWh * dSoC / 100) / (dMin / 60);
+            // dSoC reflects pack-side energy; divide by η to report charger-side kW.
+            segKw[i - 1] = (kWh * dSoC / 100) / (dMin / 60) / eta;
     }
 
     // Per-point power = central average of the segments on either side.


### PR DESCRIPTION
## Why

Reported charge rate (kW) is measured **charger-side**, but only a fraction **η** of that power actually lands in the pack (~5% loss typical). When deriving **time from known SoC + power pairs**, ignoring this made estimates **5–10% optimistic** vs. measured time.

## What

Thread a **charging-loss factor** (default **5%**) through the shared `deriveChargingAxis` engine so it applies consistently to all three modes:

| Mode | Effect |
|---|---|
| `time` | `dt = (C·dSoC/100) / (P·η) · 60` — times grow by `1/η` |
| `soc` | `dSoC = (P·η)·dt / C · 100` — less SoC gained per interval |
| `power` | charger-side kW = pack-side `/ η` — reported rate matches the charger |

Key property: **calibration anchors empirically absorb losses**, so η **cancels** once ≥2 anchors pin the curve — no double-counting. The loss only moves the needle on the un-calibrated "derive from populated data" path, which is exactly where the optimism lived. Loss is clamped to `[0, 50]%` so a fat-fingered value can't invert the physics.

**UI:** a hand-curatable *"Charging loss %"* input in the derive panel, shown on the populated-data path (hidden when calibrating, since anchors override it).

## Verification

Bundled-unit-tested across modes:
- Time with 5% loss runs ~5.3% longer than lossless (`1/0.95`).
- Calibrated SoC endpoints identical with/without loss (η cancels).
- Power charger-side `240 → 252.63 kW` (`= 240 / 0.95`).
- `npm run build` green; app boots with no console errors.

Note: independent of the open timestamp-import PR (#133); touches different regions of `RunsView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)