### PR TITLE
Road trip: realistic high-SoC charge tail, destination buffer, trimmed last stop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,7 @@ export default function App() {
     const [compareConfig, setCompareConfig] = useState({ xMinutes: 15, mMiles: 150, startSoc: 10 });
     const [epaConfig, setEpaConfig] = useState({ yAxis: 'kwh100mi', xMin: null, xMax: null, yMin: null, yMax: null });
     const [roadTripConfig, setRoadTripConfig] = useState({
-        mode: 'distance', startSoc: 90, minSoc: 10,
+        mode: 'distance', startSoc: 90, minSoc: 10, destinationMinSoc: 10,
         legDistance: 150, chargeTime: 30,
         totalDistance: 500, speed: 70,
         overhead: 5,              // per-stop overhead minutes (applies to EV and ICE)

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -48,8 +48,9 @@ const CHARGE_CEIL_SOC = 95; // % — charging above this marks a sim as unrealis
  */
 function isSimUnrealistic(sim) {
     if (!sim) return true;
+    if (sim.completed === false) return true;
     if (sim.segments.some(s => s.type === 'charge' && s.endSoc > CHARGE_CEIL_SOC)) return true;
-    if (sim.warnings.some(w => /depleted|maximum iterations/i.test(w))) return true;
+    if (sim.warnings.some(w => /depleted|maximum iterations|complete trip/i.test(w))) return true;
     return false;
 }
 
@@ -173,8 +174,8 @@ function makeRoadTripPlugin(simResults, units, yAxis, iceTimeMin, iceByTestInfo)
                     const lastPt = meta.data[meta.data.length - 1];
                     if (!lastPt) return;
 
-                    const timeLabel = formatTime(sim.totalTimeMin);
-                    const deltaMin  = iceTimeMin != null ? sim.totalTimeMin - iceTimeMin : null;
+                    const timeLabel = sim.completed === false ? 'did not finish' : formatTime(sim.totalTimeMin);
+                    const deltaMin  = (sim.completed !== false && iceTimeMin != null) ? sim.totalTimeMin - iceTimeMin : null;
                     const absDelta  = deltaMin != null ? Math.abs(deltaMin) : null;
                     const vsIce     = absDelta != null
                         ? (deltaMin > 0 ? `+${formatTime(absDelta)} vs ICE` : `−${formatTime(absDelta)} vs ICE`)
@@ -297,7 +298,9 @@ function makeRoadTripPlugin(simResults, units, yAxis, iceTimeMin, iceByTestInfo)
                     const sim = simResults[si++];
                     if (sim) finishLabels.push({
                         x: lastPt.x, y: lastPt.y,
-                        text: `${ds.label} — ${formatTime(sim.totalTimeMin)}`,
+                        text: sim.completed === false
+                            ? `${ds.label} — did not finish`
+                            : `${ds.label} — ${formatTime(sim.totalTimeMin)}`,
                         color: ds.borderColor,
                     });
                 }
@@ -545,7 +548,7 @@ export default function RoadTripView({
     // ── Run simulation for each entry ─────────────────────────────────────────
     const simResults = useMemo(() => {
         const {
-            startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, overhead,
+            startSoc, minSoc, destinationMinSoc, legDistance, chargeTime, totalDistance, speed, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
 
@@ -561,6 +564,7 @@ export default function RoadTripView({
                 chargingData,
                 startSoc,
                 minSoc,
+                destinationMinSoc,
                 legDistanceMi:     legDistance,
                 totalDistanceMi:   totalDistance,
                 speedMph:          speed,
@@ -582,7 +586,7 @@ export default function RoadTripView({
     const speedSweepResults = useMemo(() => {
         if (roadTripConfig.xAxis !== 'speed') return null;
         const {
-            startSoc, minSoc, legDistance, chargeTime, totalDistance, mode, overhead,
+            startSoc, minSoc, destinationMinSoc, legDistance, chargeTime, totalDistance, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
         return validEntries.map(entry => {
@@ -592,7 +596,7 @@ export default function RoadTripView({
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
-                startSoc, minSoc,
+                startSoc, minSoc, destinationMinSoc,
                 legDistanceMi:     legDistance,
                 totalDistanceMi:   totalDistance,
                 speedMph,
@@ -608,7 +612,7 @@ export default function RoadTripView({
     const distSweepResults = useMemo(() => {
         if (roadTripConfig.xAxis !== 'tripDist') return null;
         const {
-            startSoc, minSoc, chargeTime, totalDistance, speed, mode, overhead,
+            startSoc, minSoc, destinationMinSoc, chargeTime, totalDistance, speed, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
         return validEntries.map(entry => {
@@ -618,7 +622,7 @@ export default function RoadTripView({
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
-                startSoc, minSoc,
+                startSoc, minSoc, destinationMinSoc,
                 legDistanceMi:     legMi,
                 totalDistanceMi:   totalDistance,
                 speedMph:          speed,
@@ -1200,7 +1204,7 @@ export default function RoadTripView({
 
     // ── Render ───────────────────────────────────────────────────────────────
     const {
-        startSoc, minSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, sweepYAxis, overhead,
+        startSoc, minSoc, destinationMinSoc, legDistance, chargeTime, totalDistance, speed, mode, yAxis, xAxis, sweepYAxis, overhead,
         towingMode, towingEfficiency, towingRefSpeedMph,
     } = roadTripConfig;
     const isSpeedMode    = xAxis === 'speed';
@@ -1358,7 +1362,15 @@ export default function RoadTripView({
                             <span className="font-medium block mb-1 whitespace-nowrap">Min SoC (%)</span>
                             <input type="number" className="w-full border rounded px-2 py-1"
                                 min={0} max={30} value={minSoc}
+                                title="Lowest SoC before charging en route"
                                 onChange={e => setField('minSoc', Number(e.target.value))} />
+                        </label>
+                        <label className="text-sm">
+                            <span className="font-medium block mb-1 whitespace-nowrap">Dest. SoC (%)</span>
+                            <input type="number" className="w-full border rounded px-2 py-1"
+                                min={0} max={90} value={destinationMinSoc ?? minSoc}
+                                title="SoC to arrive at the destination with. Higher than Min SoC keeps a bigger buffer for the final leg."
+                                onChange={e => setField('destinationMinSoc', Number(e.target.value))} />
                         </label>
                         {mode === 'distance' && !isTripDistMode && (
                             <label className="text-sm">
@@ -1662,7 +1674,11 @@ export default function RoadTripView({
                                                     </div>
                                                 </div>
                                             </td>
-                                            <td className="px-3 py-2 font-medium">{formatTime(sim.totalTimeMin)}</td>
+                                            <td className="px-3 py-2 font-medium">
+                                                {sim.completed === false
+                                                    ? <span className="text-red-500" title={`Only reached ${Math.round(convDistance(sim.totalDistMi, units))} ${dl} of ${Math.round(convDistance(totalDistance, units))} ${dl}`}>Did not finish</span>
+                                                    : formatTime(sim.totalTimeMin)}
+                                            </td>
                                             <td className="px-3 py-2">{sim.chargeStops}</td>
                                             <td className="px-3 py-2">{sim.chargeStops > 0 ? formatTime(avgChargeTime) : '—'}</td>
                                             <td className="px-3 py-2">
@@ -1697,7 +1713,7 @@ export default function RoadTripView({
                                                 )}
                                             </td>
                                             <td className="px-3 py-2 font-medium">
-                                                {(() => {
+                                                {sim.completed === false ? <span className="text-faint">—</span> : (() => {
                                                     const absDelta = Math.abs(vsIce);
                                                     const h = Math.floor(absDelta / 60);
                                                     const m = Math.round(absDelta % 60);

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1341,7 +1341,7 @@ export default function RoadTripView({
                         </div>
                     )}
 
-                    <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 mb-4">
+                    <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-4">
                         <label className="text-sm">
                             <span className="font-medium block mb-1 whitespace-nowrap">Start SoC (%)</span>
                             <input type="number" className="w-full border rounded px-2 py-1"

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1007,19 +1007,9 @@ export default function RoadTripView({
         const autoXMax = isDriveTimeXAxis ? maxDriveTime * 1.15 : maxTime * 1.15;
         const autoYMax = isChargeTimeMode ? Math.ceil(maxChargeTime * 1.2 / 10) * 10 : totalDistDisplay;
 
-        // Default X minimum: time of the earliest first charge stop.
-        // In drive-time X mode, compute cumulative drive time up to first stop.
-        const firstChargeStart = isDriveTimeXAxis
-            ? Math.min(...validSims.map(s => {
-                let cum = 0;
-                for (const seg of s.segments) {
-                    if (seg.type === 'charge') return cum;
-                    cum += seg.endTime - seg.startTime;
-                }
-                return Infinity;
-            }))
-            : Math.min(...validSims.map(s => s.segments.find(seg => seg.type === 'charge')?.startTime ?? Infinity));
-        const autoXMin = isFinite(firstChargeStart) && firstChargeStart > 0 ? firstChargeStart : 0;
+        // Default X minimum is always 0 — the trip starts at the origin, not at
+        // the first charging stop.
+        const autoXMin = 0;
 
         chartRef.current = new Chart(canvasRef.current, {
             type: 'line',

--- a/src/utils/roadTripSimulation.js
+++ b/src/utils/roadTripSimulation.js
@@ -188,12 +188,15 @@ export function simulateRoadTrip({
         const tStart = timeAtSoc(currentSoc);
 
         if (mode === 'distance') {
-            if (canFinishNext) {
-                // Last stop — charge only enough to arrive at destFloor.
-                targetSoc = Math.min(100, Math.max(arrivalRequiredSoc, currentSoc + 1));
+            // Final (short) leg once the remaining trip fits within ~one leg — charge
+            // only enough to cover it and arrive at destFloor. A <2 mi leftover is
+            // absorbed into this leg to avoid a phantom tiny final stop. Otherwise add
+            // exactly one leg's worth of range (never the whole remaining trip).
+            const isLastLeg = remaining <= legDistanceMi + 2.0;
+            if (isLastLeg) {
+                targetSoc = Math.min(100, Math.max(destFloor + socForMiles(remaining), currentSoc + 1));
             } else {
-                // Add one leg's worth of range, capped at 100%.
-                targetSoc = Math.min(currentSoc + socForMiles(Math.min(legDistanceMi, remaining)), 100);
+                targetSoc = Math.min(currentSoc + socForMiles(legDistanceMi), 100);
                 targetSoc = Math.max(targetSoc, currentSoc + 1);
             }
             const tEnd = timeAtSoc(targetSoc);

--- a/src/utils/roadTripSimulation.js
+++ b/src/utils/roadTripSimulation.js
@@ -5,8 +5,53 @@ import { convDistance, roundTo } from './unitConversions';
 const AERO_FRACTION        = 0.70; // fraction of energy from aero drag at ref speed (unladen EV)
 const TOWING_AERO_FRACTION = 0.85; // higher aero fraction when towing — trailer roughly doubles Cd×A
 const REFERENCE_SPEED      = 70;   // mph
-const MAX_ITERATIONS       = 50;   // safety guard against infinite loops
+const MAX_ITERATIONS       = 200;  // safety guard against infinite loops (≈ enough stops for any trip)
 const MIN_DRIVE_MI         = 0.1;  // minimum driveable distance before bailing
+const TAIL_END_KW          = 5;    // assumed charging power at 100% SoC for the synthetic tail
+const TAIL_STEP_SOC        = 2;    // % SoC step when generating the synthetic high-SoC tail
+
+// ── High-SoC charging tail ─────────────────────────────────────────────────────
+
+/**
+ * Extend a measured charging curve above its last data point with a synthetic
+ * tail: charger power declines linearly from the curve's end power down to
+ * TAIL_END_KW at 100% SoC, integrated to elapsed time. This replaces slope
+ * extrapolation of the time curve (which under-reports, since charge time is
+ * convex in SoC) with a physically-shaped taper. Cheap — ~a dozen points.
+ *
+ * @param {Array}  sortedBySoc  Measured points sorted ascending by soc, each {soc,time,chargeRate?}
+ * @param {number} batteryKwh   Usable capacity (kWh)
+ * @returns {Array} synthetic points {soc,time,chargeRate} above the measured max SoC (may be empty)
+ */
+export function buildChargeTail(sortedBySoc, batteryKwh) {
+    const last = sortedBySoc[sortedBySoc.length - 1];
+    if (!last || last.soc >= 100 - 1e-6 || !batteryKwh || batteryKwh <= 0) return [];
+
+    // End power: prefer the slope of the last measured segment (kW into the pack,
+    // consistent with the time curve we're extending); fall back to charge_rate.
+    const prev = sortedBySoc[sortedBySoc.length - 2];
+    let endKw = null;
+    if (prev) {
+        const dSoc = last.soc - prev.soc, dMin = last.time - prev.time;
+        if (dSoc > 0 && dMin > 0) endKw = (batteryKwh * dSoc / 100) / (dMin / 60);
+    }
+    if (!endKw || !isFinite(endKw) || endKw <= 0) endKw = last.chargeRate ?? 50;
+
+    const p100    = Math.min(TAIL_END_KW, endKw); // never let power rise toward 100%
+    const powerAt = soc => endKw + (p100 - endKw) * (soc - last.soc) / (100 - last.soc);
+
+    const tail = [];
+    let t = last.time, prevSoc = last.soc;
+    for (let soc = last.soc + TAIL_STEP_SOC; soc < 100 + TAIL_STEP_SOC; soc += TAIL_STEP_SOC) {
+        const s = Math.min(soc, 100);
+        const avgKw = (powerAt(prevSoc) + powerAt(s)) / 2;
+        if (avgKw > 0) t += (batteryKwh * (s - prevSoc) / 100) / (avgKw / 60);
+        tail.push({ soc: s, time: round1(t), chargeRate: round1(powerAt(s)) });
+        prevSoc = s;
+        if (s >= 100) break;
+    }
+    return tail;
+}
 
 // ── Speed correction ─────────────────────────────────────────────────────────
 
@@ -38,7 +83,9 @@ export function speedCorrectionFactor(travelMph, testMph, aeroFraction = AERO_FR
  * @param {number}  params.testSpeedMph     Speed the range test was conducted at
  * @param {Array}   params.chargingData     Charging run data points (sorted by frame)
  * @param {number}  params.startSoc         Starting SoC (0–100)
- * @param {number}  params.minSoc           Minimum SoC before charging (0–100)
+ * @param {number}  params.minSoc           Minimum SoC before charging en route (0–100)
+ * @param {number}  [params.destinationMinSoc] SoC to arrive at the destination with
+ *   (defaults to minSoc). Lets the final leg keep a bigger buffer than en-route stops.
  * @param {number}  params.legDistanceMi    Miles of range added per charging stop (distance mode)
  * @param {number}  params.totalDistanceMi  Total trip distance
  * @param {number}  params.speedMph         Travel speed
@@ -47,34 +94,43 @@ export function speedCorrectionFactor(travelMph, testMph, aeroFraction = AERO_FR
  * @param {number}  [params.overheadMinutes] Per-stop overhead (default 5)
  * @param {boolean} [params.towingMode]      When true, use higher aero fraction for speed correction
  *
- * @returns {{ segments, totalTimeMin, chargeStops, warnings, speedFactor }}
+ * @returns {{ segments, totalTimeMin, totalDistMi, chargeStops, warnings, speedFactor, correctedMiPerKwh, completed }}
  */
 export function simulateRoadTrip({
     batteryKwh, miPerKwh, testSpeedMph, chargingData,
-    startSoc, minSoc, legDistanceMi, totalDistanceMi,
+    startSoc, minSoc, destinationMinSoc, legDistanceMi, totalDistanceMi,
     speedMph, chargeTimeMinutes = 30, mode = 'distance',
     overheadMinutes = 5, towingMode = false,
 }) {
     const warnings = [];
     const segments = [];
 
+    // Arrival buffer defaults to the en-route floor (no behaviour change until set).
+    const destFloor = (destinationMinSoc != null && !isNaN(destinationMinSoc)) ? destinationMinSoc : minSoc;
+
     // Speed correction — use higher aero fraction when towing (trailer raises Cd×A of system)
     const aeroFrac = towingMode ? TOWING_AERO_FRACTION : AERO_FRACTION;
     const factor = speedCorrectionFactor(speedMph, testSpeedMph, aeroFrac);
     const correctedMiPerKwh = miPerKwh / factor;
 
-    // Prepare charging curve sorted by SoC and by time
-    const chargingBySoc = chargingData
+    // Prepare charging curve sorted by SoC, extended with a synthetic high-SoC tail
+    // so charging past the measured data tapers realistically instead of via slope
+    // extrapolation. Both lookup orders share the augmented curve.
+    const measuredBySoc = chargingData
         .filter(p => p.soc != null && p.time != null)
         .sort((a, b) => a.soc - b.soc);
 
-    const chargingByTime = chargingData
-        .filter(p => p.soc != null && p.time != null)
-        .sort((a, b) => a.time - b.time);
-
-    if (chargingBySoc.length < 2) {
+    if (measuredBySoc.length < 2) {
         warnings.push('Insufficient charging data points');
     }
+
+    const curveBySoc  = [...measuredBySoc, ...buildChargeTail(measuredBySoc, batteryKwh)];
+    const curveByTime = [...curveBySoc].sort((a, b) => a.time - b.time);
+
+    // Range (mi) available driving from `soc` down to a given floor.
+    const rangeFrom = (soc, floor) => batteryKwh * (soc - floor) / 100 * correctedMiPerKwh;
+    // SoC needed now to cover `mi` of driving.
+    const socForMiles = mi => (mi / (batteryKwh * correctedMiPerKwh)) * 100;
 
     let currentSoc  = startSoc;
     let currentDist = 0;
@@ -86,19 +142,20 @@ export function simulateRoadTrip({
         iterations++;
 
         // ── DRIVE ────────────────────────────────────────────────────────
-        const rangeFromSoc  = batteryKwh * (currentSoc - minSoc) / 100 * correctedMiPerKwh;
         const remainingTrip = totalDistanceMi - currentDist;
 
-        // Both modes: drive until minSoc (or trip end).
-        // Distance mode adds a fixed amount of charge at each stop rather than stopping at fixed intervals.
-        const driveDist = Math.max(0, Math.min(rangeFromSoc, remainingTrip));
+        // Final leg if we can reach the destination while keeping ≥ destFloor;
+        // otherwise drive down to the en-route floor (minSoc) and charge.
+        const driveDist = (rangeFrom(currentSoc, destFloor) >= remainingTrip - 0.01)
+            ? remainingTrip
+            : Math.max(0, Math.min(rangeFrom(currentSoc, minSoc), remainingTrip));
 
         if (driveDist < MIN_DRIVE_MI && currentDist < totalDistanceMi) {
             warnings.push('Battery depleted: cannot drive far enough to reach next charger');
             break;
         }
 
-        const socUsed   = (driveDist / (batteryKwh * correctedMiPerKwh)) * 100;
+        const socUsed   = socForMiles(driveDist);
         const driveTime = (driveDist / speedMph) * 60; // minutes
 
         segments.push({
@@ -122,40 +179,45 @@ export function simulateRoadTrip({
         chargeStops++;
         let chargeTime, targetSoc;
 
+        // SoC needed here to finish the whole remaining trip arriving at destFloor.
+        const remaining = totalDistanceMi - currentDist;
+        const arrivalRequiredSoc = destFloor + socForMiles(remaining);
+        const canFinishNext = arrivalRequiredSoc <= 100 + 1e-6;
+
+        const timeAtSoc = soc => interpolate(curveBySoc, 'soc', 'time', soc, true, true);
+        const tStart = timeAtSoc(currentSoc);
+
         if (mode === 'distance') {
-            // Add a fixed number of miles of range per stop (legDistanceMi), capped at
-            // what's needed for the remaining trip and at 100% SoC.
-            // If the leftover after one legDistanceMi charge would be tiny (< 2 mi),
-            // extend this stop to cover the whole remaining distance — avoids phantom stops
-            // when the trip distance doesn't divide evenly by the leg size.
-            const remaining  = totalDistanceMi - currentDist;
-            const leftover   = remaining - legDistanceMi;
-            const chargeMi   = (leftover > 0 && leftover < 2.0) ? remaining : Math.min(legDistanceMi, remaining);
-            const socToAdd   = (chargeMi / (batteryKwh * correctedMiPerKwh)) * 100;
-            targetSoc = Math.min(currentSoc + socToAdd, 100);
-            targetSoc = Math.max(targetSoc, currentSoc + 1);
-
-            const tStart = interpolate(chargingBySoc, 'soc', 'time', currentSoc, true, true);
-            const tEnd   = interpolate(chargingBySoc, 'soc', 'time', targetSoc,  true, true);
-
-            if (tStart == null || tEnd == null) {
-                warnings.push(`Charging data incomplete for SoC ${round1(currentSoc)}%-${round1(targetSoc)}%`);
-                chargeTime = (targetSoc - currentSoc) * 0.5; // fallback: ~0.5 min per %
+            if (canFinishNext) {
+                // Last stop — charge only enough to arrive at destFloor.
+                targetSoc = Math.min(100, Math.max(arrivalRequiredSoc, currentSoc + 1));
             } else {
-                chargeTime = Math.max(0, tEnd - tStart);
+                // Add one leg's worth of range, capped at 100%.
+                targetSoc = Math.min(currentSoc + socForMiles(Math.min(legDistanceMi, remaining)), 100);
+                targetSoc = Math.max(targetSoc, currentSoc + 1);
             }
+            const tEnd = timeAtSoc(targetSoc);
+            chargeTime = (tStart != null && tEnd != null)
+                ? Math.max(0, tEnd - tStart)
+                : (targetSoc - currentSoc) * 0.5; // fallback: ~0.5 min per %
         } else {
-            // Mode B: charge for fixed time
-            const tStart = interpolate(chargingBySoc, 'soc', 'time', currentSoc, true, true);
-            if (tStart == null) {
-                warnings.push(`Charging data incomplete at SoC ${round1(currentSoc)}%`);
-                targetSoc = Math.min(currentSoc + chargeTimeMinutes * 2, 100); // rough fallback
+            // Fixed-time mode. On the final approach, charge only as long as needed
+            // to reach the destination rather than the full fixed duration.
+            const timeToArrival = (canFinishNext && tStart != null) ? (timeAtSoc(arrivalRequiredSoc) - tStart) : Infinity;
+            if (canFinishNext && isFinite(timeToArrival) && timeToArrival <= chargeTimeMinutes) {
+                targetSoc  = Math.min(100, Math.max(arrivalRequiredSoc, currentSoc + 1));
+                chargeTime = Math.max(0, timeToArrival);
             } else {
-                const tEnd = tStart + chargeTimeMinutes;
-                const endSoc = interpolate(chargingByTime, 'time', 'soc', tEnd, false, true);
-                targetSoc = endSoc != null ? Math.min(endSoc, 100) : Math.min(currentSoc + chargeTimeMinutes * 2, 100);
+                // Normal full-duration stop.
+                if (tStart == null) {
+                    warnings.push(`Charging data incomplete at SoC ${round1(currentSoc)}%`);
+                    targetSoc = Math.min(currentSoc + chargeTimeMinutes * 2, 100); // rough fallback
+                } else {
+                    const endSoc = interpolate(curveByTime, 'time', 'soc', tStart + chargeTimeMinutes, false, true);
+                    targetSoc = endSoc != null ? Math.min(endSoc, 100) : Math.min(currentSoc + chargeTimeMinutes * 2, 100);
+                }
+                chargeTime = chargeTimeMinutes;
             }
-            chargeTime = chargeTimeMinutes;
 
             if (targetSoc <= currentSoc + 1) {
                 warnings.push('Charger too slow for meaningful charge');
@@ -179,8 +241,14 @@ export function simulateRoadTrip({
         currentSoc   = targetSoc;
     }
 
-    if (iterations >= MAX_ITERATIONS) {
-        warnings.push('Simulation reached maximum iterations');
+    const completed = currentDist >= totalDistanceMi - 0.01;
+    if (iterations >= MAX_ITERATIONS && !completed) {
+        warnings.push('Could not complete trip: too many charging stops required');
+    }
+    // Reached the destination but below the requested arrival buffer (the buffer was
+    // unachievable given battery / efficiency / charging limits).
+    if (completed && destFloor > minSoc && currentSoc < destFloor - 0.5) {
+        warnings.push(`Arrived at ${round1(currentSoc)}% — below the ${round1(destFloor)}% destination minimum`);
     }
 
     return {
@@ -191,6 +259,7 @@ export function simulateRoadTrip({
         warnings,
         speedFactor: factor,
         correctedMiPerKwh,
+        completed,
     };
 }
 


### PR DESCRIPTION
Bundles the interrelated road-trip simulation fixes (#2/#3/#4 from the review).

## 1. Realistic high-SoC charging tail (#2)
The sim interpolated charge time with slope extrapolation on both ends, so a car whose charging test only reached, say, 60% SoC would "charge" to 100% with badly **under-reported** time (charge time is convex in SoC). Now, above the measured curve, charger power is modeled **declining linearly from the curve's end power to ~5 kW at 100%** and integrated to time — a physically-shaped taper. It's cheap: ~12 synthetic points (`buildChargeTail`), generated once per run, appended to the curve so existing interpolation just works.

Example (curve ending at 60% / 80 kWh): the tail now takes ~112 min to go 60→100%, vs. a near-linear underestimate before.

## 2. `destinationMinSoc` — separate arrival buffer (#4)
`minSoc` was doing double duty as the en-route charging floor *and* the arrival SoC. New **Dest. SoC** setting lets you arrive with a bigger buffer than your en-route minimum. Defaults to `minSoc`, so **behaviour is unchanged until raised**. The final leg targets arrival at this SoC.

## 3. Trimmed last stop (#3)
In fixed-time mode every charge was the full duration — including the last one. The stop before the final leg now charges only as long as needed to reach the destination at `destinationMinSoc` (verified: a 30-min-stop trip trims its last stop to ~9 min). Distance mode already trimmed; both now go through the same arrival-requirement logic.

## 4. Honest incompletion
`MAX_ITERATIONS` raised 50→200. When a trip still can't complete, the result is `completed: false` and shows **"Did not finish"** in the chart finish labels, byTest callouts, and summary table (Total Time + vs-ICE), instead of a bogus finish time. `isSimUnrealistic` keys off the flag so sweeps end their lines correctly too.

## Verification
- Bundled-unit-tested: tail taper, distance-mode last-stop trim (arrives exactly at floor), `destinationMinSoc=40` forces 40% arrival with an extra stop, time-mode last stop 30→9 min, and a 20 kWh / 5000 mi stress case completes with 79 stops (no fake infinity).
- `npm run build` green; app boots with no console errors.

Per your call, `destinationMinSoc` is **not** URL-encoded (consistent with the other settings that currently don't round-trip).

Follow-up: **PR B** (per-vehicle charging-strategy overrides) is separate and coming next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)