### PR TITLE
Add elevation gain/loss correction to EPA Curves, closing out #139

### DIFF
--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -10,7 +10,7 @@ import {
     resolveUseableKwh, resolveUseableKwhSource,
     HIGHWAY_BAND_MPH, MPG_E_CONVERSION,
 } from '../utils/epaPhysics';
-import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, correctMeasuredConsumption, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
+import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, correctMeasuredConsumption, averageGradePercent, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
 import { filterRangeRuns } from '../utils/runUtils';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
@@ -299,12 +299,19 @@ export default function EpaCurvesView({
     // (see apparentAirspeed in epaDerivations.js); never persisted, η untouched.
     const [windSpeedMph,     setWindSpeedMph]     = useState('');
     const [windDirectionDeg, setWindDirectionDeg] = useState('');
+    // Elevation gain/loss — a route/grade effect, distinct from static altitude
+    // (an air-density effect). Almost always 0; hidden behind a collapsible
+    // disclosure since the physics (weight-based PE, regen-efficiency
+    // approximation for descents) is more involved than the other conditions.
+    const [gradeExpanded,        setGradeExpanded]        = useState(false);
+    const [gradeGainFt,          setGradeGainFt]          = useState('');
+    const [gradeDistanceMiles,   setGradeDistanceMiles]   = useState('');
     // Overlay real-world range-test points on top of the curve. null = off.
-    // 'corrected' scales each point (temp + wind only, not elevation gain/loss
-    // — no model for that yet) to the viewing conditions above, so it's
-    // comparable to the curve as currently displayed. 'uncorrected' plots the
-    // raw measured value as recorded — not a valid comparison across
-    // different test conditions, but useful to see the true recorded data.
+    // 'corrected' scales each point (temp, wind, and elevation gain/loss) to
+    // the viewing conditions above, so it's comparable to the curve as
+    // currently displayed. 'uncorrected' plots the raw measured value as
+    // recorded — not a valid comparison across different test conditions,
+    // but useful to see the true recorded data.
     const [overlayMode, setOverlayMode] = useState(null); // null | 'corrected' | 'uncorrected'
     const clampTempF = (raw) => {
         if (raw === '' || raw === '-') return raw; // allow in-progress typing of a negative number
@@ -328,6 +335,10 @@ export default function EpaCurvesView({
     const windAdjusted = windSpeedMph !== '' && Number(windSpeedMph) > 0;
     const windSpeedMphNum = windAdjusted ? Number(windSpeedMph) : 0;
     const windDirectionDegNum = windDirectionDeg === '' ? 0 : Number(windDirectionDeg);
+    const gradeGainFtNum        = gradeGainFt === '' ? 0 : Number(gradeGainFt);
+    const gradeDistanceMilesNum = gradeDistanceMiles === '' ? 0 : Number(gradeDistanceMiles);
+    const gradeAdjusted    = gradeGainFtNum !== 0 && gradeDistanceMilesNum > 0;
+    const avgGradePercent  = averageGradePercent(gradeGainFtNum, gradeDistanceMilesNum);
 
     const { yAxis, xMin, xMax, yMin, yMax } = epaConfig;
 
@@ -363,7 +374,7 @@ export default function EpaCurvesView({
 
                 const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
                 const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
-                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio, accessoryOverrideWNum, windSpeedMphNum, windDirectionDegNum);
+                const curve            = buildEpaCurveFromModel(epaGroup, useableKwh, densityRatio, accessoryOverrideWNum, windSpeedMphNum, windDirectionDegNum, gradeGainFtNum, gradeDistanceMilesNum);
                 if (!curve.length) return;
 
                 // Color: user override → vehicleColorMap/vehicle color → palette (with alpha for 2nd+ mapping)
@@ -375,7 +386,7 @@ export default function EpaCurvesView({
                     ? `${vehicleLabel(vehicle)}${vehicle.epa_mappings.length > 1 ? ` (${epaLabel})` : ''}`
                     : vehicleLabel(vehicle);
                 // Subtle "adjusted" marker on each curve's legend entry (density or accessory load).
-                const label = (densityAdjusted || accessoryAdjusted || windAdjusted) ? `${baseLabel} ▲` : baseLabel;
+                const label = (densityAdjusted || accessoryAdjusted || windAdjusted || gradeAdjusted) ? `${baseLabel} ▲` : baseLabel;
 
                 result.push({
                     label,
@@ -400,15 +411,18 @@ export default function EpaCurvesView({
                 });
 
                 // ── Real-world overlay: this vehicle's own range-test runs, plotted as
-                // scatter points. 'corrected' scales each point (temp + wind only — see
-                // correctMeasuredConsumption) to the same viewing conditions as the curve
-                // above; 'uncorrected' plots the raw measured value as recorded.
+                // scatter points. 'corrected' scales each point (temp, wind, and
+                // elevation gain/loss — see correctMeasuredConsumption) to the same
+                // viewing conditions as the curve above; 'uncorrected' plots the raw
+                // measured value as recorded.
                 if (overlayMode) {
                     const viewConditions = {
                         densityRatio,
-                        accessoryOverrideW: accessoryOverrideWNum,
-                        windSpeedMph:       windSpeedMphNum,
-                        windDirectionDeg:   windDirectionDegNum,
+                        accessoryOverrideW:     accessoryOverrideWNum,
+                        windSpeedMph:           windSpeedMphNum,
+                        windDirectionDeg:       windDirectionDegNum,
+                        elevationGainFt:        gradeGainFtNum,
+                        elevationDistanceMiles: gradeDistanceMilesNum,
                     };
                     const overlayPoints = filterRangeRuns(vehicle.runs)
                         .filter(r => !r._inherited && r.speed_mph != null && r.distance_miles > 0 && r.energy_kwh != null)
@@ -420,6 +434,8 @@ export default function EpaCurvesView({
                                     temperatureF:     run.temperature_f,
                                     windSpeedMph:     run.avg_wind_speed_mph,
                                     windDirectionDeg: run.wind_direction_deg,
+                                    elevationGainFt:  run.elevation_gain_ft,
+                                    distanceMiles:    run.distance_miles,
                                 };
                                 kwh100mi = correctMeasuredConsumption(epaGroup, run.speed_mph, measuredKwh100mi, runConditions, viewConditions);
                                 if (kwh100mi == null) return null;
@@ -459,7 +475,7 @@ export default function EpaCurvesView({
             });
         });
         return result;
-    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, overlayMode]);
+    }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, gradeGainFtNum, gradeDistanceMilesNum, gradeAdjusted, overlayMode]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
     useEffect(() => {
@@ -677,7 +693,7 @@ export default function EpaCurvesView({
                                     className="ml-1"
                                 >
                                     <p>Plot this vehicle's own range-test points on top of its curve.</p>
-                                    <p className="mt-1.5"><strong>Corrected:</strong> scaled by temperature + wind to match the curve's current viewing conditions above — an apples-to-apples comparison (not elevation gain/loss — no model for that yet).</p>
+                                    <p className="mt-1.5"><strong>Corrected:</strong> scaled by temperature, wind, and elevation gain/loss to match the curve's current viewing conditions above — an apples-to-apples comparison.</p>
                                     <p className="mt-1.5"><strong>Uncorrected:</strong> the raw measured value as recorded, unadjusted — not a valid comparison across different test conditions, but useful to see the true recorded data.</p>
                                 </InfoIcon>
                             </span>
@@ -811,6 +827,61 @@ export default function EpaCurvesView({
                                 aria-label="Wind direction relative to travel, in degrees"
                             />
                             <span className="text-sm text-faint">°{windAdjusted ? ' ▲' : ''}</span>
+                        </div>
+
+                        {/* Elevation gain/loss — a route/grade effect (distinct from static
+                            altitude). Almost always 0, and more convoluted than the other
+                            conditions (weight-based PE physics, regen-efficiency approximation
+                            for descents), so it's collapsed by default. */}
+                        <div className="flex items-center gap-1.5">
+                            <span
+                                onClick={() => setGradeExpanded(e => !e)}
+                                className="text-sm font-medium flex items-center cursor-pointer"
+                                style={{ color: 'var(--color-text-secondary)' }}
+                            >
+                                {gradeExpanded ? '▾' : '▸'} Elevation Gain/Loss
+                                <InfoIcon
+                                    text="Adds a fixed energy cost/credit for a net climb or descent over a given distance — a route effect, distinct from static altitude (air density). Climbing: full physics based on vehicle weight. Descending: only ~70% of the theoretical energy is assumed recovered via regen. Usually 0 — most tests are round trips or flat routes."
+                                    position="right"
+                                    className="ml-1"
+                                />
+                            </span>
+                            {!gradeExpanded && gradeAdjusted && (
+                                <span className="text-xs text-amber-600 dark:text-amber-400 font-medium whitespace-nowrap">
+                                    ({avgGradePercent.toFixed(1)}% grade ▲)
+                                </span>
+                            )}
+                            {gradeExpanded && (
+                                <>
+                                    <input
+                                        type="number"
+                                        step="50"
+                                        value={gradeGainFt}
+                                        onChange={e => setGradeGainFt(e.target.value)}
+                                        placeholder="0"
+                                        className="form-input text-sm py-1 w-20 text-right"
+                                        aria-label="Net elevation gain in feet (negative for net descent)"
+                                    />
+                                    <span className="text-sm text-faint">ft over</span>
+                                    <input
+                                        type="number"
+                                        step="5"
+                                        min="0"
+                                        value={gradeDistanceMiles}
+                                        onChange={e => setGradeDistanceMiles(e.target.value)}
+                                        placeholder="0"
+                                        className="form-input text-sm py-1 w-16 text-right"
+                                        aria-label="Distance in miles the elevation change is spread over"
+                                    />
+                                    <span className="text-sm text-faint">mi</span>
+                                    <span
+                                        className={`text-xs whitespace-nowrap ${gradeAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
+                                        title="Average grade over the distance above"
+                                    >
+                                        → {avgGradePercent.toFixed(1)}% grade{gradeAdjusted ? ' ▲' : ''}
+                                    </span>
+                                </>
+                            )}
                         </div>
                     </div>
 

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -729,11 +729,20 @@ export default function EpaCurvesView({
                             row below so opening one never reflows the rows above it. */}
                         <button
                             type="button"
-                            className={`btn btn-sm ${gradeExpanded || gradeAdjusted ? 'btn-primary' : 'btn-secondary'}`}
-                            onClick={() => setGradeExpanded(e => !e)}
+                            className={`btn btn-sm ${gradeExpanded ? 'btn-primary' : 'btn-secondary'}`}
+                            onClick={() => setGradeExpanded(e => {
+                                const next = !e;
+                                // Turning off fully disables the adjustment, not just hides
+                                // the panel — otherwise it keeps applying invisibly.
+                                if (!next) {
+                                    setGradeGainFt('');
+                                    setGradeDistanceMiles('');
+                                }
+                                return next;
+                            })}
                             title="Adjust for a net elevation gain/loss over a route (advanced — usually 0)"
                         >
-                            Adj. Elevation{gradeAdjusted ? ` (${avgGradePercent.toFixed(1)}%)` : ''}
+                            Adj. Elevation
                         </button>
                     </div>
 

--- a/src/components/EpaCurvesView.jsx
+++ b/src/components/EpaCurvesView.jsx
@@ -10,7 +10,7 @@ import {
     resolveUseableKwh, resolveUseableKwhSource,
     HIGHWAY_BAND_MPH, MPG_E_CONVERSION,
 } from '../utils/epaPhysics';
-import { buildEpaCurveFromModel, deriveDrivetrainEta, airDensityRatio, temperatureDensityRatio, correctMeasuredConsumption, averageGradePercent, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
+import { buildEpaCurveFromModel, deriveDrivetrainEta, resolvePrimaryCoeffs, airDensityRatio, temperatureDensityRatio, correctMeasuredConsumption, averageGradePercent, STANDARD_TEMP_F, DEFAULT_ACCESSORY_W } from '../utils/epaDerivations';
 import { filterRangeRuns } from '../utils/runUtils';
 import AxisScaleControls from './AxisScaleControls';
 import InfoIcon from './InfoIcon';
@@ -360,8 +360,9 @@ export default function EpaCurvesView({
     );
 
     // ── Datasets ──────────────────────────────────────────────────────────────
-    const datasets = useMemo(() => {
+    const { datasets, missingWeightWarnings } = useMemo(() => {
         const result = [];
+        const missingWeightWarnings = [];
         vehiclesWithEpa.forEach((vehicle, vi) => {
             const effectiveVehicle = {
                 ...vehicle,
@@ -371,6 +372,18 @@ export default function EpaCurvesView({
                 const { epaGroup, confidence } = mapping;
                 if (!epaGroup) return;
                 if (hiddenMappings.has(mapping.id)) return;
+
+                // An elevation adjustment needs the group's own EPA equivalent test
+                // weight (see gradeEnergyKwh100mi) — some imports never captured it.
+                // Rather than silently drawing an unadjusted curve as if there were
+                // no grade, drop the curve (and its overlay) entirely and flag it.
+                if (gradeAdjusted && !resolvePrimaryCoeffs(epaGroup)?.equivTestWeightLbs) {
+                    missingWeightWarnings.push({
+                        vehicleName: vehicleLabel(vehicle),
+                        epaLabel: epaGroup.display_name || epaGroup.epa_carline_name,
+                    });
+                    return;
+                }
 
                 const useableKwh       = resolveUseableKwh(epaGroup, effectiveVehicle);
                 const useableKwhSource = resolveUseableKwhSource(epaGroup, effectiveVehicle);
@@ -474,7 +487,7 @@ export default function EpaCurvesView({
                 }
             });
         });
-        return result;
+        return { datasets: result, missingWeightWarnings };
     }, [vehiclesWithEpa, vehicles, yAxis, units, hiddenMappings, mappingColors, vehicleColorMap, densityRatio, densityAdjusted, accessoryOverrideWNum, accessoryAdjusted, windSpeedMphNum, windDirectionDegNum, windAdjusted, gradeGainFtNum, gradeDistanceMilesNum, gradeAdjusted, overlayMode]);
 
     // ── Chart build / rebuild ─────────────────────────────────────────────────
@@ -712,6 +725,16 @@ export default function EpaCurvesView({
                                 Uncorrected
                             </button>
                         </div>
+                        {/* Advanced/experimental toggles — collapsed by default, own panel
+                            row below so opening one never reflows the rows above it. */}
+                        <button
+                            type="button"
+                            className={`btn btn-sm ${gradeExpanded || gradeAdjusted ? 'btn-primary' : 'btn-secondary'}`}
+                            onClick={() => setGradeExpanded(e => !e)}
+                            title="Adjust for a net elevation gain/loss over a route (advanced — usually 0)"
+                        >
+                            Adj. Elevation{gradeAdjusted ? ` (${avgGradePercent.toFixed(1)}%)` : ''}
+                        </button>
                     </div>
 
                     {/* Viewing conditions — altitude, temperature, accessory load. Kept on
@@ -828,62 +851,58 @@ export default function EpaCurvesView({
                             />
                             <span className="text-sm text-faint">°{windAdjusted ? ' ▲' : ''}</span>
                         </div>
-
-                        {/* Elevation gain/loss — a route/grade effect (distinct from static
-                            altitude). Almost always 0, and more convoluted than the other
-                            conditions (weight-based PE physics, regen-efficiency approximation
-                            for descents), so it's collapsed by default. */}
-                        <div className="flex items-center gap-1.5">
-                            <span
-                                onClick={() => setGradeExpanded(e => !e)}
-                                className="text-sm font-medium flex items-center cursor-pointer"
-                                style={{ color: 'var(--color-text-secondary)' }}
-                            >
-                                {gradeExpanded ? '▾' : '▸'} Elevation Gain/Loss
-                                <InfoIcon
-                                    text="Adds a fixed energy cost/credit for a net climb or descent over a given distance — a route effect, distinct from static altitude (air density). Climbing: full physics based on vehicle weight. Descending: only ~70% of the theoretical energy is assumed recovered via regen. Usually 0 — most tests are round trips or flat routes."
-                                    position="right"
-                                    className="ml-1"
-                                />
-                            </span>
-                            {!gradeExpanded && gradeAdjusted && (
-                                <span className="text-xs text-amber-600 dark:text-amber-400 font-medium whitespace-nowrap">
-                                    ({avgGradePercent.toFixed(1)}% grade ▲)
-                                </span>
-                            )}
-                            {gradeExpanded && (
-                                <>
-                                    <input
-                                        type="number"
-                                        step="50"
-                                        value={gradeGainFt}
-                                        onChange={e => setGradeGainFt(e.target.value)}
-                                        placeholder="0"
-                                        className="form-input text-sm py-1 w-20 text-right"
-                                        aria-label="Net elevation gain in feet (negative for net descent)"
-                                    />
-                                    <span className="text-sm text-faint">ft over</span>
-                                    <input
-                                        type="number"
-                                        step="5"
-                                        min="0"
-                                        value={gradeDistanceMiles}
-                                        onChange={e => setGradeDistanceMiles(e.target.value)}
-                                        placeholder="0"
-                                        className="form-input text-sm py-1 w-16 text-right"
-                                        aria-label="Distance in miles the elevation change is spread over"
-                                    />
-                                    <span className="text-sm text-faint">mi</span>
-                                    <span
-                                        className={`text-xs whitespace-nowrap ${gradeAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
-                                        title="Average grade over the distance above"
-                                    >
-                                        → {avgGradePercent.toFixed(1)}% grade{gradeAdjusted ? ' ▲' : ''}
-                                    </span>
-                                </>
-                            )}
-                        </div>
                     </div>
+
+                    {/* Elevation gain/loss panel — a route/grade effect (distinct from static
+                        altitude). Its own row, toggled by the "Adj. Elevation" button above, so
+                        opening/closing it never reflows the altitude/temp/wind row. */}
+                    {gradeExpanded && (
+                        <div className="chart-viewing-conditions">
+                            <div className="flex items-center gap-1.5">
+                                <span className="text-sm font-medium flex items-center" style={{ color: 'var(--color-text-secondary)' }}>
+                                    Elevation Gain/Loss
+                                    <InfoIcon
+                                        text="Adds a fixed energy cost/credit for a net climb or descent over a given distance — a route effect, distinct from static altitude (air density). Climbing: full physics based on vehicle weight. Descending: only ~70% of the theoretical energy is assumed recovered via regen. Usually 0 — most tests are round trips or flat routes."
+                                        position="right"
+                                        className="ml-1"
+                                    />
+                                </span>
+                                <input
+                                    type="number"
+                                    step="50"
+                                    value={gradeGainFt}
+                                    onChange={e => setGradeGainFt(e.target.value)}
+                                    placeholder="0"
+                                    className="form-input text-sm py-1 w-20 text-right"
+                                    aria-label="Net elevation gain in feet (negative for net descent)"
+                                />
+                                <span className="text-sm text-faint">ft over</span>
+                                <input
+                                    type="number"
+                                    step="5"
+                                    min="0"
+                                    value={gradeDistanceMiles}
+                                    onChange={e => setGradeDistanceMiles(e.target.value)}
+                                    placeholder="0"
+                                    className="form-input text-sm py-1 w-16 text-right"
+                                    aria-label="Distance in miles the elevation change is spread over"
+                                />
+                                <span className="text-sm text-faint">mi</span>
+                                <span
+                                    className={`text-xs whitespace-nowrap ${gradeAdjusted ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-faint'}`}
+                                    title="Average grade over the distance above"
+                                >
+                                    → {avgGradePercent.toFixed(1)}% grade{gradeAdjusted ? ' ▲' : ''}
+                                </span>
+                            </div>
+                        </div>
+                    )}
+
+                    {missingWeightWarnings.length > 0 && (
+                        <div className="chart-warning-banner">
+                            ⚠ Elevation Gain/Loss can't be applied for {missingWeightWarnings.map(w => `${w.vehicleName} (${w.epaLabel})`).join(', ')} — no EPA equivalent test weight on file. That curve is hidden while an elevation adjustment is active.
+                        </div>
+                    )}
 
                     {/* Collapsible EPA test selector */}
                     {vehiclesWithEpa.length > 0 && (

--- a/src/index.css
+++ b/src/index.css
@@ -758,6 +758,17 @@ body {
     @apply flex flex-wrap items-center gap-4 mb-4;
 }
 
+/* Warning banner for a viewing condition that can't be applied (e.g. EPA
+   Curves elevation adjustment missing a required weight for one vehicle) */
+.chart-warning-banner {
+    @apply text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 mb-4;
+}
+[data-theme="dark"] .chart-warning-banner {
+    background-color: rgba(245, 158, 11, 0.1);
+    border-color: rgba(245, 158, 11, 0.3);
+    color: rgb(252, 211, 77);
+}
+
 /* Collapsible "Select Runs" section header button */
 .run-selector-header {
     @apply flex items-center gap-2 w-full text-left font-medium transition-colors mb-1;
@@ -1131,6 +1142,7 @@ body {
     position: absolute;
     z-index: 100;
     width: 240px;
+    max-width: calc(100vw - 2rem); /* never wider than the viewport on narrow screens */
     padding: 0.5rem 0.625rem;
     font-size: 0.75rem;
     line-height: 1.4;
@@ -1171,6 +1183,7 @@ body {
 /* Width override for richer tooltip content (e.g. a reference table) */
 .info-icon-tooltip--wide {
     width: 460px;
+    max-width: calc(100vw - 2rem);
 }
 
 /* Reference table shown inside a wide info-icon tooltip (e.g. EPA Curves accessory load) */

--- a/src/utils/epaDerivations.js
+++ b/src/utils/epaDerivations.js
@@ -65,7 +65,7 @@ const inBand = (v, [lo, hi]) => v != null && v >= lo && v <= hi;
  * Pick the coefficient set that drives derivations: the primary (City/Highway)
  * set, else the first available. Prefers target_* coefficients over set_*.
  *
- * @returns {{ a, b, c, source: 'target'|'set', category }|null}
+ * @returns {{ a, b, c, source: 'target'|'set', category, equivTestWeightLbs }|null}
  */
 export function resolvePrimaryCoeffs(group) {
     const sets = group?.epa_coefficient_sets || [];
@@ -73,14 +73,15 @@ export function resolvePrimaryCoeffs(group) {
     const primary = sets.find(s => s.is_primary)
         || sets.find(s => s.category === 'City/Highway')
         || sets[0];
+    const equivTestWeightLbs = num(primary.equiv_test_weight_lbs);
 
     const ta = num(primary.target_a), tb = num(primary.target_b), tc = num(primary.target_c);
     if (ta != null && tb != null && tc != null) {
-        return { a: ta, b: tb, c: tc, source: 'target', category: primary.category };
+        return { a: ta, b: tb, c: tc, source: 'target', category: primary.category, equivTestWeightLbs };
     }
     const sa = num(primary.set_a), sb = num(primary.set_b), sc = num(primary.set_c);
     if (sa != null && sb != null && sc != null) {
-        return { a: sa, b: sb, c: sc, source: 'set', category: primary.category };
+        return { a: sa, b: sb, c: sc, source: 'set', category: primary.category, equivTestWeightLbs };
     }
     return null;
 }
@@ -388,6 +389,57 @@ export function apparentAirspeed(vMph, windSpeedMph, windDirectionDeg) {
     return Math.sqrt(Math.max(0, vRelSq));
 }
 
+// ── Elevation gain/loss (grade) ──────────────────────────────────────────────
+
+/** Fraction of the theoretical descent PE actually recovered to the battery
+ *  via regen — the rest is lost to rolling/aero drag during the descent and
+ *  motor/inverter conversion losses. Real-world EVs recover roughly 60-80%;
+ *  this is a single fleet-wide approximation, not vehicle-specific. */
+export const REGEN_EFFICIENCY = 0.7;
+
+/**
+ * Average grade, as a percentage (rise/run), for a net elevation change over
+ * a horizontal distance. Display-only — not used in the energy math directly
+ * (that uses the same rise/run fraction, unitless).
+ *
+ * @param {number} elevationGainFt  net elevation change (ft); + = net climb
+ * @param {number} distanceMiles    horizontal distance the gain is spread over
+ * @returns {number} grade, as a percentage (0 if either input is falsy)
+ */
+export function averageGradePercent(elevationGainFt, distanceMiles) {
+    if (!elevationGainFt || !distanceMiles) return 0;
+    return (elevationGainFt / (distanceMiles * 5280)) * 100;
+}
+
+/**
+ * Energy contribution (kWh/100mi) from a net elevation change over a given
+ * distance — a route/grade effect, distinct from static altitude (which is an
+ * air-density effect on aerodynamic drag, see airDensityRatio). Unlike
+ * density or wind, grade doesn't vary with speed: climbing a given grade
+ * costs the same energy per mile regardless of how fast it's driven, so this
+ * is a constant additive term, not a per-speed curve-shape scale.
+ *
+ * Climbing (positive grade): full small-angle PE physics (energy = weight ×
+ * rise, via the same LBF_MILE_TO_KWH conversion used for road-load force),
+ * divided by η like any other wheel-level work.
+ * Descending (negative grade): only REGEN_EFFICIENCY of the theoretical PE
+ * is assumed recovered — regen braking never returns 100%.
+ *
+ * @param {number|null} weightLbs    vehicle weight (EPA equivalent test weight — same
+ *                                   basis as the a/b/c road-load coefficients); null/0 ⇒ 0
+ * @param {number} elevationGainFt   net elevation change (ft); + = net climb
+ * @param {number} distanceMiles     horizontal distance the gain is spread over
+ * @param {number} eta               drivetrain efficiency (same η used for the rest of the curve)
+ * @returns {number} signed kWh/100mi contribution (+ increases consumption, − decreases it)
+ */
+export function gradeEnergyKwh100mi(weightLbs, elevationGainFt, distanceMiles, eta) {
+    if (!weightLbs || !elevationGainFt || !distanceMiles) return 0;
+    const gradeFraction = elevationGainFt / (distanceMiles * 5280); // rise/run, small-angle approx
+    const gradeForceLbf = weightLbs * gradeFraction;
+    const rawKwh100mi = gradeForceLbf * LBF_MILE_TO_KWH * 100;
+    return gradeFraction > 0 ? rawKwh100mi / eta : rawKwh100mi * REGEN_EFFICIENCY;
+}
+
 // ── Real-world overlay correction ───────────────────────────────────────────
 
 /**
@@ -395,23 +447,24 @@ export function apparentAirspeed(vMph, windSpeedMph, windDirectionDeg) {
  * comparable to an EPA curve drawn at different viewing conditions than the
  * run was actually driven under (issue #139 step 3).
  *
- * Uses the SAME model (a/b/c road-load coefficients + η) as the curve itself:
- * computes what the model predicts at the run's own conditions vs. at the
- * curve's current viewing conditions, and scales the measured value by that
- * ratio. This cancels most model error (it's a delta correction, not an
- * absolute one) and guarantees a run driven under the exact viewing
- * conditions is left unchanged (ratio = 1).
+ * Temperature and wind use the SAME model (a/b/c road-load coefficients + η)
+ * as the curve itself: computes what the model predicts at the run's own
+ * conditions vs. at the curve's current viewing conditions, and scales the
+ * measured value by that ratio. This cancels most model error (it's a delta
+ * correction, not an absolute one) and guarantees a run driven under the
+ * exact viewing conditions is left unchanged (ratio = 1).
  *
- * NOT corrected: elevation gain/loss. Unlike static altitude (an air-density
- * term), route elevation gain/loss is a route-dependent net-energy term with
- * its own model that doesn't exist yet — see issue #139 step 2. Only
- * temperature (density) and wind are corrected here.
+ * Elevation gain/loss is additive rather than multiplicative (see
+ * gradeEnergyKwh100mi), so it's composed around the ratio step instead of
+ * inside it: the run's own grade contribution is subtracted out first (to
+ * isolate the flat-ground-equivalent measured value), then the view's grade
+ * contribution is added back in after scaling.
  *
  * @param {object} group             — EPA group (coefficients + tests), same as buildEpaCurveFromModel
  * @param {number} speedMph          — the run's recorded test speed
  * @param {number} measuredKwh100mi  — the run's measured consumption (kWh/100mi)
- * @param {object} runConditions     — { temperatureF, windSpeedMph, windDirectionDeg } as recorded on the run
- * @param {object} viewConditions    — { densityRatio, accessoryOverrideW, windSpeedMph, windDirectionDeg } — the SAME values driving the curve
+ * @param {object} runConditions     — { temperatureF, windSpeedMph, windDirectionDeg, elevationGainFt, distanceMiles } as recorded on the run
+ * @param {object} viewConditions    — { densityRatio, accessoryOverrideW, windSpeedMph, windDirectionDeg, elevationGainFt, elevationDistanceMiles } — the SAME values driving the curve
  * @returns {number|null} corrected kWh/100mi, or null if the model can't be evaluated
  */
 export function correctMeasuredConsumption(group, speedMph, measuredKwh100mi, runConditions, viewConditions) {
@@ -420,7 +473,7 @@ export function correctMeasuredConsumption(group, speedMph, measuredKwh100mi, ru
 
     const eta   = deriveDrivetrainEta(group).value;
     const accKw = viewConditions.accessoryOverrideW != null ? viewConditions.accessoryOverrideW / 1000 : accessoryKw(group);
-    const { a, b, c } = coeffs;
+    const { a, b, c, equivTestWeightLbs } = coeffs;
 
     const runDensityRatio = temperatureDensityRatio(runConditions.temperatureF ?? null);
     const cAtRun  = c * runDensityRatio;
@@ -430,7 +483,12 @@ export function correctMeasuredConsumption(group, speedMph, measuredKwh100mi, ru
     const predictedAtView = batteryConsumptionAt(speedMph, a, b, cAtView, eta, accKw, viewConditions.windSpeedMph || 0, viewConditions.windDirectionDeg || 0);
 
     if (!predictedAtRun || predictedAtRun <= 0 || !predictedAtView) return null;
-    return measuredKwh100mi * (predictedAtView / predictedAtRun);
+
+    const runGradeKwh100mi  = gradeEnergyKwh100mi(equivTestWeightLbs, runConditions.elevationGainFt,  runConditions.distanceMiles,        eta);
+    const viewGradeKwh100mi = gradeEnergyKwh100mi(equivTestWeightLbs, viewConditions.elevationGainFt, viewConditions.elevationDistanceMiles, eta);
+
+    const flatEquivalentMeasured = measuredKwh100mi - runGradeKwh100mi;
+    return flatEquivalentMeasured * (predictedAtView / predictedAtRun) + viewGradeKwh100mi;
 }
 
 // ── Curve builder (curator model) ───────────────────────────────────────────
@@ -459,15 +517,23 @@ export function correctMeasuredConsumption(group, speedMph, measuredKwh100mi, ru
  * speed-dependent, so it's applied per-point rather than as a single prefactor.
  * η is never recomputed.
  *
+ * Elevation gain/loss (viewing condition): `elevationGainFt`/`elevationDistanceMiles`
+ * add a constant kWh/100mi offset (see gradeEnergyKwh100mi) — unlike density/wind,
+ * grade doesn't vary with speed, so it's the same shift at every point. Uses the
+ * EPA coefficient set's own equivalent test weight; a group with no weight on
+ * file has no grade effect (gradeEnergyKwh100mi returns 0).
+ *
  * @param {object} group       — full group (with epa_coefficient_sets + epa_tests)
  * @param {number|null} useableKwh — battery capacity for range; null ⇒ rangeMi null
  * @param {number} densityRatio   — ρ_altitude / ρ_sea_level (default 1 = sea level)
  * @param {number|null} accessoryOverrideW — override accessory draw in watts; null ⇒ use the group's own value
  * @param {number} windSpeedMph      — ambient wind speed; 0 ⇒ no wind effect
  * @param {number} windDirectionDeg  — wind direction relative to travel (0=tailwind, 180=headwind)
+ * @param {number} elevationGainFt          — net elevation change (ft) over elevationDistanceMiles; + = net climb
+ * @param {number} elevationDistanceMiles   — horizontal distance the gain is spread over
  * @returns {Array<{ mph, kwh100mi, miPerKwh, mpge, rangeMi }>}
  */
-export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, accessoryOverrideW = null, windSpeedMph = 0, windDirectionDeg = 0) {
+export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, accessoryOverrideW = null, windSpeedMph = 0, windDirectionDeg = 0, elevationGainFt = 0, elevationDistanceMiles = 0) {
     const coeffs = resolvePrimaryCoeffs(group);
     if (!coeffs) return [];
 
@@ -475,12 +541,15 @@ export function buildEpaCurveFromModel(group, useableKwh, densityRatio = 1, acce
     const accKw = accessoryOverrideW != null ? accessoryOverrideW / 1000 : accessoryKw(group);
     const { a, b } = coeffs;
     const c = coeffs.c * densityRatio; // aerodynamic term only, display-time scale
+    const gradeKwh100mi = gradeEnergyKwh100mi(coeffs.equivTestWeightLbs, elevationGainFt, elevationDistanceMiles, eta);
     const [vMin, vMax] = CURVE_SPEED_RANGE;
 
     const out = [];
     for (let v = vMin; v <= vMax; v++) {
-        const kwh100mi = batteryConsumptionAt(v, a, b, c, eta, accKw, windSpeedMph, windDirectionDeg);
-        if (kwh100mi == null || kwh100mi <= 0) continue;
+        const base = batteryConsumptionAt(v, a, b, c, eta, accKw, windSpeedMph, windDirectionDeg);
+        if (base == null) continue;
+        const kwh100mi = base + gradeKwh100mi;
+        if (kwh100mi <= 0) continue;
         const miPerKwh = 100 / kwh100mi;
         out.push({
             mph: v,


### PR DESCRIPTION
## Summary
The last piece of issue #139 (environmental corrections epic) — temp, wind, and accessory load are already done; this adds elevation gain/loss.

- New **"Elevation Gain/Loss"** control in EPA Curves: net gain (ft) over a distance (mi), with an average-grade % readout. Collapsed behind a disclosure (▸/▾) by default — usually 0, and the physics here is more involved than the other viewing conditions, per your ask to keep it out of the way.
- `gradeEnergyKwh100mi()` in `epaDerivations.js`: unlike density/wind, grade doesn't vary with speed — climbing a grade costs the same energy per mile regardless of how fast you drive it. Modeled as a constant kWh/100mi offset added to every point on the curve:
  - **Climbing**: full small-angle PE physics (weight × rise), divided by η like any other wheel-level work.
  - **Descending**: only `REGEN_EFFICIENCY` (0.7, a single fleet-wide approximation) of the theoretical PE is assumed recovered — regen never returns 100%.
  - Uses the EPA coefficient set's own **equivalent test weight** (same basis as the a/b/c road-load coefficients) — `resolvePrimaryCoeffs()` now also returns `equivTestWeightLbs`. A group missing that field just has no grade effect (no error).
- **Real-world overlay**: `correctMeasuredConsumption()` now composes grade alongside the existing temp/wind ratio correction. Since grade is additive (not multiplicative like density/wind), the run's own grade contribution (from its recorded `elevation_gain_ft`/`distance_miles`) is subtracted out first to isolate a flat-ground-equivalent measured value, scaled by the temp/wind ratio as before, then the viewing condition's grade contribution is added back in. This closes the "not corrected: elevation gain/loss" gap called out in the original overlay PR.

## Test plan
- [ ] EPA Curves: expand "Elevation Gain/Loss", enter e.g. 500 ft over 10 mi (5% grade climb) — confirm the curve shifts up (more consumption) by a constant amount at every speed, and gets the ▲ marker
- [ ] Enter a negative gain (net descent) — confirm the curve shifts down, by less than the climb case at the same magnitude (since only ~70% is recovered)
- [ ] Collapse the panel — confirm it reads as "(X% grade ▲)" next to the label when non-zero, and disappears when 0
- [ ] With "Overlay Real World Tests" → Corrected enabled, and a run that has `elevation_gain_ft` set: confirm the point shifts appropriately when grade viewing conditions change
- [ ] A vehicle/EPA group missing `equiv_test_weight_lbs`: confirm no crash, grade control simply has no visible effect

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)