### PR TITLE
Add side-wind to EPA Curves and show wind on range graphs

### DIFF
--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -293,11 +293,22 @@ export default function EpaCurvesView({
     const [elevationFt,      setElevationFt]      = useState(0);
     const [tempF,            setTempF]            = useState('');
     const [accessoryOverrideW, setAccessoryOverrideW] = useState('');
+    // Wind — same 0=tailwind/180=headwind/90|270=crosswind convention as
+    // runs.wind_direction_deg (#142). Applied to the curve as apparent airspeed
+    // (see apparentAirspeed in epaDerivations.js); never persisted, η untouched.
+    const [windSpeedMph,     setWindSpeedMph]     = useState('');
+    const [windDirectionDeg, setWindDirectionDeg] = useState('');
     const clampTempF = (raw) => {
         if (raw === '' || raw === '-') return raw; // allow in-progress typing of a negative number
         const n = Number(raw);
         if (isNaN(n)) return raw;
         return String(Math.min(MAX_TEMP_F, Math.max(MIN_TEMP_F, n)));
+    };
+    const clampWindDirection = (raw) => {
+        if (raw === '') return raw;
+        const n = Number(raw);
+        if (isNaN(n)) return raw;
+        return String(Math.min(360, Math.max(0, n)));
     };
     const densityRatio = useMemo(
         () => airDensityRatio(elevationFt) * temperatureDensityRatio(tempF === '' ? null : Number(tempF)),
@@ -306,6 +317,9 @@ export default function EpaCurvesView({
     const densityAdjusted  = Math.abs(densityRatio - 1) > 1e-6;
     const accessoryAdjusted = accessoryOverrideW !== '';
     const accessoryOverrideWNum = accessoryAdjusted ? Number(accessoryOverrideW) : null;
+    const windAdjusted = windSpeedMph !== '' && Number(windSpeedMph) > 0;
+    const windSpeedMphNum = windAdjusted ? Number(windSpeedMph) : 0;
+    const windDirectionDegNum = windDirectionDeg === '' ? 0 : Number(windDirectionDeg);
 
     const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
 
@@ -341,7 +355,7 @@ export default function EpaCurvesView({
 
                 const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
                 const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
-                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio, accessoryOverrideWNum);
+                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio, accessoryOverrideWNum, windSpeedMphNum, windDirectionDegNum);
                 if (!curve.length) return;
 
                 // Color: user override → vehicleColorMap/vehicle color → palette (with alpha for 2nd+ mapping)
@@ -353,7 +367,7 @@ export default function EpaCurvesView({
                     ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
                     : vehicleLabel(vehicle);
                 // Subtle "adjusted" marker on each curve's legend entry (density or accessory load).
-                const label = (densityAdjusted || accessoryAdjusted) ? `${baseLabel} ▲` : baseLabel;
+                const label = (densityAdjusted || accessoryAdjusted || windAdjusted) ? `${baseLabel} ▲` : baseLabel;
 
                 result.push({
                     label,
@@ -379,7 +393,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -657,6 +671,41 @@ export default function EpaCurvesView({
                                 aria-label="Accessory load override in watts"
                             />
                             <span className="text-sm text-faint">W</span>
+                        </div>
+
+                        {/* Wind — viewing condition, applies to all curves */}
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
+                                Wind
+                                <InfoIcon
+                                    text="Scales aerodynamic drag by apparent (relative) airspeed — a headwind raises effective drag speed, a tailwind lowers it, a pure crosswind raises it slightly. Direction is relative to travel: 0°=tailwind, 180°=headwind, 90°/270°=crosswind. Models relative-airspeed magnitude only — does not capture yaw-angle sensitivity of drag coefficient."
+                                    position="right"
+                                    className="ml-1"
+                                />
+                            </span>
+                            <input
+                                type="number"
+                                step="5"
+                                min="0"
+                                value={windSpeedMph}
+                                onChange={e => setWindSpeedMph(e.target.value)}
+                                placeholder="0"
+                                className="form-input text-sm py-1 w-16 text-right"
+                                aria-label="Wind speed in mph"
+                            />
+                            <span className="text-sm text-faint">mph @</span>
+                            <input
+                                type="number"
+                                step="15"
+                                min="0"
+                                max="360"
+                                value={windDirectionDeg}
+                                onChange={e => setWindDirectionDeg(clampWindDirection(e.target.value))}
+                                placeholder="180"
+                                className="form-input text-sm py-1 w-16 text-right"
+                                aria-label="Wind direction relative to travel, in degrees"
+                            />
+                            <span className="text-sm text-faint">°{windAdjusted ? ' ▲' : ''}</span>
                         </div>
                     </div>
 

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -299,10 +299,13 @@ export default function EpaCurvesView({
     // (see apparentAirspeed in epaDerivations.js); never persisted, η untouched.
     const [windSpeedMph,     setWindSpeedMph]     = useState('');
     const [windDirectionDeg, setWindDirectionDeg] = useState('');
-    // Overlay real-world range-test points, corrected (temp + wind only, not
-    // elevation gain/loss — no model for that yet) to the viewing conditions
-    // above, so they're comparable to the curve as currently displayed.
-    const [overlayRealWorld, setOverlayRealWorld] = useState(false);
+    // Overlay real-world range-test points on top of the curve. null = off.
+    // 'corrected' scales each point (temp + wind only, not elevation gain/loss
+    // — no model for that yet) to the viewing conditions above, so it's
+    // comparable to the curve as currently displayed. 'uncorrected' plots the
+    // raw measured value as recorded — not a valid comparison across
+    // different test conditions, but useful to see the true recorded data.
+    const [overlayMode, setOverlayMode] = useState(null); // null | 'corrected' | 'uncorrected'
     const clampTempF = (raw) => {
         if (raw === '' || raw === '-') return raw; // allow in-progress typing of a negative number
         const n = Number(raw);
@@ -396,10 +399,11 @@ export default function EpaCurvesView({
                     _curve:            curve,
                 });
 
-                // ── Real-world overlay: this vehicle's own range-test runs, corrected
-                // (temp + wind only — see correctMeasuredConsumption) to the same
-                // viewing conditions as the curve above, plotted as scatter points.
-                if (overlayRealWorld) {
+                // ── Real-world overlay: this vehicle's own range-test runs, plotted as
+                // scatter points. 'corrected' scales each point (temp + wind only — see
+                // correctMeasuredConsumption) to the same viewing conditions as the curve
+                // above; 'uncorrected' plots the raw measured value as recorded.
+                if (overlayMode) {
                     const viewConditions = {
                         densityRatio,
                         accessoryOverrideW: accessoryOverrideWNum,
@@ -410,20 +414,23 @@ export default function EpaCurvesView({
                         .filter(r => !r._inherited && r.speed_mph != null && r.distance_miles > 0 && r.energy_kwh != null)
                         .map(run => {
                             const measuredKwh100mi = (run.energy_kwh / run.distance_miles) * 100;
-                            const runConditions = {
-                                temperatureF:     run.temperature_f,
-                                windSpeedMph:     run.avg_wind_speed_mph,
-                                windDirectionDeg: run.wind_direction_deg,
-                            };
-                            const correctedKwh100mi = correctMeasuredConsumption(epaGroup, run.speed_mph, measuredKwh100mi, runConditions, viewConditions);
-                            if (correctedKwh100mi == null) return null;
-                            const miPerKwh = 100 / correctedKwh100mi;
+                            let kwh100mi = measuredKwh100mi;
+                            if (overlayMode === 'corrected') {
+                                const runConditions = {
+                                    temperatureF:     run.temperature_f,
+                                    windSpeedMph:     run.avg_wind_speed_mph,
+                                    windDirectionDeg: run.wind_direction_deg,
+                                };
+                                kwh100mi = correctMeasuredConsumption(epaGroup, run.speed_mph, measuredKwh100mi, runConditions, viewConditions);
+                                if (kwh100mi == null) return null;
+                            }
+                            const miPerKwh = 100 / kwh100mi;
                             const pt = {
-                                mph:      run.speed_mph,
-                                kwh100mi: correctedKwh100mi,
+                                mph: run.speed_mph,
+                                kwh100mi,
                                 miPerKwh,
-                                mpge:     miPerKwh * MPG_E_CONVERSION,
-                                rangeMi:  useableKwh > 0 ? useableKwh / (correctedKwh100mi / 100) : null,
+                                mpge:    miPerKwh * MPG_E_CONVERSION,
+                                rangeMi: useableKwh > 0 ? useableKwh / (kwh100mi / 100) : null,
                             };
                             return {
                                 x: convSpeed(pt.mph, units),
@@ -435,12 +442,13 @@ export default function EpaCurvesView({
                     if (overlayPoints.length) {
                         result.push({
                             type:            'scatter',
-                            label:           `${baseLabel} (real-world)`,
+                            label:           `${baseLabel} (real-world${overlayMode === 'uncorrected' ? ', uncorrected' : ''})`,
                             data:            overlayPoints,
                             backgroundColor: color,
                             borderColor:     color,
                             pointRadius:     5,
                             pointHoverRadius: 7,
+                            pointStyle:      overlayMode === 'uncorrected' ? 'triangle' : 'circle',
                             showLine:        false,
                             _vehicleId:      vehicle.id,
                             _mappingId:      mapping.id,
@@ -451,7 +459,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, overlayRealWorld]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, overlayMode]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -656,15 +664,30 @@ export default function EpaCurvesView({
                                 <span className="text-sm font-medium">Auto Color</span>
                             </label>
                         )}
-                        <label className="toggle-label" title="Plot real-world range-test points on top of each curve, corrected for temperature and wind to match the curve's current viewing conditions (not elevation gain/loss — no model for that yet)">
-                            <input
-                                type="checkbox"
-                                checked={overlayRealWorld}
-                                onChange={e => setOverlayRealWorld(e.target.checked)}
-                                className="w-4 h-4"
-                            />
-                            <span className="text-sm font-medium">Overlay Real World Tests</span>
-                        </label>
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
+                                Overlay Real World Tests
+                                <InfoIcon
+                                    text="Plot this vehicle's own range-test points on top of its curve. Corrected: scaled by temperature + wind to match the curve's current viewing conditions above — an apples-to-apples comparison (not elevation gain/loss — no model for that yet). Uncorrected: the raw measured value as recorded, unadjusted — not a valid comparison across different test conditions, but useful to see the true recorded data."
+                                    position="right"
+                                    className="ml-1"
+                                />
+                            </span>
+                            <button
+                                type="button"
+                                className={`btn btn-sm ${overlayMode === 'corrected' ? 'btn-primary' : 'btn-secondary'}`}
+                                onClick={() => setOverlayMode(m => m === 'corrected' ? null : 'corrected')}
+                            >
+                                Corrected
+                            </button>
+                            <button
+                                type="button"
+                                className={`btn btn-sm ${overlayMode === 'uncorrected' ? 'btn-primary' : 'btn-secondary'}`}
+                                onClick={() => setOverlayMode(m => m === 'uncorrected' ? null : 'uncorrected')}
+                            >
+                                Uncorrected
+                            </button>
+                        </div>
                     </div>
 
                     {/* Viewing conditions — altitude, temperature, accessory load. Kept on

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -668,10 +668,14 @@ export default function EpaCurvesView({
                             <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
                                 Overlay Real World Tests
                                 <InfoIcon
-                                    text="Plot this vehicle's own range-test points on top of its curve. Corrected: scaled by temperature + wind to match the curve's current viewing conditions above — an apples-to-apples comparison (not elevation gain/loss — no model for that yet). Uncorrected: the raw measured value as recorded, unadjusted — not a valid comparison across different test conditions, but useful to see the true recorded data."
+                                    tooltipClassName="info-icon-tooltip--wide"
                                     position="right"
                                     className="ml-1"
-                                />
+                                >
+                                    <p>Plot this vehicle's own range-test points on top of its curve.</p>
+                                    <p className="mt-1.5"><strong>Corrected:</strong> scaled by temperature + wind to match the curve's current viewing conditions above — an apples-to-apples comparison (not elevation gain/loss — no model for that yet).</p>
+                                    <p className="mt-1.5"><strong>Uncorrected:</strong> the raw measured value as recorded, unadjusted — not a valid comparison across different test conditions, but useful to see the true recorded data.</p>
+                                </InfoIcon>
                             </span>
                             <button
                                 type="button"

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -8,9 +8,10 @@ import { PALETTE } from '../utils/specHelpers';
 import { resolveChartColors } from '../utils/colorUtils';
 import {
     resolveUseableKwh, resolveUseableKwhSource,
-    HIGHWAY_BAND_MPH,
+    HIGHWAY_BAND_MPH, MPG_E_CONVERSION,
 } from '../utils/epaPhysics';
-import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
+import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, correctMeasuredConsumption, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
+import { filterRangeRuns } from '../utils/runUtils';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
@@ -298,6 +299,10 @@ export default function EpaCurvesView({
     // (see apparentAirspeed in epaDerivations.js); never persisted, η untouched.
     const [windSpeedMph,     setWindSpeedMph]     = useState('');
     const [windDirectionDeg, setWindDirectionDeg] = useState('');
+    // Overlay real-world range-test points, corrected (temp + wind only, not
+    // elevation gain/loss — no model for that yet) to the viewing conditions
+    // above, so they're comparable to the curve as currently displayed.
+    const [overlayRealWorld, setOverlayRealWorld] = useState(false);
     const clampTempF = (raw) => {
         if (raw === '' || raw === '-') return raw; // allow in-progress typing of a negative number
         const n = Number(raw);
@@ -390,10 +395,63 @@ export default function EpaCurvesView({
                     _useableKwhSource: useableKwhSource,
                     _curve:            curve,
                 });
+
+                // ── Real-world overlay: this vehicle's own range-test runs, corrected
+                // (temp + wind only — see correctMeasuredConsumption) to the same
+                // viewing conditions as the curve above, plotted as scatter points.
+                if (overlayRealWorld) {
+                    const viewConditions = {
+                        densityRatio,
+                        accessoryOverrideW: accessoryOverrideWNum,
+                        windSpeedMph:       windSpeedMphNum,
+                        windDirectionDeg:   windDirectionDegNum,
+                    };
+                    const overlayPoints = filterRangeRuns(vehicle.runs)
+                        .filter(r => !r._inherited && r.speed_mph != null && r.distance_miles > 0 && r.energy_kwh != null)
+                        .map(run => {
+                            const measuredKwh100mi = (run.energy_kwh / run.distance_miles) * 100;
+                            const runConditions = {
+                                temperatureF:     run.temperature_f,
+                                windSpeedMph:     run.avg_wind_speed_mph,
+                                windDirectionDeg: run.wind_direction_deg,
+                            };
+                            const correctedKwh100mi = correctMeasuredConsumption(epaGroup, run.speed_mph, measuredKwh100mi, runConditions, viewConditions);
+                            if (correctedKwh100mi == null) return null;
+                            const miPerKwh = 100 / correctedKwh100mi;
+                            const pt = {
+                                mph:      run.speed_mph,
+                                kwh100mi: correctedKwh100mi,
+                                miPerKwh,
+                                mpge:     miPerKwh * MPG_E_CONVERSION,
+                                rangeMi:  useableKwh > 0 ? useableKwh / (correctedKwh100mi / 100) : null,
+                            };
+                            return {
+                                x: convSpeed(pt.mph, units),
+                                y: convertYValue(getYValue(pt, yAxis), yAxis, units),
+                            };
+                        })
+                        .filter(p => p && p.y != null);
+
+                    if (overlayPoints.length) {
+                        result.push({
+                            type:            'scatter',
+                            label:           `${baseLabel} (real-world)`,
+                            data:            overlayPoints,
+                            backgroundColor: color,
+                            borderColor:     color,
+                            pointRadius:     5,
+                            pointHoverRadius: 7,
+                            showLine:        false,
+                            _vehicleId:      vehicle.id,
+                            _mappingId:      mapping.id,
+                            _isOverlay:      true,
+                        });
+                    }
+                }
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, overlayRealWorld]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -468,6 +526,13 @@ export default function EpaCurvesView({
                             },
                             label(item) {
                                 const ds = item.dataset;
+                                if (ds._isOverlay) {
+                                    // Overlay points are already corrected/converted at build
+                                    // time (see the datasets useMemo) — use the plotted value
+                                    // directly rather than re-deriving from a curve.
+                                    const decimals = yAxis === 'range_mi' ? 0 : yAxis === 'mi_kwh' ? 2 : 1;
+                                    return `${ds.label}: ${item.parsed.y?.toFixed(decimals)} ${yAxisLabel(yAxis, units)}`;
+                                }
                                 const curve = ds._curve;
                                 const speedMph = units === 'metric'
                                     ? item.parsed.x / 1.60934
@@ -591,6 +656,15 @@ export default function EpaCurvesView({
                                 <span className="text-sm font-medium">Auto Color</span>
                             </label>
                         )}
+                        <label className="toggle-label" title="Plot real-world range-test points on top of each curve, corrected for temperature and wind to match the curve's current viewing conditions (not elevation gain/loss — no model for that yet)">
+                            <input
+                                type="checkbox"
+                                checked={overlayRealWorld}
+                                onChange={e => setOverlayRealWorld(e.target.checked)}
+                                className="w-4 h-4"
+                            />
+                            <span className="text-sm font-medium">Overlay Real World Tests</span>
+                        </label>
                     </div>
 
                     {/* Viewing conditions — altitude, temperature, accessory load. Kept on

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -256,6 +256,10 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                     if (run._yValue != null) badges.push({ text: `${run._yValue} ${run._yUnit}`, primary: true });
                     if (run.speed_mph     != null) badges.push({ text: fmtSpeed(run.speed_mph, units) });
                     if (run.temperature_f != null) badges.push({ text: fmtTemp(run.temperature_f, units) });
+                    if (run.avg_wind_speed_mph != null) {
+                        const dir = run.wind_direction_deg != null ? ` @ ${run.wind_direction_deg}°` : '';
+                        badges.push({ text: `💨 ${fmtSpeed(run.avg_wind_speed_mph, units)}${dir}` });
+                    }
                     if (badges.length === 0) return;
 
                     const pillH  = 15, pillPad = 5, gap = 3, topPad = 6;
@@ -542,6 +546,14 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
                                 )}
                                 {run.temperature_f != null && (
                                     <span className="text-xs bg-orange-50 text-orange-700 px-1.5 py-0.5 rounded border border-orange-200">{fmtTemp(run.temperature_f, units)}</span>
+                                )}
+                                {run.avg_wind_speed_mph != null && (
+                                    <span
+                                        className="text-xs bg-cyan-50 text-cyan-700 px-1.5 py-0.5 rounded border border-cyan-200"
+                                        title={run.wind_direction_deg != null ? `${run.wind_direction_deg}° vs travel (0°=tailwind, 180°=headwind)` : 'Direction not recorded'}
+                                    >
+                                        💨 {fmtSpeed(run.avg_wind_speed_mph, units)}{run.wind_direction_deg != null ? ` @ ${run.wind_direction_deg}°` : ''}
+                                    </span>
                                 )}
                                 {range != null && (
                                     <span

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -388,6 +388,51 @@ export function apparentAirspeed(vMph, windSpeedMph, windDirectionDeg) {
     return Math.sqrt(Math.max(0, vRelSq));
 }
 
+// ── Real-world overlay correction ───────────────────────────────────────────
+
+/**
+ * Correct a real-world range-test point's measured consumption so it's
+ * comparable to an EPA curve drawn at different viewing conditions than the
+ * run was actually driven under (issue #139 step 3).
+ *
+ * Uses the SAME model (a/b/c road-load coefficients + η) as the curve itself:
+ * computes what the model predicts at the run's own conditions vs. at the
+ * curve's current viewing conditions, and scales the measured value by that
+ * ratio. This cancels most model error (it's a delta correction, not an
+ * absolute one) and guarantees a run driven under the exact viewing
+ * conditions is left unchanged (ratio = 1).
+ *
+ * NOT corrected: elevation gain/loss. Unlike static altitude (an air-density
+ * term), route elevation gain/loss is a route-dependent net-energy term with
+ * its own model that doesn't exist yet — see issue #139 step 2. Only
+ * temperature (density) and wind are corrected here.
+ *
+ * @param {object} group             — EPA group (coefficients + tests), same as buildEpaCurveFromModel
+ * @param {number} speedMph          — the run's recorded test speed
+ * @param {number} measuredKwh100mi  — the run's measured consumption (kWh/100mi)
+ * @param {object} runConditions     — { temperatureF, windSpeedMph, windDirectionDeg } as recorded on the run
+ * @param {object} viewConditions    — { densityRatio, accessoryOverrideW, windSpeedMph, windDirectionDeg } — the SAME values driving the curve
+ * @returns {number|null} corrected kWh/100mi, or null if the model can't be evaluated
+ */
+export function correctMeasuredConsumption(group, speedMph, measuredKwh100mi, runConditions, viewConditions) {
+    const coeffs = resolvePrimaryCoeffs(group);
+    if (!coeffs || !speedMph || !measuredKwh100mi) return null;
+
+    const eta   = deriveDrivetrainEta(group).value;
+    const accKw = viewConditions.accessoryOverrideW != null ? viewConditions.accessoryOverrideW / 1000 : accessoryKw(group);
+    const { a, b, c } = coeffs;
+
+    const runDensityRatio = temperatureDensityRatio(runConditions.temperatureF ?? null);
+    const cAtRun  = c * runDensityRatio;
+    const cAtView = c * viewConditions.densityRatio;
+
+    const predictedAtRun  = batteryConsumptionAt(speedMph, a, b, cAtRun,  eta, accKw, runConditions.windSpeedMph  || 0, runConditions.windDirectionDeg  || 0);
+    const predictedAtView = batteryConsumptionAt(speedMph, a, b, cAtView, eta, accKw, viewConditions.windSpeedMph || 0, viewConditions.windDirectionDeg || 0);
+
+    if (!predictedAtRun || predictedAtRun <= 0 || !predictedAtView) return null;
+    return measuredKwh100mi * (predictedAtView / predictedAtRun);
+}
+
 // ── Curve builder (curator model) ───────────────────────────────────────────
 
 /**

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -113,9 +113,13 @@ function accessoryKw(group) {
     return (w != null && w > 0 ? w : DEFAULT_ACCESSORY_W) / 1000;
 }
 
-/** Battery-side consumption (kWh/100mi) at a steady speed for a given η. */
-function batteryConsumptionAt(speedMph, a, b, c, eta, accKw) {
-    const eWheel = roadLoadForce(speedMph, a, b, c) * LBF_MILE_TO_KWH * 100;
+/** Battery-side consumption (kWh/100mi) at a steady speed for a given η.
+ *  Optional windSpeedMph/windDirectionDeg apply apparent-airspeed scaling to
+ *  ONLY the aerodynamic (C) term — see apparentAirspeed() below. Defaults to
+ *  no wind, so existing (still-air) call sites are unaffected. */
+function batteryConsumptionAt(speedMph, a, b, c, eta, accKw, windSpeedMph = 0, windDirectionDeg = 0) {
+    const vRel  = windSpeedMph ? apparentAirspeed(speedMph, windSpeedMph, windDirectionDeg) : speedMph;
+    const eWheel = (a + b * speedMph + c * vRel * vRel) * LBF_MILE_TO_KWH * 100;
     const eAcc   = accKw * 100 / speedMph;
     return eWheel / eta + eAcc;
 }
@@ -356,6 +360,34 @@ export function temperatureDensityRatio(tempF) {
     return standardRankine / actualRankine;
 }
 
+// ── Side wind ────────────────────────────────────────────────────────────────
+
+/**
+ * Apparent (relative) airspeed felt by the vehicle given its ground speed and
+ * an ambient wind, via the standard apparent-wind law:
+ *   V_rel = √(V² + W² − 2·V·W·cos ψ)
+ * where ψ (windDirectionDeg) follows the same convention as runs.wind_direction_deg
+ * (#142): 0° = tailwind, 180° = headwind, 90°/270° = crosswind, relative to the
+ * vehicle's direction of travel.
+ *
+ * This models only the MAGNITUDE of the relative airflow (so a headwind raises
+ * effective drag speed, a tailwind lowers it, and a pure crosswind raises it
+ * slightly) — it does NOT model yaw-angle sensitivity of the drag coefficient
+ * itself (real vehicles typically see Cd rise somewhat at non-zero yaw), since
+ * that requires a per-vehicle yaw-sensitivity curve this app doesn't have.
+ *
+ * @param {number} vMph              vehicle ground speed
+ * @param {number} windSpeedMph      ambient wind speed; 0/null ⇒ vRel === vMph
+ * @param {number} windDirectionDeg  wind direction relative to travel, 0-360°
+ * @returns {number} apparent airspeed (mph)
+ */
+export function apparentAirspeed(vMph, windSpeedMph, windDirectionDeg) {
+    if (!windSpeedMph) return vMph;
+    const psi = ((windDirectionDeg || 0) * Math.PI) / 180;
+    const vRelSq = vMph * vMph + windSpeedMph * windSpeedMph - 2 * vMph * windSpeedMph * Math.cos(psi);
+    return Math.sqrt(Math.max(0, vRelSq));
+}
+
 // ── Curve builder (curator model) ───────────────────────────────────────────
 
 /**
@@ -376,13 +408,21 @@ export function temperatureDensityRatio(tempF) {
  * the group's stored accessory load for THIS curve only, at plot time. η (which
  * was derived using the group's own accessory load) is never recomputed.
  *
+ * Side wind (viewing condition): `windSpeedMph`/`windDirectionDeg`, when given,
+ * scale the aerodynamic (C) term by apparent airspeed at EACH point (see
+ * apparentAirspeed() above) instead of ground speed — unlike density, this is
+ * speed-dependent, so it's applied per-point rather than as a single prefactor.
+ * η is never recomputed.
+ *
  * @param {object} group       — full group (with epa_coefficient_sets + epa_tests)
  * @param {number|null} useableKwh — battery capacity for range; null ⇒ rangeMi null
  * @param {number} densityRatio   — ρ_altitude / ρ_sea_level (default 1 = sea level)
  * @param {number|null} accessoryOverrideW — override accessory draw in watts; null ⇒ use the group's own value
+ * @param {number} windSpeedMph      — ambient wind speed; 0 ⇒ no wind effect
+ * @param {number} windDirectionDeg  — wind direction relative to travel (0=tailwind, 180=headwind)
  * @returns {Array<{ mph, kwh100mi, miPerKwh, mpge, rangeMi }>}
  */
-export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, accessoryOverrideW = null) {
+export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, accessoryOverrideW = null, windSpeedMph = 0, windDirectionDeg = 0) {
     const coeffs = resolvePrimaryCoeffs(group);
     if (!coeffs) return [];
 
@@ -394,7 +434,7 @@ export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, acce
 
     const out = [];
     for (let v = vMin; v <= vMax; v++) {
-        const kwh100mi = batteryConsumptionAt(v, a, b, c, eta, accKw);
+        const kwh100mi = batteryConsumptionAt(v, a, b, c, eta, accKw, windSpeedMph, windDirectionDeg);
         if (kwh100mi == null || kwh100mi <= 0) continue;
         const miPerKwh = 100 / kwh100mi;
         out.push({

--- a/src/utils/tooltipHelpers.js
+++ b/src/utils/tooltipHelpers.js
@@ -5,7 +5,7 @@ import { fmtSpeed, fmtTemp, fmtDistance } from './unitConversions';
  * Sections: Run specifics → Chart specifics (caller-provided).
  * Returns a flat array of strings; empty strings act as spacers.
  *
- * @param {object|null} run  - Run object with optional: source, speed_mph, temperature_f
+ * @param {object|null} run  - Run object with optional: source, speed_mph, temperature_f, avg_wind_speed_mph, wind_direction_deg
  * @param {string[]} chartLines - Additional lines for the chart-specifics section.
  * @param {string} units - 'imperial' | 'metric'
  */
@@ -17,6 +17,10 @@ export function runTooltipLines(run, chartLines = [], units = 'imperial') {
     if (run?.source)               runSection.push(`Source: ${run.source}`);
     if (run?.speed_mph     != null) runSection.push(`Speed: ${fmtSpeed(run.speed_mph, units)}`);
     if (run?.temperature_f != null) runSection.push(`Temp: ${fmtTemp(run.temperature_f, units)}`);
+    if (run?.avg_wind_speed_mph != null) {
+        const dir = run.wind_direction_deg != null ? ` @ ${run.wind_direction_deg}°` : '';
+        runSection.push(`Wind: ${fmtSpeed(run.avg_wind_speed_mph, units)}${dir}`);
+    }
     if (runSection.length) lines.push(...runSection);
 
     // ── Chart specifics ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Both queued items from issue #139 (environmental corrections epic), building on #142's wind data capture.

**EPA Curves — side wind:**
- New `apparentAirspeed(vMph, windSpeedMph, windDirectionDeg)` in `src/utils/epaDerivations.js`: apparent-wind law `V_rel = √(V² + W² − 2VW·cosψ)`, same direction convention as `runs.wind_direction_deg` (0°=tailwind, 180°=headwind, 90°/270°=crosswind).
- Unlike altitude/temp (a single density-ratio prefactor), wind is speed-dependent, so it's applied per-point inside `buildEpaCurveFromModel`'s loop via `batteryConsumptionAt`'s new optional wind params (default 0 ⇒ identical output to before, so the two existing still-air call sites — η derivation and implied-SS-speed — are unaffected).
- New "Wind" control (speed + direction) next to Altitude/Temp/Accessory Load in EPA Curves, with an info tooltip disclosing the model only captures relative-airspeed magnitude, not yaw-angle drag-coefficient sensitivity.

**Range graphs — show wind:**
- Wind speed + direction now shows next to speed/temp in: the bar-chart pill badges, the run-selector meta badges (cyan, matching the Tests & Data pill from #142), and the shared `runTooltipLines` helper (so Charging/Charge Compare tooltips pick it up too, wherever wind happens to be populated).

## Test plan
- [ ] EPA Curves: set Wind to e.g. 20mph @ 180° (headwind), confirm curves shift up and get the ▲ marker; @ 0° (tailwind) shifts down; @ 90°/270° shifts up slightly
- [ ] Confirm Wind at 0 mph reproduces the baseline curve exactly
- [ ] Range & Efficiency: pick a run with wind data (from #142), confirm the 💨 badge appears on its bar and in the run selector
- [ ] Hover a Charging/Charge Compare tooltip for a run with wind data, confirm the Wind line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)