### PR TITLE
Capture wind speed and direction on range runs

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -60,6 +60,16 @@ function RunRangeMetaLine({ run, units }) {
     if (run.energy_kwh != null && run.distance_miles != null)
         items.push(<span key="eff" className="text-blue-700">{calcEff(run.distance_miles, run.energy_kwh, 'mi_kwh', units)} {getEffLabel('mi_kwh', units)}</span>);
     if (run.temperature_f != null) items.push(<span key="tmp" className="text-orange-700">{fmtTemp(run.temperature_f, units)}</span>);
+    if (run.avg_wind_speed_mph != null) {
+        const dirTitle = run.wind_direction_deg != null
+            ? `${run.wind_direction_deg}° vs travel (0°=tailwind, 180°=headwind)`
+            : 'Direction not recorded';
+        items.push(
+            <span key="wind" className="text-cyan-700" title={dirTitle}>
+                💨 {fmtSpeed(run.avg_wind_speed_mph, units)}{run.wind_direction_deg != null ? ` @ ${run.wind_direction_deg}°` : ''}
+            </span>
+        );
+    }
     if (run.start_soc != null && run.end_soc != null)
         items.push(<span key="soc" className="text-secondary">SoC {run.start_soc}→{run.end_soc}%</span>);
     if (run.url)
@@ -475,6 +485,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         chargeEnergyKwh: '',
         temperatureF: '',
         elevationGainFt: '',
+        windSpeedMph: '',
+        windDirectionDeg: '',
         url: '',
         chargingUrl: '',
     });
@@ -550,7 +562,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         setUploadStep('file');
         setCsvData(null);
         setFieldMapping({});
-        setRunMetadata({ name: '', date: new Date().toISOString().split('T')[0], softwareVersion: '', conditions: '', dataFlags: ['charging'], source: '', startSoc: '', endSoc: '', speedMph: '', distanceMiles: '', energyKwh: '', chargeEnergyKwh: '', temperatureF: '', elevationGainFt: '', url: '', chargingUrl: '' });
+        setRunMetadata({ name: '', date: new Date().toISOString().split('T')[0], softwareVersion: '', conditions: '', dataFlags: ['charging'], source: '', startSoc: '', endSoc: '', speedMph: '', distanceMiles: '', energyKwh: '', chargeEnergyKwh: '', temperatureF: '', elevationGainFt: '', windSpeedMph: '', windDirectionDeg: '', url: '', chargingUrl: '' });
         setUploadMode('create');
         setMergeTargetRun(null);
         setEstimations({ range: null });
@@ -842,6 +854,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             chargeEnergyKwh: run.charge_energy_kwh ?? '',
             temperatureF: run.temperature_f ?? '',
             elevationGainFt: run.elevation_gain_ft ?? '',
+            windSpeedMph: run.avg_wind_speed_mph ?? '',
+            windDirectionDeg: run.wind_direction_deg ?? '',
             url: run.url || '',
             chargingUrl: run.charging_url || '',
         });
@@ -1506,6 +1520,22 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                         className="form-input col-span-2"
                                                     />
                                                     <input
+                                                        type="number"
+                                                        placeholder="Avg wind speed (mph)"
+                                                        value={runMetadata.windSpeedMph}
+                                                        onChange={(e) => setRunMetadata({...runMetadata, windSpeedMph: e.target.value})}
+                                                        className="form-input"
+                                                    />
+                                                    <input
+                                                        type="number"
+                                                        placeholder="Wind dir. vs travel (0-360°)"
+                                                        title="Direction relative to travel: 0° = tailwind, 180° = headwind, 90/270° = crosswind"
+                                                        value={runMetadata.windDirectionDeg}
+                                                        onChange={(e) => setRunMetadata({...runMetadata, windDirectionDeg: e.target.value})}
+                                                        className="form-input"
+                                                        min="0" max="360"
+                                                    />
+                                                    <input
                                                         type="url"
                                                         placeholder="Source URL"
                                                         value={runMetadata.url}
@@ -1900,6 +1930,22 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                     value={editFormData.elevationGainFt}
                                                     onChange={(e) => setEditFormData({...editFormData, elevationGainFt: e.target.value})}
                                                     className="form-input col-span-2"
+                                                />
+                                                <input
+                                                    type="number"
+                                                    placeholder="Avg wind speed (mph)"
+                                                    value={editFormData.windSpeedMph}
+                                                    onChange={(e) => setEditFormData({...editFormData, windSpeedMph: e.target.value})}
+                                                    className="form-input"
+                                                />
+                                                <input
+                                                    type="number"
+                                                    placeholder="Wind dir. vs travel (0-360°)"
+                                                    title="Direction relative to travel: 0° = tailwind, 180° = headwind, 90/270° = crosswind"
+                                                    value={editFormData.windDirectionDeg}
+                                                    onChange={(e) => setEditFormData({...editFormData, windDirectionDeg: e.target.value})}
+                                                    className="form-input"
+                                                    min="0" max="360"
                                                 />
                                                 <input
                                                     type="url"

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -513,6 +513,8 @@ class DataService {
       charge_energy_kwh: numField(run.chargeEnergyKwh, run.charge_energy_kwh),
       temperature_f:     numField(run.temperatureF,    run.temperature_f),
       elevation_gain_ft: numField(run.elevationGainFt, run.elevation_gain_ft),
+      avg_wind_speed_mph: numField(run.windSpeedMph,     run.avg_wind_speed_mph),
+      wind_direction_deg: numField(run.windDirectionDeg, run.wind_direction_deg),
       url: run.url || null,
       charging_url: coalesce(run.chargingUrl, run.charging_url) || null,
     }).select().single();
@@ -565,6 +567,8 @@ class DataService {
       ...(updates.chargeEnergyKwh !== undefined ? { charge_energy_kwh: updates.chargeEnergyKwh !== '' ? Number(updates.chargeEnergyKwh) : null } : {}),
       ...(updates.temperatureF !== undefined ? { temperature_f: updates.temperatureF !== '' ? Number(updates.temperatureF) : null } : {}),
       ...(updates.elevationGainFt !== undefined ? { elevation_gain_ft: updates.elevationGainFt !== '' ? Number(updates.elevationGainFt) : null } : {}),
+      ...(updates.windSpeedMph !== undefined ? { avg_wind_speed_mph: updates.windSpeedMph !== '' ? Number(updates.windSpeedMph) : null } : {}),
+      ...(updates.windDirectionDeg !== undefined ? { wind_direction_deg: updates.windDirectionDeg !== '' ? Number(updates.windDirectionDeg) : null } : {}),
       ...(updates.url !== undefined ? { url: updates.url || null } : {}),
       ...(updates.chargingUrl !== undefined ? { charging_url: updates.chargingUrl || null } : {}),
     }).eq('id', runId);

--- a/supabase/migrations/035_run_wind_fields.sql
+++ b/supabase/migrations/035_run_wind_fields.sql
@@ -1,0 +1,10 @@
+-- Capture wind conditions on range runs, for future correction modeling
+-- (see issue #139). Data capture only — no correction math yet.
+--
+--   avg_wind_speed_mph — average wind speed during the test
+--   wind_direction_deg — direction RELATIVE TO the vehicle's direction of
+--                        travel, 0-360°: 0° = pure tailwind (from behind),
+--                        180° = pure headwind (from ahead), 90/270° = crosswind.
+
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS avg_wind_speed_mph numeric;
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS wind_direction_deg numeric;


### PR DESCRIPTION
## Summary
- First step of issue #139 (environmental corrections): data capture only, no correction math yet.
- New `avg_wind_speed_mph` and `wind_direction_deg` columns on `runs` (migration 035). Direction is relative to the vehicle's direction of travel: 0°=tailwind, 180°=headwind, 90°/270°=crosswind.
- New fields in the "Range Test Details" subpanel of both the add-run and edit-run forms, right after elevation gain.
- Run cards show a 💨 wind pill in the range meta line (speed + direction, converts with the unit toggle like other speeds) when present.
- Verified in-browser: build is clean, no console errors, and the run meta line renders correctly for existing runs with null wind fields (nothing shown, no breakage). Didn't have a signed-in contributor session on hand to click through the edit-form inputs themselves, but they're structurally identical to the already-shipped temperature/elevation fields.

## Test plan
- [ ] Apply migration 035 in Supabase SQL editor
- [ ] As admin/contributor, add or edit a range run and fill in wind speed + direction
- [ ] Confirm the 💨 pill appears on the run card with correct speed/direction
- [ ] Confirm leaving the fields blank behaves as before (no pill, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)