### PR TITLE
Road trip: per-run charging-strategy overrides

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,7 @@ export default function App() {
         towingMode: false,        // override all vehicle efficiencies with a fixed trailer-system value
         towingEfficiency: 1.5,    // mi/kWh for the whole vehicle+trailer system
         towingRefSpeedMph: 70,    // speed at which towingEfficiency was measured
+        perRun: {},               // { [runId]: { minSoc?, legDistance?, chargeTime? } } — per-run overrides
     });
     const [chartConfig, setChartConfig] = useState({
         xAxis: 'soc',

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -111,54 +111,97 @@ const PALETTE = [
     '#3b82f6', '#a855f7', '#ec4899', '#14b8a6',
 ];
 
-// ── Per-run override inputs ───────────────────────────────────────────────────
-// Two compact overrides shown beside each selected run: en-route arrival SoC
-// (minSoc) and the mode-dependent charge amount (leg distance / charge time).
-// Empty shows the global value greyed as a placeholder; typing overrides it.
-function RunOverrideInputs({ runId, override, mode, global, units, dl, onChange }) {
-    const num = (v, key, cls) => (
-        <input
-            type="number"
-            value={v === '' || v == null ? '' : v}
-            placeholder={key.placeholder}
-            onChange={key.onChange}
-            onClick={e => e.stopPropagation()}
-            className={`border rounded px-1 py-0.5 text-xs ${cls}`}
-        />
-    );
-    const legGlobal = units === 'metric' ? Math.round(global.legDistance * MI_TO_KM) : global.legDistance;
-    const legValue  = override.legDistance != null
-        ? (units === 'metric' ? Math.round(override.legDistance * MI_TO_KM) : override.legDistance)
-        : '';
+// ── Per-run routing overrides panel ───────────────────────────────────────────
+// Dedicated collapsible section listing the selected runs with per-run overrides
+// of the charging strategy: en-route Charger Arrival SoC (minSoc) and the
+// mode-dependent charge amount (leg distance / charge time). Blank shows the
+// global value greyed as a placeholder; typing overrides just that run.
+function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onChange }) {
+    const [open, setOpen] = useState(false);
+    if (!entries.length) return null;
+
+    const customized  = entries.filter(e => Object.keys(perRun[e.run.id] || {}).length).length;
+    const legGlobal   = units === 'metric' ? Math.round(global.legDistance * MI_TO_KM) : global.legDistance;
+    const amountLabel = mode === 'distance' ? `Leg Distance (${dl})` : 'Charge Time (min)';
+
+    const cell = 'px-3 py-2 text-left font-semibold text-muted whitespace-nowrap';
+    const inputCls = 'w-20 border rounded px-2 py-1 text-sm';
 
     return (
-        <span className="inline-flex items-center gap-1 ml-2 align-middle" onClick={e => e.stopPropagation()}>
-            <span className="text-[10px] text-faint">arr SoC</span>
-            {num(override.minSoc ?? '', {
-                placeholder: `${global.minSoc}`,
-                onChange: e => onChange(runId, 'minSoc', e.target.value),
-            }, 'w-11')}
-            {mode === 'distance' ? (
-                <>
-                    <span className="text-[10px] text-faint">leg {dl}</span>
-                    {num(legValue, {
-                        placeholder: `${legGlobal}`,
-                        onChange: e => {
-                            const v = e.target.value;
-                            onChange(runId, 'legDistance', v === '' ? '' : (units === 'metric' ? Number(v) / MI_TO_KM : Number(v)));
-                        },
-                    }, 'w-14')}
-                </>
-            ) : (
-                <>
-                    <span className="text-[10px] text-faint">chg min</span>
-                    {num(override.chargeTime ?? '', {
-                        placeholder: `${global.chargeTime}`,
-                        onChange: e => onChange(runId, 'chargeTime', e.target.value),
-                    }, 'w-12')}
-                </>
+        <div className="mt-4">
+            <button onClick={() => setOpen(o => !o)} className="run-selector-header">
+                <span style={{ display: 'inline-block', transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
+                Customize routing
+                <span className="text-sm font-normal text-muted">
+                    {customized ? `(${customized} customized)` : '(optional — per test)'}
+                </span>
+            </button>
+
+            {open && (
+                <div className="mt-3 overflow-x-auto">
+                    <table className="text-sm">
+                        <thead className="bg-[var(--color-surface-muted)]">
+                            <tr>
+                                <th className={cell}>Test</th>
+                                <th className={cell}>Charger Arrival SoC (%)</th>
+                                <th className={cell}>{amountLabel}</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y dark:divide-slate-700">
+                            {entries.map(e => {
+                                const ov = perRun[e.run.id] || {};
+                                const legValue = ov.legDistance != null
+                                    ? (units === 'metric' ? Math.round(ov.legDistance * MI_TO_KM) : ov.legDistance)
+                                    : '';
+                                return (
+                                    <tr key={e.run.id}>
+                                        <td className="px-3 py-2">
+                                            <span className="flex items-center gap-2">
+                                                <span className="inline-block w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
+                                                <span className="text-secondary">{vehicleLabel(e.vehicle)}</span>
+                                                <span className="text-muted">· {e.run.name}</span>
+                                            </span>
+                                        </td>
+                                        <td className="px-3 py-2">
+                                            <input
+                                                type="number" min={0} max={100}
+                                                className={inputCls}
+                                                placeholder={`${global.minSoc}`}
+                                                value={ov.minSoc ?? ''}
+                                                onChange={ev => onChange(e.run.id, 'minSoc', ev.target.value)}
+                                            />
+                                        </td>
+                                        <td className="px-3 py-2">
+                                            {mode === 'distance' ? (
+                                                <input
+                                                    type="number" min={0}
+                                                    className={inputCls}
+                                                    placeholder={`${legGlobal}`}
+                                                    value={legValue}
+                                                    onChange={ev => {
+                                                        const v = ev.target.value;
+                                                        onChange(e.run.id, 'legDistance', v === '' ? '' : (units === 'metric' ? Number(v) / MI_TO_KM : Number(v)));
+                                                    }}
+                                                />
+                                            ) : (
+                                                <input
+                                                    type="number" min={0}
+                                                    className={inputCls}
+                                                    placeholder={`${global.chargeTime}`}
+                                                    value={ov.chargeTime ?? ''}
+                                                    onChange={ev => onChange(e.run.id, 'chargeTime', ev.target.value)}
+                                                />
+                                            )}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                    <p className="text-xs text-muted mt-2">Blank fields use the global value shown as a placeholder.</p>
+                </div>
             )}
-        </span>
+        </div>
     );
 }
 
@@ -1299,8 +1342,14 @@ export default function RoadTripView({
     const setRunOverride = (runId, key, rawVal) => setRoadTripConfig(prev => {
         const perRun = { ...(prev.perRun || {}) };
         const cur = { ...(perRun[runId] || {}) };
-        if (rawVal === '' || rawVal == null || isNaN(Number(rawVal))) delete cur[key];
-        else cur[key] = Number(rawVal);
+        if (rawVal === '' || rawVal == null || isNaN(Number(rawVal))) {
+            delete cur[key];
+        } else {
+            // Never below 0; SoC additionally capped at 100.
+            let n = Math.max(0, Number(rawVal));
+            if (key === 'minSoc') n = Math.min(100, n);
+            cur[key] = n;
+        }
         if (Object.keys(cur).length) perRun[runId] = cur;
         else delete perRun[runId];
         return { ...prev, perRun };
@@ -1595,7 +1644,6 @@ export default function RoadTripView({
                                 const spd = entry.testSpeedMph
                                     ? `${fmtSpeed(entry.testSpeedMph, units)}`
                                     : '70 mph (assumed)';
-                                const selected = selectedRunIds.some(id => String(id) === String(run.id));
                                 return (
                                     <span className="text-xs text-faint ml-1">
                                         {eff} {units === 'metric' ? 'km/kWh' : 'mi/kWh'} @ {spd}
@@ -1605,6 +1653,19 @@ export default function RoadTripView({
                             }}
                         />
                     </div>
+
+                    {/* Per-run routing overrides */}
+                    {!isSweepMode && (
+                        <RoutingOverridesPanel
+                            entries={validEntries}
+                            perRun={roadTripConfig.perRun || {}}
+                            mode={mode}
+                            global={{ minSoc, legDistance, chargeTime }}
+                            units={units}
+                            dl={dl}
+                            onChange={setRunOverride}
+                        />
+                    )}
 
                     {/* Warnings for vehicles/runs that can't be simulated */}
                     {(vehiclesWithNoChargingRuns.length > 0 || skippedEntries.length > 0) && (

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -111,8 +111,16 @@ const PALETTE = [
     '#3b82f6', '#a855f7', '#ec4899', '#14b8a6',
 ];
 
-// ── Per-run routing overrides panel ───────────────────────────────────────────
-// Dedicated collapsible section listing the selected runs with per-run overrides
+// ── Per-row routing overrides panel ───────────────────────────────────────────
+//
+// Keyed by PAIR KEY, not charging-run id. When this was written a road-trip row
+// was a charging run, so the run's id identified it. Since the pairing epic a
+// row is a (range test × charging test) pair, and one charging run can appear in
+// several rows against different range tests — so a run id would have made two
+// distinct simulations share one override, and collide as React keys besides.
+// Every other per-row thing here (colour, label, selection) is already keyed
+// this way.
+// Dedicated collapsible section listing the selected rows with per-row overrides
 // of the charging strategy: en-route Charger Arrival SoC (minSoc) and the
 // mode-dependent charge amount (leg distance / charge time). Blank shows the
 // global value greyed as a placeholder; typing overrides just that run.
@@ -120,7 +128,7 @@ function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onCha
     const [open, setOpen] = useState(false);
     if (!entries.length) return null;
 
-    const customized  = entries.filter(e => Object.keys(perRun[e.run.id] || {}).length).length;
+    const customized  = entries.filter(e => Object.keys(perRun[e.key] || {}).length).length;
     const legGlobal   = units === 'metric' ? Math.round(global.legDistance * MI_TO_KM) : global.legDistance;
     const amountLabel = mode === 'distance' ? `Leg Distance (${dl})` : 'Charge Time (min)';
 
@@ -149,17 +157,20 @@ function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onCha
                         </thead>
                         <tbody className="divide-y dark:divide-slate-700">
                             {entries.map(e => {
-                                const ov = perRun[e.run.id] || {};
+                                const ov = perRun[e.key] || {};
                                 const legValue = ov.legDistance != null
                                     ? (units === 'metric' ? Math.round(ov.legDistance * MI_TO_KM) : ov.legDistance)
                                     : '';
                                 return (
-                                    <tr key={e.run.id}>
+                                    <tr key={e.key}>
                                         <td className="px-3 py-2">
                                             <span className="flex items-center gap-2">
                                                 <span className="inline-block w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: e.color }} />
                                                 <span className="text-secondary">{vehicleLabel(e.vehicle)}</span>
-                                                <span className="text-muted">· {e.run.name}</span>
+                                                <span className="text-muted">· {e.rangeRun?.name ?? e.run.name}</span>
+                                                {e.rangeRun && e.run?.name && (
+                                                    <span className="text-faint">· {e.run.name}</span>
+                                                )}
                                             </span>
                                         </td>
                                         <td className="px-3 py-2">
@@ -168,7 +179,7 @@ function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onCha
                                                 className={inputCls}
                                                 placeholder={`${global.minSoc}`}
                                                 value={ov.minSoc ?? ''}
-                                                onChange={ev => onChange(e.run.id, 'minSoc', ev.target.value)}
+                                                onChange={ev => onChange(e.key, 'minSoc', ev.target.value)}
                                             />
                                         </td>
                                         <td className="px-3 py-2">
@@ -180,7 +191,7 @@ function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onCha
                                                     value={legValue}
                                                     onChange={ev => {
                                                         const v = ev.target.value;
-                                                        onChange(e.run.id, 'legDistance', v === '' ? '' : (units === 'metric' ? Number(v) / MI_TO_KM : Number(v)));
+                                                        onChange(e.key, 'legDistance', v === '' ? '' : (units === 'metric' ? Number(v) / MI_TO_KM : Number(v)));
                                                     }}
                                                 />
                                             ) : (
@@ -189,7 +200,7 @@ function RoutingOverridesPanel({ entries, perRun, mode, global, units, dl, onCha
                                                     className={inputCls}
                                                     placeholder={`${global.chargeTime}`}
                                                     value={ov.chargeTime ?? ''}
-                                                    onChange={ev => onChange(e.run.id, 'chargeTime', ev.target.value)}
+                                                    onChange={ev => onChange(e.key, 'chargeTime', ev.target.value)}
                                                 />
                                             )}
                                         </td>
@@ -706,7 +717,7 @@ export default function RoadTripView({
             const chargingData = runDataCache[entry.run.id];
             if (!chargingData || chargingData.length === 0) return null;
 
-            const ov = perRun[entry.run.id] || {};
+            const ov = perRun[entry.key] || {};
             const result = simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 // Towing: all vehicles share the same system efficiency; battery still varies per vehicle
@@ -743,7 +754,7 @@ export default function RoadTripView({
         const perRun = roadTripConfig.perRun || {};
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id] ?? [];
-            const ov = perRun[entry.run.id] || {};
+            const ov = perRun[entry.key] || {};
             return SPEED_SWEEP_MPH.map(speedMph => simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
@@ -771,7 +782,7 @@ export default function RoadTripView({
         const perRun = roadTripConfig.perRun || {};
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id] ?? [];
-            const ov = perRun[entry.run.id] || {};
+            const ov = perRun[entry.key] || {};
             // Leg distance is the swept axis here, so a per-run leg override doesn't apply.
             return LEG_SWEEP_MI.map(legMi => simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
@@ -1337,8 +1348,9 @@ export default function RoadTripView({
     // ── Config update helper ─────────────────────────────────────────────────
     const setField = (key, value) => setRoadTripConfig(prev => ({ ...prev, [key]: value }));
 
-    // Per-run override setter. Empty/invalid clears the override (falls back to global);
-    // prunes empty run entries so unset runs use globals cleanly.
+    // Per-row override setter, keyed by pair key. Empty/invalid clears the
+    // override (falls back to global); prunes empty entries so unset rows use
+    // globals cleanly.
     const setRunOverride = (runId, key, rawVal) => setRoadTripConfig(prev => {
         const perRun = { ...(prev.perRun || {}) };
         const cur = { ...(perRun[runId] || {}) };

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -111,6 +111,57 @@ const PALETTE = [
     '#3b82f6', '#a855f7', '#ec4899', '#14b8a6',
 ];
 
+// ── Per-run override inputs ───────────────────────────────────────────────────
+// Two compact overrides shown beside each selected run: en-route arrival SoC
+// (minSoc) and the mode-dependent charge amount (leg distance / charge time).
+// Empty shows the global value greyed as a placeholder; typing overrides it.
+function RunOverrideInputs({ runId, override, mode, global, units, dl, onChange }) {
+    const num = (v, key, cls) => (
+        <input
+            type="number"
+            value={v === '' || v == null ? '' : v}
+            placeholder={key.placeholder}
+            onChange={key.onChange}
+            onClick={e => e.stopPropagation()}
+            className={`border rounded px-1 py-0.5 text-xs ${cls}`}
+        />
+    );
+    const legGlobal = units === 'metric' ? Math.round(global.legDistance * MI_TO_KM) : global.legDistance;
+    const legValue  = override.legDistance != null
+        ? (units === 'metric' ? Math.round(override.legDistance * MI_TO_KM) : override.legDistance)
+        : '';
+
+    return (
+        <span className="inline-flex items-center gap-1 ml-2 align-middle" onClick={e => e.stopPropagation()}>
+            <span className="text-[10px] text-faint">arr SoC</span>
+            {num(override.minSoc ?? '', {
+                placeholder: `${global.minSoc}`,
+                onChange: e => onChange(runId, 'minSoc', e.target.value),
+            }, 'w-11')}
+            {mode === 'distance' ? (
+                <>
+                    <span className="text-[10px] text-faint">leg {dl}</span>
+                    {num(legValue, {
+                        placeholder: `${legGlobal}`,
+                        onChange: e => {
+                            const v = e.target.value;
+                            onChange(runId, 'legDistance', v === '' ? '' : (units === 'metric' ? Number(v) / MI_TO_KM : Number(v)));
+                        },
+                    }, 'w-14')}
+                </>
+            ) : (
+                <>
+                    <span className="text-[10px] text-faint">chg min</span>
+                    {num(override.chargeTime ?? '', {
+                        placeholder: `${global.chargeTime}`,
+                        onChange: e => onChange(runId, 'chargeTime', e.target.value),
+                    }, 'w-12')}
+                </>
+            )}
+        </span>
+    );
+}
+
 // ── Chart.js plugin: charging badges + finish labels ─────────────────────────
 function makeRoadTripPlugin(simResults, units, yAxis, iceTimeMin, iceByTestInfo) {
     return {
@@ -606,10 +657,13 @@ export default function RoadTripView({
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
 
+        const perRun = roadTripConfig.perRun || {};
+
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id];
             if (!chargingData || chargingData.length === 0) return null;
 
+            const ov = perRun[entry.run.id] || {};
             const result = simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 // Towing: all vehicles share the same system efficiency; battery still varies per vehicle
@@ -617,12 +671,12 @@ export default function RoadTripView({
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
                 startSoc,
-                minSoc,
+                minSoc:            ov.minSoc ?? minSoc,
                 destinationMinSoc,
-                legDistanceMi:     legDistance,
+                legDistanceMi:     ov.legDistance ?? legDistance,
                 totalDistanceMi:   totalDistance,
                 speedMph:          speed,
-                chargeTimeMinutes: chargeTime,
+                chargeTimeMinutes: ov.chargeTime ?? chargeTime,
                 overheadMinutes:   overhead,
                 mode,
                 towingMode,
@@ -643,18 +697,20 @@ export default function RoadTripView({
             startSoc, minSoc, destinationMinSoc, legDistance, chargeTime, totalDistance, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
+        const perRun = roadTripConfig.perRun || {};
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id] ?? [];
+            const ov = perRun[entry.run.id] || {};
             return SPEED_SWEEP_MPH.map(speedMph => simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
-                startSoc, minSoc, destinationMinSoc,
-                legDistanceMi:     legDistance,
+                startSoc, minSoc: ov.minSoc ?? minSoc, destinationMinSoc,
+                legDistanceMi:     ov.legDistance ?? legDistance,
                 totalDistanceMi:   totalDistance,
                 speedMph,
-                chargeTimeMinutes: chargeTime,
+                chargeTimeMinutes: ov.chargeTime ?? chargeTime,
                 overheadMinutes:   overhead,
                 mode,
                 towingMode,
@@ -669,18 +725,21 @@ export default function RoadTripView({
             startSoc, minSoc, destinationMinSoc, chargeTime, totalDistance, speed, mode, overhead,
             towingMode, towingEfficiency, towingRefSpeedMph,
         } = roadTripConfig;
+        const perRun = roadTripConfig.perRun || {};
         return validEntries.map(entry => {
             const chargingData = runDataCache[entry.run.id] ?? [];
+            const ov = perRun[entry.run.id] || {};
+            // Leg distance is the swept axis here, so a per-run leg override doesn't apply.
             return LEG_SWEEP_MI.map(legMi => simulateRoadTrip({
                 batteryKwh:        entry.batteryKwh,
                 miPerKwh:          towingMode ? towingEfficiency : entry.miPerKwh,
                 testSpeedMph:      towingMode ? towingRefSpeedMph : (entry.testSpeedMph || 70),
                 chargingData,
-                startSoc, minSoc, destinationMinSoc,
+                startSoc, minSoc: ov.minSoc ?? minSoc, destinationMinSoc,
                 legDistanceMi:     legMi,
                 totalDistanceMi:   totalDistance,
                 speedMph:          speed,
-                chargeTimeMinutes: chargeTime,
+                chargeTimeMinutes: ov.chargeTime ?? chargeTime,
                 overheadMinutes:   overhead,
                 mode,
                 towingMode,
@@ -1235,6 +1294,18 @@ export default function RoadTripView({
     // ── Config update helper ─────────────────────────────────────────────────
     const setField = (key, value) => setRoadTripConfig(prev => ({ ...prev, [key]: value }));
 
+    // Per-run override setter. Empty/invalid clears the override (falls back to global);
+    // prunes empty run entries so unset runs use globals cleanly.
+    const setRunOverride = (runId, key, rawVal) => setRoadTripConfig(prev => {
+        const perRun = { ...(prev.perRun || {}) };
+        const cur = { ...(perRun[runId] || {}) };
+        if (rawVal === '' || rawVal == null || isNaN(Number(rawVal))) delete cur[key];
+        else cur[key] = Number(rawVal);
+        if (Object.keys(cur).length) perRun[runId] = cur;
+        else delete perRun[runId];
+        return { ...prev, perRun };
+    });
+
     // ── PNG export ────────────────────────────────────────────────────────────
     const handleCopyImage = async () => {
         if (!chartRef.current) return;
@@ -1524,6 +1595,7 @@ export default function RoadTripView({
                                 const spd = entry.testSpeedMph
                                     ? `${fmtSpeed(entry.testSpeedMph, units)}`
                                     : '70 mph (assumed)';
+                                const selected = selectedRunIds.some(id => String(id) === String(run.id));
                                 return (
                                     <span className="text-xs text-faint ml-1">
                                         {eff} {units === 'metric' ? 'km/kWh' : 'mi/kWh'} @ {spd}

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -147,7 +147,7 @@ export default function RunSelector({
                 className="run-selector-header"
             >
                 <span style={{ display: 'inline-block', transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>&#9660;</span>
-                Select Vehicle Tests to Display
+                Select vehicles &amp; tests
                 <span className="text-sm font-normal text-muted">({selectedCount} selected)</span>
                 {expanded && (
                     <span className="text-xs font-normal text-faint ml-2">· Drag the pills above to reorder</span>


### PR DESCRIPTION
Per-run overrides for the road-trip simulation (PR B from the review).

## What

Each **selected** run can override two charging-strategy settings independently of the global controls, shown as compact inputs beside the run in the selector:

- **arr SoC** — en-route arrival SoC (`minSoc`), i.e. the SoC you charge back up from.
- **leg (mi/km)** *(distance mode)* or **chg min** *(time mode)* — the mode-dependent charge amount.

Empty fields show the **global value greyed as a placeholder**; typing overrides just that run, clearing falls back to the global. Trip-level params (total distance, speed, overhead, destination SoC) stay global — the point is comparing vehicles on the same trip.

## How

- Overrides live in `roadTripConfig.perRun`, keyed by run id: `{ [runId]: { minSoc?, legDistance?, chargeTime? } }`. `setRunOverride` prunes empty entries so unset runs use globals cleanly.
- Merged into all three sim call sites via `ov.x ?? global.x`. In the **leg-distance sweep** the leg override is intentionally skipped (leg distance is the swept axis).
- Inputs render only for selected runs in the non-sweep (timeline) views. Leg distance respects the metric/imperial unit toggle (displayed in km, stored in mi).

## Notes

- **Stacked on #136** (`feature/roadtrip-charge-tail-destination`) — it extends the exact same sim call sites, so basing it here avoids conflicts. Retarget to `main` once #136 merges.
- No URL persistence, per your call (consistent with the other road-trip settings that don't round-trip).
- Per-**run** (not per-vehicle), as agreed — consistent with the per-run selector and chart lines.

## Verification
- `npm run build` green; app boots with no console errors.
- Live per-run behavior against real charging data is yours to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)