### PR TITLE
Add admin/contributor toggle to hide test data from viewers

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -2215,6 +2215,14 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     <div className="flex items-center gap-2 flex-wrap">
                                         <h3 className="section-title">
                                             {run.name}
+                                            {run.isHidden && (
+                                                <span
+                                                    title="Hidden from regular viewers — only admins/contributors can see this test"
+                                                    className="ml-1 badge-hidden"
+                                                >
+                                                    Hidden
+                                                </span>
+                                            )}
                                             {run.url && (
                                                 <a href={run.url} target="_blank" rel="noopener noreferrer"
                                                     title="Range test source"
@@ -2317,6 +2325,15 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                                 className="dropdown-item w-full text-left"
                                                             >
                                                                 ↑ Upload additional data
+                                                            </button>
+                                                        )}
+                                                        {isContributor && (
+                                                            <button
+                                                                onClick={() => { onUpdateRun(run.id, { isHidden: !run.isHidden }); setOpenMenuRunId(null); }}
+                                                                title={run.isHidden ? 'Make this test visible to all viewers' : 'Hide this test from regular viewers'}
+                                                                className="dropdown-item w-full text-left"
+                                                            >
+                                                                {run.isHidden ? '◎ Unhide from viewers' : '⊘ Hide from viewers'}
                                                             </button>
                                                         )}
                                                     </div>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { dataService } from '../services/DataService';
 
 const AppContext = createContext(null);
@@ -1036,8 +1036,16 @@ export function AppProvider({ children }) {
         window.location.reload();
     };
 
+    // Admins/contributors can hide a run's test data (disputed, incomplete) without
+    // deleting it. Everyone else — including anonymous viewers — never sees it, in
+    // Tests & Data or in any chart/compare tab, since all of those read from `vehicles`.
+    const visibleVehicles = useMemo(() => {
+        if (isContributor) return vehicles;
+        return vehicles.map(v => ({ ...v, runs: (v.runs || []).filter(r => !r.isHidden) }));
+    }, [vehicles, isContributor]);
+
     const value = {
-        vehicles,
+        vehicles: visibleVehicles,
         selectedVehicles,
         user,
         userRole,

--- a/src/index.css
+++ b/src/index.css
@@ -572,6 +572,15 @@ body {
     color: rgb(147, 197, 253);
 }
 
+/* Marks a run hidden from regular viewers (admin/contributor-only visibility) */
+.badge-hidden {
+    @apply text-xs font-normal bg-orange-100 text-orange-700 px-1.5 py-0.5 rounded align-middle;
+}
+[data-theme="dark"] .badge-hidden {
+    background-color: rgba(249, 115, 22, 0.2);
+    color: rgb(253, 186, 116);
+}
+
 /* Border-style status badge (full-radius); color classes added inline */
 .badge-status {
     @apply text-xs px-1.5 py-0.5 rounded-full border;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -139,6 +139,7 @@ class DataService {
           ...r,
           // Normalise DB snake_case to the camelCase used throughout the app.
           isDefault: !!r.is_default,
+          isHidden:  !!r.is_hidden,
           // data_points(count) returns [{ count: N }]; normalise to a plain number
           dataPointCount: Array.isArray(r.data_points) ? (r.data_points[0]?.count ?? 0) : 0,
         })),
@@ -567,6 +568,7 @@ class DataService {
       ...(updates.elevationGainFt !== undefined ? { elevation_gain_ft: updates.elevationGainFt !== '' ? Number(updates.elevationGainFt) : null } : {}),
       ...(updates.url !== undefined ? { url: updates.url || null } : {}),
       ...(updates.chargingUrl !== undefined ? { charging_url: updates.chargingUrl || null } : {}),
+      ...(updates.isHidden !== undefined ? { is_hidden: updates.isHidden } : {}),
     }).eq('id', runId);
     if (error) throw error;
   }

--- a/supabase/migrations/034_run_visibility.sql
+++ b/supabase/migrations/034_run_visibility.sql
@@ -1,0 +1,4 @@
+-- Let admins/contributors hide a run's test data from regular viewers without
+-- deleting it (e.g. disputed data pending review, incomplete uploads).
+
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS is_hidden boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Admins/contributors can now hide a run's test data from regular viewers without deleting it (e.g. disputed data pending review, incomplete uploads).
- New `is_hidden` column on `runs` (migration 034).
- Toggle lives in the run card's **More ▾** menu, gated to `isContributor`; hidden runs show an orange "Hidden" badge for admins/contributors.
- Filtering happens once, at the `AppContext` level: for non-contributors, hidden runs are stripped out of `vehicles[].runs` before anything renders — so Tests & Data, chart selection, and Compare Specs all stay consistent automatically.

## Test plan
- [ ] Apply migration 034 in Supabase SQL editor
- [ ] As admin/contributor: hide a run, confirm the "Hidden" badge appears and the run stays visible/editable
- [ ] As a signed-out/viewer session: confirm the hidden run disappears from Tests & Data, chart run-selection, and Compare Specs
- [ ] Unhide the run and confirm it reappears everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)