### PR TITLE
Fix EPA Curves legend swatch mismatch for scatter overlay points

### DIFF
--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -507,23 +507,27 @@ export default function EpaCurvesView({
                         display: datasets.length > 1,
                         labels: {
                             color: legendColor,
-                            // Draw a short dashed line matching each dataset's line style
-                            // rather than the default filled circle.
+                            // Curve datasets get a short line swatch; the real-world
+                            // overlay (a scatter dataset) gets a dot/triangle swatch
+                            // matching its actual point marker — previously every
+                            // dataset used a line swatch regardless of type, so the
+                            // overlay's legend entry didn't match its plotted dots.
+                            usePointStyle: true,
                             generateLabels(chart) {
-                                return chart.data.datasets.map((ds, i) => ({
-                                    text:        ds.label,
-                                    fontColor:   legendColor,
-                                    fillStyle:   'transparent',
-                                    strokeStyle: ds.borderColor,
-                                    lineWidth:   ds.borderWidth ?? 2,
-                                    lineDash:    ds.borderDash  ?? [],
-                                    hidden:      !chart.isDatasetVisible(i),
-                                    datasetIndex: i,
-                                }));
+                                return chart.data.datasets.map((ds, i) => {
+                                    const isPointDataset = ds.type === 'scatter';
+                                    return {
+                                        text:        ds.label,
+                                        fontColor:   legendColor,
+                                        pointStyle:  isPointDataset ? (ds.pointStyle || 'circle') : 'line',
+                                        fillStyle:   isPointDataset ? ds.backgroundColor : 'transparent',
+                                        strokeStyle: ds.borderColor,
+                                        lineWidth:   ds.borderWidth ?? 2,
+                                        hidden:      !chart.isDatasetVisible(i),
+                                        datasetIndex: i,
+                                    };
+                                });
                             },
-                            usePointStyle: false,
-                            boxWidth: 24,
-                            boxHeight: 2,
                         },
                     },
                     tooltip: {


### PR DESCRIPTION
## Summary
- Bug: the custom legend `generateLabels()` in `EpaCurvesView.jsx` always rendered a line swatch (stroke + optional dash), even for the real-world overlay's scatter dataset — so its legend entry showed a line while the chart plots dots/triangles for those points.
- Fix: enabled `usePointStyle` on the legend and set a per-dataset `pointStyle` in `generateLabels` — curve datasets get a short line, the scatter overlay gets a filled dot (Corrected) or triangle (Uncorrected) matching its actual marker.
- Checked whether this affects other chart views: only `EpaCurvesView.jsx` has a custom `generateLabels` (confirmed via grep) — other charts use Chart.js's default legend swatch, which doesn't have this mismatch.

## Test plan
- [ ] EPA Curves with "Overlay Real World Tests" → Corrected enabled: legend shows a filled circle for the "(real-world)" entries, a short line for the curve entries
- [ ] Switch to Uncorrected: legend shows a filled triangle for the overlay entries
- [ ] Toggle a dataset off/on via legend click still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)