### PR TITLE
Add temperature adjustment to EPA Curves altitude control

### DIFF
--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -10,11 +10,16 @@ import {
     resolveUseableKwh, resolveUseableKwhSource,
     HIGHWAY_BAND_MPH,
 } from '../utils/epaPhysics';
-import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, STANDARD_TEMP_F } from '../utils/epaDerivations';
+import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 import ChartInfoBubble from './ChartInfoBubble';
+
+// Sane bounds for the ambient-temperature viewing condition; far outside this
+// the ideal-gas density approximation isn't meaningful anyway.
+const MIN_TEMP_F = -100;
+const MAX_TEMP_F = 150;
 
 // ── Highway band plugin ───────────────────────────────────────────────────────
 
@@ -229,16 +234,26 @@ export default function EpaCurvesView({
     const [mappingColors,    setMappingColors]    = useState({});        // mapping.id → hex
     const [urlCopied,        setUrlCopied]        = useState(false);
     const [imageCopied,      setImageCopied]      = useState(false);
-    // Altitude and temperature are viewing conditions (like the unit toggle):
-    // together they scale the aerodynamic C term at plot time for ALL curves.
-    // Never persisted; never affect stored coefficients or the standard-density η.
+    // Altitude, temperature, and accessory load are viewing conditions (like the
+    // unit toggle): they scale the plotted curve at plot time for ALL curves.
+    // Never persisted; never affect stored coefficients, accessory fields, or
+    // the standard-condition η.
     const [elevationFt,      setElevationFt]      = useState(0);
     const [tempF,            setTempF]            = useState('');
+    const [accessoryOverrideW, setAccessoryOverrideW] = useState('');
+    const clampTempF = (raw) => {
+        if (raw === '' || raw === '-') return raw; // allow in-progress typing of a negative number
+        const n = Number(raw);
+        if (isNaN(n)) return raw;
+        return String(Math.min(MAX_TEMP_F, Math.max(MIN_TEMP_F, n)));
+    };
     const densityRatio = useMemo(
         () => airDensityRatio(elevationFt) * temperatureDensityRatio(tempF === '' ? null : Number(tempF)),
         [elevationFt, tempF]
     );
     const densityAdjusted  = Math.abs(densityRatio - 1) > 1e-6;
+    const accessoryAdjusted = accessoryOverrideW !== '';
+    const accessoryOverrideWNum = accessoryAdjusted ? Number(accessoryOverrideW) : null;
 
     const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
 
@@ -274,7 +289,7 @@ export default function EpaCurvesView({
 
                 const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
                 const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
-                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio);
+                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio, accessoryOverrideWNum);
                 if (!curve.length) return;
 
                 // Color: user override → vehicleColorMap/vehicle color → palette (with alpha for 2nd+ mapping)
@@ -285,8 +300,8 @@ export default function EpaCurvesView({
                 const baseLabel = vehiclesWithEpa.length > 1 || mi > 0
                     ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
                     : vehicleLabel(vehicle);
-                // Subtle "density-adjusted" marker on each curve's legend entry.
-                const label = densityAdjusted ? `${baseLabel} ▲` : baseLabel;
+                // Subtle "adjusted" marker on each curve's legend entry (density or accessory load).
+                const label = (densityAdjusted || accessoryAdjusted) ? `${baseLabel} ▲` : baseLabel;
 
                 result.push({
                     label,
@@ -312,7 +327,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -545,8 +560,10 @@ export default function EpaCurvesView({
                             <input
                                 type="number"
                                 step="5"
+                                min={MIN_TEMP_F}
+                                max={MAX_TEMP_F}
                                 value={tempF}
-                                onChange={e => setTempF(e.target.value)}
+                                onChange={e => setTempF(clampTempF(e.target.value))}
                                 placeholder={String(STANDARD_TEMP_F)}
                                 className="form-input text-sm py-1 w-20 text-right"
                                 aria-label="Ambient temperature in °F"
@@ -558,6 +575,29 @@ export default function EpaCurvesView({
                             >
                                 → ρ {densityRatio.toFixed(2)}{densityAdjusted ? ' ▲' : ''}
                             </span>
+                        </div>
+
+                        {/* Accessory load — viewing condition, applies to all curves */}
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
+                                Accessory Load
+                                <InfoIcon
+                                    text={`Overrides the constant accessory draw (HVAC, lighting, etc.) used in the curve. Default is ${DEFAULT_ACCESSORY_W}W. Typical ranges: cooling (AC compressor) ~1000-2500W; heating ~500-5000W depending on exterior temperature and heat pump vs. resistive; lighting ~100-200W on modern vehicles. Viewing condition only — never persisted, and η is not recomputed.`}
+                                    position="left"
+                                    className="ml-1"
+                                />
+                            </span>
+                            <input
+                                type="number"
+                                step="50"
+                                min="0"
+                                value={accessoryOverrideW}
+                                onChange={e => setAccessoryOverrideW(e.target.value)}
+                                placeholder={String(DEFAULT_ACCESSORY_W)}
+                                className="form-input text-sm py-1 w-24 text-right"
+                                aria-label="Accessory load override in watts"
+                            />
+                            <span className="text-sm text-faint">W</span>
                         </div>
                     </div>
 

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -10,7 +10,7 @@ import {
     resolveUseableKwh, resolveUseableKwhSource,
     HIGHWAY_BAND_MPH,
 } from '../utils/epaPhysics';
-import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio } from '../utils/epaDerivations';
+import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, STANDARD_TEMP_F } from '../utils/epaDerivations';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
@@ -229,12 +229,16 @@ export default function EpaCurvesView({
     const [mappingColors,    setMappingColors]    = useState({});        // mapping.id → hex
     const [urlCopied,        setUrlCopied]        = useState(false);
     const [imageCopied,      setImageCopied]      = useState(false);
-    // Altitude is a viewing condition (like the unit toggle): scales the
-    // aerodynamic C term at plot time for ALL curves. Never persisted; never
-    // affects stored coefficients or the standard-density η.
+    // Altitude and temperature are viewing conditions (like the unit toggle):
+    // together they scale the aerodynamic C term at plot time for ALL curves.
+    // Never persisted; never affect stored coefficients or the standard-density η.
     const [elevationFt,      setElevationFt]      = useState(0);
-    const densityRatio = useMemo(() => airDensityRatio(elevationFt), [elevationFt]);
-    const altAdjusted  = Math.abs(densityRatio - 1) > 1e-6;
+    const [tempF,            setTempF]            = useState('');
+    const densityRatio = useMemo(
+        () => airDensityRatio(elevationFt) * temperatureDensityRatio(tempF === '' ? null : Number(tempF)),
+        [elevationFt, tempF]
+    );
+    const densityAdjusted  = Math.abs(densityRatio - 1) > 1e-6;
 
     const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
 
@@ -281,8 +285,8 @@ export default function EpaCurvesView({
                 const baseLabel = vehiclesWithEpa.length > 1 || mi > 0
                     ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
                     : vehicleLabel(vehicle);
-                // Subtle "altitude-adjusted" marker on each curve's legend entry.
-                const label = altAdjusted ? `${baseLabel} ▲` : baseLabel;
+                // Subtle "density-adjusted" marker on each curve's legend entry.
+                const label = densityAdjusted ? `${baseLabel} ▲` : baseLabel;
 
                 result.push({
                     label,
@@ -308,7 +312,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, altAdjusted]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -526,11 +530,33 @@ export default function EpaCurvesView({
                                 aria-label="Elevation in feet"
                             />
                             <span className="text-sm text-faint">ft</span>
+                        </div>
+
+                        {/* Temperature — viewing condition, applies to all curves */}
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
+                                Temp
+                                <InfoIcon
+                                    text={`Adjusts aerodynamic drag for air density at this ambient temperature (colder air is denser). Standard condition is ${STANDARD_TEMP_F}°F. Models air density only — does not capture battery, HVAC, or cold-tire effects.`}
+                                    position="left"
+                                    className="ml-1"
+                                />
+                            </span>
+                            <input
+                                type="number"
+                                step="5"
+                                value={tempF}
+                                onChange={e => setTempF(e.target.value)}
+                                placeholder={String(STANDARD_TEMP_F)}
+                                className="form-input text-sm py-1 w-20 text-right"
+                                aria-label="Ambient temperature in °F"
+                            />
+                            <span className="text-sm text-faint">°F</span>
                             <span
-                                className={`text-xs whitespace-nowrap ${altAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
-                                title="Air-density ratio applied to the aerodynamic (C) term"
+                                className={`text-xs whitespace-nowrap ${densityAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
+                                title="Combined air-density ratio (altitude × temperature) applied to the aerodynamic (C) term"
                             >
-                                → ρ {densityRatio.toFixed(2)}{altAdjusted ? ' ▲' : ''}
+                                → ρ {densityRatio.toFixed(2)}{densityAdjusted ? ' ▲' : ''}
                             </span>
                         </div>
                     </div>

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -189,6 +189,58 @@ function ConfidenceBadge({ confidence }) {
     );
 }
 
+// ── Accessory-load reference table (for the Accessory Load info tooltip) ─────
+
+// Steady-state auxiliary draw by ambient temperature, in watts. Heat-pump and
+// resistive rows are alternative heating methods for the same job, not
+// simultaneous loads. Battery conditioning here is steady-state pack-temperature
+// maintenance, not the much higher, short-duration draw of active DC-fast-charge
+// preconditioning.
+const ACCESSORY_LOAD_REFERENCE_W = [
+    { ambient: '0°F',   heatPump: '2500–4000*',  resistive: '4000–6000', ac: '—',         battery: '1000–3000', lighting: '100–300' },
+    { ambient: '32°F',  heatPump: '1000–1500',   resistive: '2000–3000', ac: '—',         battery: '500–1500',  lighting: '100–300' },
+    { ambient: '50°F',  heatPump: '400–700',     resistive: '1000–1500', ac: '—',         battery: '0–500',     lighting: '100–300' },
+    { ambient: '68°F',  heatPump: '~0',          resistive: '~0',        ac: '~0',        battery: '~0',        lighting: '100–300' },
+    { ambient: '80°F',  heatPump: '—',           resistive: '—',         ac: '1000–1500',  battery: '~0',        lighting: '100–300' },
+    { ambient: '90°F',  heatPump: '—',           resistive: '—',         ac: '1500–2500',  battery: '0–500',     lighting: '100–300' },
+    { ambient: '105°F', heatPump: '—',           resistive: '—',         ac: '3000–5000**', battery: '1000–3000', lighting: '100–300' },
+];
+
+function AccessoryLoadReferenceTable() {
+    return (
+        <div>
+            <p className="font-semibold mb-1">EV Auxiliary Load Reference (steady-state, W)</p>
+            <table className="accessory-load-table">
+                <thead>
+                    <tr>
+                        <th>Ambient</th>
+                        <th>Heat Pump</th>
+                        <th>Resistive</th>
+                        <th>A/C</th>
+                        <th>Batt. Cond.</th>
+                        <th>Lighting</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {ACCESSORY_LOAD_REFERENCE_W.map(row => (
+                        <tr key={row.ambient}>
+                            <td>{row.ambient}</td>
+                            <td>{row.heatPump}</td>
+                            <td>{row.resistive}</td>
+                            <td>{row.ac}</td>
+                            <td>{row.battery}</td>
+                            <td>{row.lighting}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <p className="mt-1.5 text-[10px] leading-snug opacity-80">
+                *At 0°F, heat pump COP approaches its floor, so most heating duty shifts to the resistive backup element. **Assumes a stabilized cabin; hot-soak or high solar load can push this higher during pull-down. Heat pump/resistive are alternative heating methods, not simultaneous loads. Battery conditioning is steady-state maintenance, not active DC-fast-charge preconditioning. Curve default is {DEFAULT_ACCESSORY_W}W.
+            </p>
+        </div>
+    );
+}
+
 // ── Default color for a mapping ───────────────────────────────────────────────
 
 function defaultMappingColor(vehicle, vehicleIdx, mappingIdx) {
@@ -525,14 +577,19 @@ export default function EpaCurvesView({
                                 <span className="text-sm font-medium">Auto Color</span>
                             </label>
                         )}
+                    </div>
 
+                    {/* Viewing conditions — altitude, temperature, accessory load. Kept on
+                        their own row (not wrapped in with the Y-axis controls above) since
+                        three input groups don't fit the same line at most widths. */}
+                    <div className="chart-viewing-conditions">
                         {/* Altitude — viewing condition, applies to all curves */}
-                        <div className="flex items-center gap-1.5 ml-auto">
+                        <div className="flex items-center gap-1.5">
                             <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
                                 Altitude
                                 <InfoIcon
                                     text="Adjusts aerodynamic drag for air density at this elevation. Models air density only — does not capture battery, regen, or cabin-heating effects. Curve is the standard-condition baseline scaled for thinner air."
-                                    position="left"
+                                    position="right"
                                     className="ml-1"
                                 />
                             </span>
@@ -553,7 +610,7 @@ export default function EpaCurvesView({
                                 Temp
                                 <InfoIcon
                                     text={`Adjusts aerodynamic drag for air density at this ambient temperature (colder air is denser). Standard condition is ${STANDARD_TEMP_F}°F. Models air density only — does not capture battery, HVAC, or cold-tire effects.`}
-                                    position="left"
+                                    position="right"
                                     className="ml-1"
                                 />
                             </span>
@@ -582,10 +639,12 @@ export default function EpaCurvesView({
                             <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
                                 Accessory Load
                                 <InfoIcon
-                                    text={`Overrides the constant accessory draw (HVAC, lighting, etc.) used in the curve. Default is ${DEFAULT_ACCESSORY_W}W. Typical ranges: cooling (AC compressor) ~1000-2500W; heating ~500-5000W depending on exterior temperature and heat pump vs. resistive; lighting ~100-200W on modern vehicles. Viewing condition only — never persisted, and η is not recomputed.`}
-                                    position="left"
+                                    tooltipClassName="info-icon-tooltip--wide"
+                                    position="right"
                                     className="ml-1"
-                                />
+                                >
+                                    <AccessoryLoadReferenceTable />
+                                </InfoIcon>
                             </span>
                             <input
                                 type="number"

--- a/src/components/InfoIcon.jsx
+++ b/src/components/InfoIcon.jsx
@@ -6,16 +6,18 @@
  * toggled by the `.info-icon:hover .info-icon-tooltip` CSS rule in index.css.
  *
  * Props:
- *   text      {string}  — tooltip text (plain string; no HTML)
- *   position  {'above'|'below'|'right'}  — tooltip placement (default: 'above')
- *   className {string}  — extra classes on the wrapper span
+ *   text             {string}  — tooltip text (plain string; no HTML). Ignored if `children` is given.
+ *   children         {node}    — richer tooltip content (e.g. a reference table), in place of `text`
+ *   position         {'above'|'below'|'right'}  — tooltip placement (default: 'above')
+ *   className        {string}  — extra classes on the wrapper span
+ *   tooltipClassName {string}  — extra classes on the tooltip bubble itself (e.g. a width override)
  */
-export default function InfoIcon({ text, position = 'above', className = '' }) {
+export default function InfoIcon({ text, children, position = 'above', className = '', tooltipClassName = '' }) {
     return (
-        <span className={`info-icon ${className}`} aria-label={text} role="img">
+        <span className={`info-icon ${className}`} aria-label={typeof text === 'string' ? text : undefined} role="img">
             <span className="info-icon-glyph">ⓘ</span>
-            <span className={`info-icon-tooltip info-icon-tooltip--${position}`}>
-                {text}
+            <span className={`info-icon-tooltip info-icon-tooltip--${position} ${tooltipClassName}`}>
+                {children ?? text}
             </span>
         </span>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -743,6 +743,12 @@ body {
     @apply flex flex-wrap gap-4 mb-4;
 }
 
+/* EPA Curves viewing-condition controls (altitude/temp/accessory load) —
+   own row below .chart-toggles so they don't compete for space with it */
+.chart-viewing-conditions {
+    @apply flex flex-wrap items-center gap-4 mb-4;
+}
+
 /* Collapsible "Select Runs" section header button */
 .run-selector-header {
     @apply flex items-center gap-2 w-full text-left font-medium transition-colors mb-1;
@@ -1151,6 +1157,28 @@ body {
     left: calc(100% + 6px);
     top: 50%;
     transform: translateY(-50%);
+}
+
+/* Width override for richer tooltip content (e.g. a reference table) */
+.info-icon-tooltip--wide {
+    width: 460px;
+}
+
+/* Reference table shown inside a wide info-icon tooltip (e.g. EPA Curves accessory load) */
+.accessory-load-table {
+    @apply w-full border-collapse text-[11px] mt-1;
+}
+.accessory-load-table th,
+.accessory-load-table td {
+    @apply border px-1 py-0.5 text-center;
+    border-color: var(--color-border);
+}
+.accessory-load-table th {
+    @apply font-semibold;
+}
+.accessory-load-table td:first-child,
+.accessory-load-table th:first-child {
+    @apply text-left;
 }
 
 /* ── Specs comparison chart ──────────────────────────────────────────────────── */

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -372,17 +372,22 @@ export function temperatureDensityRatio(tempF) {
  * coefficients are never modified — passing 1 (default) reproduces the standard
  * sea-level curve exactly.
  *
+ * Accessory load (viewing condition): `accessoryOverrideW`, when given, replaces
+ * the group's stored accessory load for THIS curve only, at plot time. η (which
+ * was derived using the group's own accessory load) is never recomputed.
+ *
  * @param {object} group       — full group (with epa_coefficient_sets + epa_tests)
  * @param {number|null} useableKwh — battery capacity for range; null ⇒ rangeMi null
  * @param {number} densityRatio   — ρ_altitude / ρ_sea_level (default 1 = sea level)
+ * @param {number|null} accessoryOverrideW — override accessory draw in watts; null ⇒ use the group's own value
  * @returns {Array<{ mph, kwh100mi, miPerKwh, mpge, rangeMi }>}
  */
-export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1) {
+export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, accessoryOverrideW = null) {
     const coeffs = resolvePrimaryCoeffs(group);
     if (!coeffs) return [];
 
     const eta   = deriveDrivetrainEta(group).value;
-    const accKw = accessoryKw(group);
+    const accKw = accessoryOverrideW != null ? accessoryOverrideW / 1000 : accessoryKw(group);
     const { a, b } = coeffs;
     const c = coeffs.c * densityRatio; // aerodynamic term only, display-time scale
     const [vMin, vMax] = CURVE_SPEED_RANGE;

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -335,6 +335,27 @@ export function airDensityRatio(elevationFt) {
     return Math.pow(base, 4.2559);
 }
 
+/** Standard-condition ambient temperature (°F), matching the ISA sea-level
+ *  reference (15°C) that airDensityRatio's altitude formula assumes. */
+export const STANDARD_TEMP_F = 59;
+
+/**
+ * Air-density ratio from ambient temperature alone, via the ideal gas law at
+ * constant pressure (ρ ∝ 1/T): colder air is denser (ratio > 1), hotter air
+ * is thinner (ratio < 1). Independent of, and multiplies with, airDensityRatio
+ * — same plot-time-only scale on the aerodynamic (C) term, never persisted.
+ *
+ * @param {number|null} tempF  ambient temperature in °F; null/undefined ⇒ 1 (no adjustment)
+ * @returns {number} density ratio (1.0 at the standard temperature)
+ */
+export function temperatureDensityRatio(tempF) {
+    if (tempF == null || tempF === '') return 1;
+    const actualRankine   = Number(tempF) + 459.67;
+    const standardRankine = STANDARD_TEMP_F + 459.67;
+    if (actualRankine <= 0) return 1; // guard absolute-zero-adjacent nonsense input
+    return standardRankine / actualRankine;
+}
+
 // ── Curve builder (curator model) ───────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- Quick win from issue #139: EPA Curves already scales the aerodynamic (C) road-load term for altitude (`airDensityRatio`, plot-time only). This adds the same treatment for ambient temperature.
- New `temperatureDensityRatio(tempF)` in `src/utils/epaDerivations.js` — ideal gas law (ρ ∝ 1/T), independent of and multiplied with the altitude ratio. Standard condition is 59°F (matches the ISA baseline the altitude formula already assumes), so an empty/default field reproduces the current curve exactly.
- New "Temp" input next to "Altitude" in EPA Curves, with the same combined ρ readout and "▲ adjusted" legend marker (renamed `altAdjusted` → `densityAdjusted` since it now reflects either condition).
- Verified in-browser: at 20°F the combined ratio reads ρ 1.08 (denser/colder air → more drag) and every curve + legend entry gets the adjusted marker; resetting reproduces the baseline curve.

## Test plan
- [ ] Open Charts → EPA Curves, confirm "Temp" field appears next to "Altitude" showing 59°F placeholder and ρ 1.00
- [ ] Enter a cold temp (e.g. 20°F), confirm ρ > 1 and curves shift up (more consumption)
- [ ] Enter a hot temp (e.g. 100°F), confirm ρ < 1 and curves shift down
- [ ] Combine with a non-zero altitude and confirm ratios multiply as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)