### PR TITLE
Performance testing: data foundation (schema, parser, derivations)

### DIFF
--- a/src/constants/units.js
+++ b/src/constants/units.js
@@ -11,6 +11,10 @@ export const CUFT_TO_L  = 28.3168;   // cubic feet → litres
 export const LBFT_TO_NM = 1.35582;   // lb-ft → newton-metres
 export const FT_TO_M    = 0.3048;    // feet → metres
 export const HP_TO_KW   = 0.7457;    // horsepower → kilowatts
+export const MPH_TO_MS  = 0.44704;   // miles per hour → metres per second
+
+/** Standard gravity (m/s²) — expresses accel/decel rates in g. */
+export const G_MS2 = 9.80665;
 
 /** kWh per gallon of gasoline-equivalent — the MPGe basis. */
 export const MPG_E_CONVERSION = 33.705;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -102,10 +102,24 @@ class DataService {
       const saved = localStorage.getItem('evData');
       return saved ? (JSON.parse(saved).vehicles || []) : [];
     }
-    const { data } = await getSupabase()
+    // NOTE: performance_summaries / performance_intervals are deliberately NOT
+    // embedded here. This query backs the entire app, and a nested select against
+    // a table that doesn't exist yet fails the WHOLE query — which previously
+    // surfaced as "No vehicles yet" on any environment where the newest migration
+    // hadn't been applied. Performance data is fetched separately, where a missing
+    // table degrades to "no performance data" instead of "no vehicles".
+    const { data, error } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), performance_summaries(*, performance_intervals(*)), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
       .order('created_at', { ascending: false });
+
+    // Never swallow this. Destructuring only `data` made a failed query look
+    // identical to an empty account, which turned a missing migration into a
+    // silent "No vehicles yet" that took a live debugging session to trace.
+    if (error) {
+      console.error('getVehicles failed:', error.message, error);
+      throw error;
+    }
 
     // Pass 1: process each vehicle's own data
     const processed = (data || []).map(v => {
@@ -1632,6 +1646,30 @@ class DataService {
     }
 
     return sessionRow;
+  }
+
+  /**
+   * Reported summaries with their variable-window intervals, for one vehicle or
+   * (omit the argument) all of them — the cross-vehicle compare charts need the
+   * whole set.
+   *
+   * Fetched separately from getVehicles() on purpose: this is new-table
+   * territory, and embedding it in the main vehicles query meant an unapplied
+   * migration blanked the entire app. Here a missing table degrades to "no
+   * performance data" and is logged, rather than taking the vehicle list with it.
+   */
+  async getPerformanceSummaries(vehicleId = null) {
+    if (!this.useSupabase) return [];
+    let q = getSupabase()
+      .from('performance_summaries')
+      .select('*, performance_intervals(*)');
+    if (vehicleId != null) q = q.eq('vehicle_id', vehicleId);
+    const { data, error } = await q;
+    if (error) {
+      console.warn('Performance summaries unavailable (migrations 039/040 applied?):', error.message);
+      return [];
+    }
+    return data || [];
   }
 
   /** Insert (no id) or update (with id) a reported summary. Returns the saved row. */

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), performance_summaries(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -1485,6 +1485,173 @@ class DataService {
       .limit(200);
     if (error) throw error;
     return data || [];
+  }
+
+  // ── Performance testing (acceleration / braking) ────────────────────────────
+  //
+  // Deliberately separate from `runs`: a session yields ~8 launches in 90
+  // seconds, and runs rows feed the charging/range selectors and vehicle-card
+  // counts (isChargingRun treats anything without has_charging=false as a
+  // charging run). See migration 036 for the full rationale.
+
+  /**
+   * All performance sessions for a vehicle, with runs and split points nested.
+   * Single relational query, same shape as getEpaTestGroupFull().
+   */
+  async getPerformanceSessions(vehicleId) {
+    if (!this.useSupabase) return [];
+    const { data, error } = await getSupabase()
+      .from('performance_sessions')
+      .select(`
+        *,
+        performance_runs(*, performance_run_points(*))
+      `)
+      .eq('vehicle_id', vehicleId)
+      .order('tested_at', { ascending: false });
+    if (error) throw error;
+    // PostgREST doesn't order nested rows — sort children so runs and their
+    // splits read in test order rather than insertion order.
+    for (const session of data || []) {
+      const runs = session.performance_runs || [];
+      runs.sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+      for (const run of runs) {
+        (run.performance_run_points || []).sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+      }
+    }
+    return data || [];
+  }
+
+  /** Insert (no id) or update (with id) a session. Returns the saved row. */
+  async savePerformanceSession(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('performance_sessions');
+    const { id, performance_runs, ...fields } = row; // never write nested runs here
+    const q = id ? db.update(fields).eq('id', id) : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deletePerformanceSession(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('performance_sessions').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /** Insert (no id) or update (with id) a single run. Returns the saved row. */
+  async savePerformanceRun(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('performance_runs');
+    const { id, performance_run_points, ...fields } = row;
+    const q = id ? db.update(fields).eq('id', id) : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deletePerformanceRun(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('performance_runs').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /**
+   * Import a parsed performance CSV as one session with its runs and splits.
+   *
+   * Takes the output of parsePerformanceCSV() directly. Rolls the session back
+   * if any child insert fails, so a partial import can't leave an empty session
+   * card behind (there are no transactions over PostgREST).
+   *
+   * @param {number} vehicleId
+   * @param {{session: object, runs: object[]}} parsed
+   * @param {{trimId?: number, sourceName?: string, youtubeUrl?: string,
+   *          spreadsheetUrl?: string, notes?: string}} [meta]
+   * @returns {Promise<object>} the created session row
+   */
+  async importPerformanceSession(vehicleId, parsed, meta = {}) {
+    if (!this.useSupabase || !this.user) throw new Error('Must be logged in to import.');
+    const { session, runs } = parsed;
+
+    const sessionRow = await this.savePerformanceSession({
+      vehicle_id: vehicleId,
+      trim_id: meta.trimId ?? null,
+      test_type: session.testType,
+      tested_at: session.testedAt,
+      location_name: session.locationName ?? null,
+      latitude: session.latitude ?? null,
+      longitude: session.longitude ?? null,
+      temperature_f: session.temperatureF ?? null,
+      humidity_pct: session.humidityPct ?? null,
+      pressure_inhg: session.pressureInHg ?? null,
+      wind_speed_mph: session.windSpeedMph ?? null,
+      wind_bearing_deg: session.windBearingDeg ?? null,
+      cloud_cover_pct: session.cloudCoverPct ?? null,
+      visibility_mi: session.visibilityMi ?? null,
+      source_name: meta.sourceName ?? null,
+      youtube_url: meta.youtubeUrl ?? null,
+      spreadsheet_url: meta.spreadsheetUrl ?? null,
+      notes: meta.notes ?? null,
+    });
+
+    try {
+      for (const run of runs) {
+        const runRow = await this.savePerformanceRun({
+          session_id: sessionRow.id,
+          sequence: run.sequence,
+          drive_mode: run.driveMode ?? null,
+          run_at: run.runAt ?? null,
+          altitude_ft: run.altitudeFt ?? null,
+          density_altitude_ft: run.densityAltitudeFt ?? null,
+          slope_pct: run.slopePct ?? null,
+          distance_run_ft: run.distanceRunFt ?? null,
+          max_g_force: run.maxGForce ?? null,
+          zero_to_60_sec: run.zeroTo60Sec ?? null,
+          zero_to_60_rollout_sec: run.zeroTo60RolloutSec ?? null,
+          braking_distance_ft: run.brakingDistanceFt ?? null,
+          braking_from_mph: run.brakingFromMph ?? null,
+        });
+
+        if (run.splits?.length) {
+          const points = run.splits.map((s, i) => ({
+            run_id: runRow.id,
+            sequence: i,
+            label: s.label ?? null,
+            speed_mph: s.speedMph ?? null,
+            elapsed_s: s.elapsedS ?? null,
+            distance_ft: s.distanceFt ?? null,
+          }));
+          const { error } = await getSupabase().from('performance_run_points').insert(points);
+          if (error) throw error;
+        }
+      }
+    } catch (err) {
+      await this.deletePerformanceSession(sessionRow.id).catch(() => {});
+      throw err;
+    }
+
+    return sessionRow;
+  }
+
+  /** Insert (no id) or update (with id) a reported summary. Returns the saved row. */
+  async savePerformanceSummary(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('performance_summaries');
+    const { id, ...fields } = row;
+    const q = id
+      ? db.update({ ...fields, updated_at: new Date().toISOString() }).eq('id', id)
+      : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deletePerformanceSummary(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('performance_summaries').delete().eq('id', id);
+    if (error) throw error;
   }
 
   // ── Access logging ──────────────────────────────────────────────────────────

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -104,7 +104,7 @@ class DataService {
     }
     const { data } = await getSupabase()
       .from('vehicles')
-      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), performance_summaries(*), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
+      .select(`*, runs(*, data_points(count)), vehicle_tags(tags(id, name)), vehicle_performance(*), performance_summaries(*, performance_intervals(*)), manufacturers(id,name,country), spec_links!spec_links_target_vehicle_id_fkey(id, source_run_id, scaling_factor, notes, is_default, color), epa_vehicle_mappings(id, confidence, notes, epa_test_groups(test_group_id, epa_test_family_id, model_year, make, epa_carline_name, drive, transmission, fuel_type, vehicle_config_number, evap_family, useable_kwh, total_voltage, battery_specific_energy, accessory_load_w_override, charger_efficiency_override, label_combined_mpge, label_hwy_mpge, label_range_published, cd_range_combined_calc, cd_range_hwy_calc, derived_5cycle_coefficient, display_name, epa_coefficient_sets(id, category, is_primary, target_a, target_b, target_c, set_a, set_b, set_c, equiv_test_weight_lbs), epa_tests(id, test_number, procedure_code, total_dc_energy_kwh, ac_recharge_kwh, epa_test_phases(id, phase_index, phase_type, dc_energy_kwh, distance_mi))))`)
       .order('created_at', { ascending: false });
 
     // Pass 1: process each vehicle's own data
@@ -1638,7 +1638,7 @@ class DataService {
   async savePerformanceSummary(row) {
     if (!this.useSupabase) return null;
     const db = getSupabase().from('performance_summaries');
-    const { id, ...fields } = row;
+    const { id, performance_intervals, ...fields } = row; // intervals saved separately
     const q = id
       ? db.update({ ...fields, updated_at: new Date().toISOString() }).eq('id', id)
       : db.insert(fields);
@@ -1651,6 +1651,28 @@ class DataService {
     if (!this.useSupabase) return;
     const { error } = await getSupabase()
       .from('performance_summaries').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /**
+   * Insert (no id) or update (with id) one variable-window result — a braking
+   * distance, passing time, or a non-canonical accel window. Values are stored
+   * in the unit they were reported in; see migration 040.
+   */
+  async savePerformanceInterval(row) {
+    if (!this.useSupabase) return null;
+    const db = getSupabase().from('performance_intervals');
+    const { id, ...fields } = row;
+    const q = id ? db.update(fields).eq('id', id) : db.insert(fields);
+    const { data, error } = await q.select().single();
+    if (error) throw error;
+    return data;
+  }
+
+  async deletePerformanceInterval(id) {
+    if (!this.useSupabase) return;
+    const { error } = await getSupabase()
+      .from('performance_intervals').delete().eq('id', id);
     if (error) throw error;
   }
 

--- a/src/utils/parsePerformanceCSV.js
+++ b/src/utils/parsePerformanceCSV.js
@@ -1,0 +1,265 @@
+import Papa from 'papaparse';
+
+/**
+ * Parse a GPS performance-testing CSV export (acceleration / braking runs).
+ *
+ * File structure — TRANSPOSED relative to most exports: each COLUMN is one run,
+ * each ROW is one labelled metric, with the label embedded in every cell:
+ *
+ *   Insane + Launch Mode,Insane + Launch Mode,Standard,Chill        ← row 0: drive mode
+ *   "Test Time: 7/24/2026, 10:48:22 AM (local)",…                   ← row 1+
+ *   "Location: North Carolina, United States",…
+ *   Distance: 49.372 m ≈ 162.0 ft (161 ft 11.8 in),…
+ *   0–60 mph: 3.572 s,…
+ *   • 0–10: 0.578 s,…                                               ← split rows
+ *
+ * Rows are matched by label prefix rather than position, so a source that omits
+ * or reorders rows still parses. Unrecognised rows are ignored.
+ *
+ * Returns a plain object — no Supabase calls, no side effects (same contract as
+ * parseTableauCSV.js).
+ */
+
+// Sources use an en-dash in "0–60" and a bullet on split rows. Normalise both
+// so every downstream regex can assume ASCII "-".
+const normaliseDashes = (s) => s.replace(/[‐-―−]/g, '-');
+const stripBullet     = (s) => s.replace(/^[\s•*·-]+/, '');
+
+/** First capture group of `re` as a float, or null. */
+function num(text, re) {
+    const m = re.exec(text);
+    if (!m) return null;
+    const v = parseFloat(m[1]);
+    return Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Cells are "Label: value". Return the value part when `label` matches the
+ * start of the cell (case-insensitive), else null.
+ */
+function valueFor(cell, label) {
+    const text = stripBullet(normaliseDashes(cell || '')).trim();
+    const want = normaliseDashes(label).toLowerCase();
+    if (!text.toLowerCase().startsWith(want.toLowerCase())) return null;
+    return text.slice(want.length).replace(/^\s*:\s*/, '').trim();
+}
+
+/** Find the first row whose first non-empty cell starts with `label`. */
+function findRow(rows, label) {
+    return rows.find(row =>
+        row.some(cell => valueFor(cell, label) !== null)
+    ) || null;
+}
+
+/** Read `label` from column `col`, returning the raw value string or null. */
+function cellValue(rows, label, col) {
+    const row = findRow(rows, label);
+    if (!row) return null;
+    return valueFor(row[col], label);
+}
+
+/**
+ * Split rows look like "• 0-10: 0.578 s" or "• 0-60(1ft): 3.300 s".
+ * Returns { speedMph, label, elapsedS } or null.
+ */
+function parseSplit(cell) {
+    const text = stripBullet(normaliseDashes(cell || '')).trim();
+    // 0-60(1ft): 3.300 s   |   0-10: 0.578 s
+    const m = /^0-(\d+)(\(1ft\))?\s*:\s*([\d.]+)\s*s/i.exec(text);
+    if (!m) return null;
+    const speedMph = parseInt(m[1], 10);
+    const elapsedS = parseFloat(m[3]);
+    if (!Number.isFinite(speedMph) || !Number.isFinite(elapsedS)) return null;
+    return {
+        label: m[2] ? `0-${speedMph}(1ft)` : `0-${speedMph}`,
+        speedMph,
+        elapsedS,
+        rollout: !!m[2],
+    };
+}
+
+/**
+ * Parse "7/24/2026, 10:48:22 AM (local)" into a zone-less wall-clock string
+ * ("2026-07-24T10:48:22").
+ *
+ * Deliberately NOT `new Date(...)`: that resolves the wall clock against the
+ * *parsing machine's* timezone, so importing a North Carolina test on a
+ * European laptop shifts it by hours and can roll the date over midnight. The
+ * source says "(local)" but gives no UTC offset, so the wall clock is all we
+ * actually know — stored into a `timestamp` (no time zone) column to match.
+ */
+function parseTestTime(raw) {
+    if (!raw) return null;
+    const cleaned = raw.replace(/\s*\(local\)\s*$/i, '').trim();
+    const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4}),?\s+(\d{1,2}):(\d{2}):(\d{2})\s*(AM|PM)?/i.exec(cleaned);
+    if (!m) return null;
+    const [, mo, d, y, hh, mm, ss, ampm] = m;
+    let hour = parseInt(hh, 10);
+    if (ampm) {
+        const pm = ampm.toUpperCase() === 'PM';
+        if (pm && hour !== 12) hour += 12;
+        if (!pm && hour === 12) hour = 0;
+    }
+    const p = (n, w = 2) => String(n).padStart(w, '0');
+    return `${y}-${p(mo)}-${p(d)}T${p(hour)}:${mm}:${ss}`;
+}
+
+/**
+ * Build one run object from column `col`.
+ * Session-level fields (weather, location) are read here too; the caller
+ * hoists them since they repeat identically across columns.
+ */
+function parseColumn(rows, col, splitRows) {
+    const raw = (label) => cellValue(rows, label, col);
+
+    // "Distance: 49.372 m ≈ 162.0 ft (161 ft 11.8 in)" → prefer the ft figure
+    const distanceCell = raw('Distance') || '';
+    const distanceFt = num(distanceCell, /≈\s*([\d.]+)\s*ft/)
+        ?? num(distanceCell, /([\d.]+)\s*ft/);
+
+    // "Temperature: 24.07 °C ≈ 75 °F" → we store °F
+    const tempCell = raw('Temperature') || '';
+    const temperatureF = num(tempCell, /≈\s*([\d.-]+)\s*°?\s*F/i);
+
+    // "Wind: 4.34 m/s ≈ 9.71 mph coming from 71° (ENE)"
+    // NOTE: 71° is a METEOROLOGICAL bearing (where wind comes FROM) — not the
+    // travel-relative convention used by runs.wind_direction_deg. Stored as
+    // performance_sessions.wind_bearing_deg to keep the two from being confused.
+    const windCell = raw('Wind') || '';
+    const windSpeedMph  = num(windCell, /≈\s*([\d.]+)\s*mph/);
+    const windBearingDeg = num(windCell, /coming from\s*([\d.]+)\s*°/i);
+
+    // "Pressure: 1021 hPa ≈ 30.15 inHg"
+    const pressureCell = raw('Pressure') || '';
+    const pressureInHg = num(pressureCell, /≈\s*([\d.]+)\s*inHg/i);
+
+    // "Visibility: 10 km ≈ 6.2 miles"
+    const visCell = raw('Visibility') || '';
+    const visibilityMi = num(visCell, /≈\s*([\d.]+)\s*mile/i);
+
+    // "Clouds: overcast clouds (100 %)"
+    const cloudsCell = raw('Clouds') || '';
+    const cloudCoverPct = num(cloudsCell, /\(\s*([\d.]+)\s*%/);
+
+    // Lat/long appear twice: in "Run Location: … (36.4757,-77.57971)" and in
+    // dedicated rows. Prefer the dedicated rows — they carry full precision and
+    // the source notes sign corrections there.
+    const latitude  = num(raw('Latitude')  || '', /(-?[\d.]+)/);
+    const longitude = num(raw('Longitude') || '', /(-?[\d.]+)/);
+
+    // "Slope: ~0.07 % incline (slightly uphill)." — sign carries uphill/downhill
+    const slopePct = num(raw('Slope') || '', /~?\s*(-?[\d.]+)\s*%/);
+
+    // ROLLOUT: "0-60 mph:" is the no-rollout figure; the "0-60(1ft)" split is
+    // the 1ft-rollout one. They differ by ~0.3s — see migration 037.
+    const zeroTo60Sec = num(raw('0-60 mph') || '', /([\d.]+)\s*s/);
+
+    const splits = [];
+    let zeroTo60RolloutSec = null;
+    for (const row of splitRows) {
+        const s = parseSplit(row[col]);
+        if (!s) continue;
+        splits.push({ label: s.label, speedMph: s.speedMph, elapsedS: s.elapsedS });
+        if (s.rollout && s.speedMph === 60) zeroTo60RolloutSec = s.elapsedS;
+    }
+
+    return {
+        driveMode: null, // filled by caller from the header row
+        runAt: parseTestTime(raw('Test Time')),
+
+        altitudeFt:        num(raw('Altitude') || '', /(-?[\d.]+)\s*ft/),
+        densityAltitudeFt: num(raw('Density Altitude (DA)') || '', /(-?[\d.]+)\s*ft/),
+        slopePct,
+        distanceRunFt: distanceFt,
+
+        maxGForce:  num(raw('Max G-Force Achieved (gMax)') || '', /([\d.]+)\s*g/),
+        zeroTo60Sec,
+        zeroTo60RolloutSec,
+
+        splits,
+
+        // Session-scoped values, hoisted by the caller
+        _session: {
+            locationName: raw('Location'),
+            latitude,
+            longitude,
+            temperatureF,
+            humidityPct: num(raw('Humidity') || '', /([\d.]+)\s*%/),
+            pressureInHg,
+            windSpeedMph,
+            windBearingDeg,
+            cloudCoverPct,
+            visibilityMi,
+        },
+    };
+}
+
+/**
+ * Parse performance CSV text.
+ *
+ * @param {string} text     raw CSV text
+ * @param {object} [opts]
+ * @param {'accel'|'braking'} [opts.testType='accel']
+ * @returns {{ session: object, runs: object[], warnings: string[] }}
+ */
+export function parsePerformanceCSVText(text, { testType = 'accel' } = {}) {
+    const results = Papa.parse(text, {
+        header: false,
+        skipEmptyLines: true,
+        dynamicTyping: false,
+    });
+
+    const rows = results.data.filter(r => Array.isArray(r) && r.some(c => (c || '').trim()));
+    if (rows.length < 2) {
+        throw new Error('File too short — expected a drive-mode header row plus metric rows.');
+    }
+
+    const warnings = [];
+
+    // Row 0 is the drive-mode header; its width defines the run count.
+    const header = rows[0].map(c => (c || '').trim());
+    const colCount = header.filter(Boolean).length;
+    if (colCount === 0) throw new Error('No drive-mode names found in the first row.');
+
+    const splitRows = rows.filter(row => row.some(cell => parseSplit(cell)));
+
+    const runs = [];
+    let session = null;
+
+    for (let col = 0; col < colCount; col++) {
+        const parsed = parseColumn(rows, col, splitRows);
+        const { _session, ...run } = parsed;
+
+        // The same drive mode is typically run several times in a row. Keep every
+        // run and let `sequence` disambiguate — same approach as suffixing repeated
+        // EPA Vehicle IDs with a configuration index.
+        run.driveMode = header[col] || null;
+        run.sequence  = col;
+
+        if (run.zeroTo60Sec == null && run.splits.length === 0) {
+            warnings.push(`Column ${col + 1} ("${run.driveMode ?? 'unnamed'}") has no timing data — skipped.`);
+            continue;
+        }
+        runs.push(run);
+
+        // Weather/location repeat across columns; take the first populated set.
+        if (!session) session = _session;
+    }
+
+    if (runs.length === 0) throw new Error('No runs with timing data found in the file.');
+
+    // Test time of the first run stands in for the session time.
+    const testedAt = runs.find(r => r.runAt)?.runAt ?? null;
+
+    return {
+        session: { ...session, testType, testedAt },
+        runs,
+        warnings,
+    };
+}
+
+/** File wrapper — reads as UTF-8 text, then delegates. */
+export async function parsePerformanceCSV(file, opts) {
+    const text = await file.text();
+    return parsePerformanceCSVText(text, opts);
+}

--- a/src/utils/performanceDerivations.js
+++ b/src/utils/performanceDerivations.js
@@ -27,7 +27,7 @@
  *     basis   — what it was computed from, for UI drill-down
  */
 
-import { MI_TO_KM, FT_TO_M } from '../constants/units';
+import { MI_TO_KM, FT_TO_M, MPH_TO_MS, G_MS2 } from '../constants/units';
 
 const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
 
@@ -318,6 +318,57 @@ export function windowLabel(interval) {
 }
 
 /**
+ * Average acceleration/deceleration over a window, in g.
+ *
+ * Lets otherwise-incomparable windows be put on one axis: a 50-80 against a
+ * 50-90, or a 60-0 against a 100-0 km/h. Two forms depending on what was
+ * measured:
+ *
+ *   timed windows (accel/passing)    a = Δv / Δt
+ *   distance windows (braking)       a = (v₁² − v₂²) / 2d
+ *
+ * ── ACCURACY, because this matters for how it should be presented ──
+ *
+ * BRAKING normalises well, and this is measured rather than assumed: on the
+ * sample data one car's 60-0 (0.986 g) and 75-0 (0.983 g) agree to 0.3%.
+ * Braking is grip-limited, so deceleration really is near-constant across the
+ * stop and the constant-rate assumption roughly holds. Cross-window braking
+ * comparison is trustworthy.
+ *
+ * ACCELERATION is the subtler case. The rate is near-constant while the car is
+ * traction/torque-limited — measured segment rates across 0-50 mph hold at
+ * 0.77-0.80 g — but collapses once it goes power-limited higher up: the same
+ * class of car averages ~0.57 g over 50-80 and ~0.51 g over 50-90.
+ *
+ * So it isn't window WIDTH that breaks comparability, it's window SPEED RANGE.
+ * 0-30 against 0-60 is reasonable; 0-60 (~0.79 g) against 50-90 (~0.51 g) is
+ * not, and reads as a far bigger gap than the cars actually differ by.
+ *
+ * Callers get `rateCertain` to reflect this: true for braking, false for timed
+ * windows, so the UI can mark the latter as indicative.
+ */
+export function averageRateG(interval) {
+    const fromMph = speedToMph(interval.from_speed, interval.speed_unit);
+    const toMph   = speedToMph(interval.to_speed ?? 0, interval.speed_unit);
+    if (fromMph == null || toMph == null) return null;
+
+    const v1 = fromMph * MPH_TO_MS;
+    const v2 = toMph   * MPH_TO_MS;
+
+    if (interval.kind === 'braking') {
+        const distFt = distanceToFt(interval.distance, interval.distance_unit);
+        if (distFt == null || distFt <= 0) return null;
+        const d = distFt * FT_TO_M;
+        // v₂² = v₁² − 2ad  ⇒  a = (v₁² − v₂²) / 2d
+        return Math.abs(v1 * v1 - v2 * v2) / (2 * d) / G_MS2;
+    }
+
+    const dt = num(interval.elapsed_s);
+    if (dt == null || dt <= 0) return null;
+    return Math.abs(v2 - v1) / dt / G_MS2;
+}
+
+/**
  * Normalise an interval row into a comparable record.
  * `value` is in the interval's natural unit; `comparable` is mph/ft/seconds.
  */
@@ -333,7 +384,41 @@ export function normaliseInterval(interval) {
         comparable: isBraking ? distanceToFt(interval.distance, interval.distance_unit) : raw,
         displayUnit: isBraking ? (interval.distance_unit || 'ft') : 's',
         lowerIsBetter: true,
+        // Cross-window normalisation — see averageRateG for the caveats.
+        rateG: averageRateG(interval),
+        rateCertain: isBraking,
     };
+}
+
+/**
+ * Every interval for a vehicle, expressed as an average rate in g so windows
+ * that aren't otherwise comparable can share an axis.
+ *
+ * Sorted strongest-first. `certain` distinguishes braking (grip-limited, so the
+ * constant-rate assumption roughly holds) from timed windows (rate falls away
+ * with speed, so cross-window reads are indicative only).
+ */
+export function ratesByWindow(summaries = [], kind = null) {
+    const out = [];
+    for (const s of summaries || []) {
+        for (const iv of s.performance_intervals || []) {
+            if (kind && iv.kind !== kind) continue;
+            const n = normaliseInterval(iv);
+            if (n.rateG == null) continue;
+            out.push({
+                key: n.key,
+                label: n.label,
+                kind: n.kind,
+                rateG: n.rateG,
+                certain: n.rateCertain,
+                value: n.value,
+                unit: n.displayUnit,
+                source_name: s.source_name ?? null,
+                summary_id: s.id ?? null,
+            });
+        }
+    }
+    return out.sort((a, b) => b.rateG - a.rateG);
 }
 
 /**

--- a/src/utils/performanceDerivations.js
+++ b/src/utils/performanceDerivations.js
@@ -27,6 +27,8 @@
  *     basis   — what it was computed from, for UI drill-down
  */
 
+import { MI_TO_KM, FT_TO_M } from '../constants/units';
+
 const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
 
 const EMPTY = Object.freeze({ value: null, source: null, certain: false, flags: [] });
@@ -38,10 +40,12 @@ const EMPTY = Object.freeze({ value: null, source: null, certain: false, flags: 
  */
 export const GRADE_FLAG_PCT = 1.0;
 
-/** Metrics that are "lower is better" — the whole set, currently. */
+/**
+ * Metrics where a smaller number is a better result. Trap speed is the one
+ * exception — higher is quicker.
+ */
 const LOWER_IS_BETTER = new Set([
     'zero_to_60_sec', 'zero_to_60_rollout_sec', 'quarter_mile_sec',
-    'fifty_to_ninety_sec', 'braking_distance_ft',
 ]);
 
 // ── Session / run flattening ────────────────────────────────────────────────
@@ -264,9 +268,131 @@ export const PERFORMANCE_METRICS = [
     { field: 'zero_to_60_rollout_sec', label: '0–60 mph',        unit: 's',   note: '1 ft rollout' },
     { field: 'quarter_mile_sec',       label: '¼ mile',          unit: 's' },
     { field: 'quarter_mile_trap_mph',  label: '¼ mile trap',     unit: 'mph' },
-    { field: 'fifty_to_ninety_sec',    label: '50–90 mph',       unit: 's' },
-    { field: 'braking_distance_ft',    label: 'Braking',         unit: 'ft' },
 ];
+
+// ── Variable speed-window results (performance_intervals) ───────────────────
+//
+// Braking windows vary (75-0, 70-0, 60-0) and passing windows vary (50-80,
+// 50-90), so these can't be fixed columns like 0-60. Sources also report metric
+// (100-0 km/h in metres), and normalising on write would destroy the label —
+// so values are stored as reported and converted here.
+
+const KPH_TO_MPH = 1 / MI_TO_KM;
+const M_TO_FT    = 1 / FT_TO_M;
+
+/** Speed in mph, whatever unit it was reported in. */
+export const speedToMph = (value, unit) => {
+    const v = num(value);
+    if (v == null) return null;
+    return unit === 'kph' ? v * KPH_TO_MPH : v;
+};
+
+/** Distance in feet, whatever unit it was reported in. */
+export const distanceToFt = (value, unit) => {
+    const v = num(value);
+    if (v == null) return null;
+    return unit === 'm' ? v * M_TO_FT : v;
+};
+
+/**
+ * Canonical key for a speed window, so results from different sources and unit
+ * systems land in the same comparison bucket.
+ *
+ * Metric windows are kept as their own bucket rather than converted: "100-0
+ * km/h" is a standard test in its own right, and folding it into "62-0 mph"
+ * would invent a window nobody actually tested and compare it against a 60-0.
+ */
+export function windowKey(interval) {
+    const from = num(interval.from_speed);
+    const to   = num(interval.to_speed) ?? 0;
+    const unit = interval.speed_unit || 'mph';
+    return `${interval.kind}:${from}-${to}${unit}`;
+}
+
+/** Human label for a window, e.g. "75–0 mph", "100–0 km/h", "50–90 mph". */
+export function windowLabel(interval) {
+    const unit = (interval.speed_unit || 'mph') === 'kph' ? 'km/h' : 'mph';
+    const from = num(interval.from_speed);
+    const to   = num(interval.to_speed) ?? 0;
+    return `${from}–${to} ${unit}`;
+}
+
+/**
+ * Normalise an interval row into a comparable record.
+ * `value` is in the interval's natural unit; `comparable` is mph/ft/seconds.
+ */
+export function normaliseInterval(interval) {
+    const isBraking = interval.kind === 'braking';
+    const raw = isBraking ? num(interval.distance) : num(interval.elapsed_s);
+    return {
+        ...interval,
+        key: windowKey(interval),
+        label: windowLabel(interval),
+        value: raw,
+        // Braking compares in feet; timed windows are already unit-agnostic.
+        comparable: isBraking ? distanceToFt(interval.distance, interval.distance_unit) : raw,
+        displayUnit: isBraking ? (interval.distance_unit || 'ft') : 's',
+        lowerIsBetter: true,
+    };
+}
+
+/**
+ * Group every interval across a vehicle's summaries by comparable window.
+ * Feeds both the summary UI and any chart that needs to compare one window
+ * across vehicles.
+ *
+ * @returns {Array<{key, label, kind, best, rows}>} best-first within each window
+ */
+export function groupIntervals(summaries = []) {
+    const buckets = new Map();
+    for (const s of summaries || []) {
+        for (const iv of s.performance_intervals || []) {
+            const n = normaliseInterval(iv);
+            if (n.comparable == null) continue;
+            n.source_name = s.source_name ?? null;
+            n.summary_id  = s.id ?? null;
+            if (!buckets.has(n.key)) {
+                buckets.set(n.key, { key: n.key, label: n.label, kind: n.kind, rows: [] });
+            }
+            buckets.get(n.key).rows.push(n);
+        }
+    }
+    return [...buckets.values()].map(b => {
+        b.rows.sort((a, c) => a.comparable - c.comparable);
+        b.best = b.rows[0]?.comparable ?? null;
+        return b;
+    });
+}
+
+/**
+ * Resolve one speed window across a vehicle's sources, e.g. its best 75-0.
+ *
+ * source: 'reported' — intervals only ever come from entered summary data.
+ */
+export function resolveInterval(summaries, key) {
+    const bucket = groupIntervals(summaries).find(b => b.key === key);
+    if (!bucket || bucket.rows.length === 0) return { ...EMPTY };
+    const best = bucket.rows[0];
+    return {
+        value: best.value,
+        source: 'reported',
+        certain: false,
+        flags: bucket.rows.length > 1 ? ['multiple-sources'] : [],
+        basis: {
+            summary_id: best.summary_id,
+            source_name: best.source_name,
+            label: bucket.label,
+            unit: best.displayUnit,
+            comparable_ft: bucket.kind === 'braking' ? best.comparable : null,
+            all: bucket.rows.map(r => ({
+                summary_id: r.summary_id,
+                source_name: r.source_name,
+                value: r.value,
+                unit: r.displayUnit,
+            })),
+        },
+    };
+}
 
 /**
  * Resolve every metric for a vehicle.

--- a/src/utils/performanceDerivations.js
+++ b/src/utils/performanceDerivations.js
@@ -1,0 +1,285 @@
+/**
+ * Performance Derivations
+ *
+ * Read-time, provenance-tagged derivations for acceleration/braking results.
+ * Every derivation is a pure function — nothing here is ever persisted, which
+ * is the same discipline epaDerivations.js follows and the reason a stored
+ * "derived" value can't go stale when its backing runs change.
+ *
+ * Three independent things can supply the same metric:
+ *
+ *   measured  — computed from this vehicle's own detail sessions
+ *               (performance_sessions → performance_runs)
+ *   reported   — a published figure entered in performance_summaries
+ *   claimed    — the manufacturer's own number, from the vehicle_performance
+ *                table surfaced via specs.performance.*
+ *
+ * They are deliberately NOT merged into one number. The gap between claimed and
+ * measured is the interesting part, so `resolveMetric` returns all of them and
+ * lets the UI decide what to show.
+ *
+ * Each derivation returns a provenance record, matching epaDerivations.js:
+ *   { value, source, certain, flags[], basis? }
+ *     value   — number, or null when uncomputable
+ *     source  — 'measured' | 'reported' | 'claimed' | null
+ *     certain — true only for a measured value with enough supporting runs
+ *     flags   — machine-readable warnings ('single-run', 'steep-grade', …)
+ *     basis   — what it was computed from, for UI drill-down
+ */
+
+const num = (v) => (v == null || v === '' || isNaN(Number(v)) ? null : Number(v));
+
+const EMPTY = Object.freeze({ value: null, source: null, certain: false, flags: [] });
+
+/**
+ * Grade beyond which a run materially flatters or penalises the result.
+ * The sample data runs ±0.5%; anything past this is worth flagging rather than
+ * silently averaging in.
+ */
+export const GRADE_FLAG_PCT = 1.0;
+
+/** Metrics that are "lower is better" — the whole set, currently. */
+const LOWER_IS_BETTER = new Set([
+    'zero_to_60_sec', 'zero_to_60_rollout_sec', 'quarter_mile_sec',
+    'fifty_to_ninety_sec', 'braking_distance_ft',
+]);
+
+// ── Session / run flattening ────────────────────────────────────────────────
+
+/**
+ * Flatten a vehicle's sessions into a run list, each run carrying a reference
+ * back to its session (for weather/location context in the UI).
+ *
+ * @param {object[]} sessions — performance_sessions rows with nested
+ *                              performance_runs (as getPerformanceSessions returns)
+ */
+export function flattenRuns(sessions = []) {
+    const out = [];
+    for (const s of sessions || []) {
+        for (const r of s.performance_runs || []) {
+            out.push({ ...r, session: s });
+        }
+    }
+    return out;
+}
+
+/**
+ * Best (fastest / shortest) run for a metric, ignoring runs that lack it.
+ *
+ * Best-of rather than mean: these are repeated attempts at the same maximum-
+ * effort task, so the spread is dominated by driver/surface variance in the
+ * slower direction. Publications quote best runs, so this matches how the
+ * numbers will be compared. The full run list stays available for anyone who
+ * wants the spread.
+ */
+export function bestRunFor(runs, field) {
+    let best = null;
+    for (const r of runs) {
+        const v = num(r[field]);
+        if (v == null) continue;
+        if (!best || (LOWER_IS_BETTER.has(field) ? v < num(best[field]) : v > num(best[field]))) {
+            best = r;
+        }
+    }
+    return best;
+}
+
+/**
+ * Derive a metric from detail runs.
+ *
+ * source: 'measured' — always, when any run carries the field.
+ * certain: true when backed by 2+ runs on reasonable grade (a single run can't
+ *          be distinguished from a fluke).
+ */
+export function deriveFromRuns(sessions, field) {
+    const runs = flattenRuns(sessions).filter(r => num(r[field]) != null);
+    if (runs.length === 0) return { ...EMPTY };
+
+    const best = bestRunFor(runs, field);
+    const value = num(best[field]);
+
+    // Spread is only meaningful between comparable attempts. A session sweeps
+    // drive modes (Insane → Chill), so spanning all of them would report a
+    // ~4 s "spread" that just measures the modes, not run-to-run variance.
+    const comparable = runs.filter(r => r.drive_mode === best.drive_mode);
+    const values = comparable.map(r => num(r[field])).sort((a, b) => a - b);
+
+    const flags = [];
+    if (comparable.length === 1) flags.push('single-run');
+    const grade = num(best.slope_pct);
+    if (grade != null && Math.abs(grade) > GRADE_FLAG_PCT) flags.push('steep-grade');
+
+    return {
+        value,
+        source: 'measured',
+        certain: comparable.length >= 2 && flags.length === 0,
+        flags,
+        basis: {
+            run_id: best.id ?? null,
+            drive_mode: best.drive_mode ?? null,
+            session_id: best.session?.id ?? null,
+            run_count: runs.length,
+            comparable_run_count: comparable.length,
+            slope_pct: grade,
+            spread: values.length > 1
+                ? { min: values[0], max: values[values.length - 1] }
+                : null,
+        },
+    };
+}
+
+/**
+ * Group runs by drive mode, best-first within each group.
+ * Feeds the per-mode comparison the detail data is most interesting for
+ * (Insane vs Chill on the same car, same afternoon, same tarmac).
+ */
+export function groupByDriveMode(sessions, field = 'zero_to_60_sec') {
+    const groups = new Map();
+    for (const r of flattenRuns(sessions)) {
+        if (num(r[field]) == null) continue;
+        const key = r.drive_mode || 'Unspecified';
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(r);
+    }
+    const lower = LOWER_IS_BETTER.has(field);
+    return [...groups.entries()]
+        .map(([driveMode, runs]) => {
+            const sorted = [...runs].sort((a, b) =>
+                lower ? num(a[field]) - num(b[field]) : num(b[field]) - num(a[field]));
+            return { driveMode, runs: sorted, best: num(sorted[0][field]), count: runs.length };
+        })
+        .sort((a, b) => (lower ? a.best - b.best : b.best - a.best));
+}
+
+/**
+ * Pick a metric out of the reported (published) summary rows.
+ *
+ * When several sources report the same metric, the best figure wins and the
+ * others are surfaced in `basis.all` so the UI can show disagreement rather
+ * than hiding it.
+ *
+ * source: 'reported'
+ * certain: false — we can't verify someone else's methodology.
+ */
+export function deriveFromSummaries(summaries = [], field) {
+    const rows = (summaries || []).filter(s => num(s[field]) != null);
+    if (rows.length === 0) return { ...EMPTY };
+
+    const lower = LOWER_IS_BETTER.has(field);
+    const sorted = [...rows].sort((a, b) =>
+        lower ? num(a[field]) - num(b[field]) : num(b[field]) - num(a[field]));
+    const pick = sorted[0];
+
+    return {
+        value: num(pick[field]),
+        source: 'reported',
+        certain: false,
+        flags: rows.length > 1 ? ['multiple-sources'] : [],
+        basis: {
+            summary_id: pick.id ?? null,
+            source_name: pick.source_name ?? null,
+            trim_label: pick.trim_label ?? null,
+            url: pick.youtube_url || pick.spreadsheet_url || null,
+            all: sorted.map(s => ({
+                summary_id: s.id ?? null,
+                source_name: s.source_name ?? null,
+                value: num(s[field]),
+            })),
+        },
+    };
+}
+
+/**
+ * The manufacturer's claim, read from the promoted spec fields that
+ * DataService merges onto vehicle.specs.performance from vehicle_performance.
+ *
+ * Only the metrics manufacturers actually publish are mapped; the rest return
+ * an empty record.
+ *
+ * source: 'claimed'
+ * certain: false — it's marketing, not a measurement.
+ */
+const CLAIMED_SPEC_KEY = {
+    // NB: the spec field has no rollout convention attached, and manufacturers
+    // are inconsistent about it. Treated as the rollout figure since that is
+    // the more common marketing basis, and flagged so the UI can say so.
+    zero_to_60_rollout_sec: 'zero_to_60_mph_sec',
+    quarter_mile_sec:       'quarter_mile_sec',
+    quarter_mile_trap_mph:  'quarter_mile_mph',
+};
+
+export function deriveClaimed(vehicle, field) {
+    const key = CLAIMED_SPEC_KEY[field];
+    if (!key) return { ...EMPTY };
+    const value = num(vehicle?.specs?.performance?.[key]);
+    if (value == null) return { ...EMPTY };
+    return {
+        value,
+        source: 'claimed',
+        certain: false,
+        flags: field === 'zero_to_60_rollout_sec' ? ['rollout-convention-unknown'] : [],
+        basis: { spec_key: `performance.${key}` },
+    };
+}
+
+// ── Top-level resolution ────────────────────────────────────────────────────
+
+/**
+ * Resolve one metric across all three supplies.
+ *
+ * `preferred` is what the UI should lead with: measured beats reported beats
+ * claimed, because that ordering runs from "we watched it happen" to "someone
+ * told us". Callers wanting a specific supply read the named fields instead.
+ *
+ * @returns {{ measured, reported, claimed, preferred,
+ *             claimedVsMeasured: {delta, pct}|null }}
+ */
+export function resolveMetric(vehicle, sessions, summaries, field) {
+    const measured = deriveFromRuns(sessions, field);
+    const reported = deriveFromSummaries(summaries, field);
+    const claimed  = deriveClaimed(vehicle, field);
+
+    const preferred = measured.value != null ? measured
+        : reported.value != null ? reported
+        : claimed;
+
+    // The editorial payoff: how far the marketing number sits from reality.
+    let claimedVsMeasured = null;
+    const truth = measured.value != null ? measured : reported;
+    if (claimed.value != null && truth.value != null) {
+        const delta = truth.value - claimed.value;
+        claimedVsMeasured = {
+            delta,
+            pct: claimed.value !== 0 ? (delta / claimed.value) * 100 : null,
+            against: truth.source,
+        };
+    }
+
+    return { measured, reported, claimed, preferred, claimedVsMeasured };
+}
+
+/** Metrics resolved by `resolveAll`, in display order. */
+export const PERFORMANCE_METRICS = [
+    { field: 'zero_to_60_sec',         label: '0–60 mph',        unit: 's',   note: 'no rollout' },
+    { field: 'zero_to_60_rollout_sec', label: '0–60 mph',        unit: 's',   note: '1 ft rollout' },
+    { field: 'quarter_mile_sec',       label: '¼ mile',          unit: 's' },
+    { field: 'quarter_mile_trap_mph',  label: '¼ mile trap',     unit: 'mph' },
+    { field: 'fifty_to_ninety_sec',    label: '50–90 mph',       unit: 's' },
+    { field: 'braking_distance_ft',    label: 'Braking',         unit: 'ft' },
+];
+
+/**
+ * Resolve every metric for a vehicle.
+ *
+ * @param {object}   vehicle   — vehicle row (for specs.performance claims)
+ * @param {object[]} sessions  — performance_sessions with nested performance_runs
+ * @param {object[]} summaries — performance_summaries rows for this vehicle
+ * @returns {Record<string, ReturnType<typeof resolveMetric>>} keyed by field
+ */
+export function resolveAll(vehicle, sessions = [], summaries = []) {
+    const out = {};
+    for (const { field } of PERFORMANCE_METRICS) {
+        out[field] = resolveMetric(vehicle, sessions, summaries, field);
+    }
+    return out;
+}

--- a/src/utils/vehicleSpecSchema.js
+++ b/src/utils/vehicleSpecSchema.js
@@ -38,20 +38,27 @@ export const SPEC_CATEGORIES = [
         ],
     },
     {
+        // NOTHING in this category is measured by EVBench — every value is cited
+        // from elsewhere, so the labels say where it came from. Acceleration and
+        // top-speed figures are manufacturer claims; the handling/braking figures
+        // come from published road tests. Independently-tested acceleration and
+        // braking results live separately, in performance_summaries /
+        // performance_sessions (see migration 039), and are surfaced with their
+        // own provenance so the two are never confused.
         key: 'performance',
-        label: 'Performance',
+        label: 'Performance (Published)',
         fields: [
-            { key: 'zero_to_60_mph_sec', label: '0–60 mph (sec)',              type: 'number' },
-            { key: 'quarter_mile_sec',   label: '¼ Mile (sec)',                type: 'number' },
-            { key: 'quarter_mile_mph',   label: '¼ Mile Trap Speed',           type: 'number', unitGroup: 'speed' },
-            { key: 'top_speed_mph',      label: 'Top Speed',                   type: 'number', unitGroup: 'speed' },
-            { key: 'weight_lbs',         label: 'Curb Weight',                 type: 'number', unitGroup: 'weight' },
-            { key: 'braking_60_0_ft',    label: 'Braking 60–0',               type: 'number', unitGroup: 'feet' },
-            { key: 'braking_70_0_ft',    label: 'Braking 70–0',               type: 'number', unitGroup: 'feet' },
-            { key: 'lateral_g',          label: 'Lateral Grip (g)',            type: 'number' },
-            { key: 'figure_8_sec',       label: 'Figure 8 (sec)',              type: 'number' },
-            { key: 'slalom_mph',         label: 'Slalom Speed',                type: 'number', unitGroup: 'speed' },
-            { key: 'elk_test_mph',       label: 'Elk Test Speed (Moose Test)', type: 'number', unitGroup: 'speed' },
+            { key: 'zero_to_60_mph_sec', label: '0–60 mph (sec) — claimed',     type: 'number' },
+            { key: 'quarter_mile_sec',   label: '¼ Mile (sec) — claimed',       type: 'number' },
+            { key: 'quarter_mile_mph',   label: '¼ Mile Trap Speed — claimed',  type: 'number', unitGroup: 'speed' },
+            { key: 'top_speed_mph',      label: 'Top Speed — claimed',          type: 'number', unitGroup: 'speed' },
+            { key: 'weight_lbs',         label: 'Curb Weight',                  type: 'number', unitGroup: 'weight' },
+            { key: 'braking_60_0_ft',    label: 'Braking 60–0 — published',     type: 'number', unitGroup: 'feet' },
+            { key: 'braking_70_0_ft',    label: 'Braking 70–0 — published',     type: 'number', unitGroup: 'feet' },
+            { key: 'lateral_g',          label: 'Lateral Grip (g) — published', type: 'number' },
+            { key: 'figure_8_sec',       label: 'Figure 8 (sec) — published',   type: 'number' },
+            { key: 'slalom_mph',         label: 'Slalom Speed — published',     type: 'number', unitGroup: 'speed' },
+            { key: 'elk_test_mph',       label: 'Elk Test Speed (Moose Test) — published', type: 'number', unitGroup: 'speed' },
         ],
     },
     {

--- a/supabase/migrations/036_performance_sessions.sql
+++ b/supabase/migrations/036_performance_sessions.sql
@@ -1,0 +1,76 @@
+-- ============================================================
+-- Migration 036: Performance testing — Part 1 (sessions)
+--
+-- A testing outing: one vehicle, one location, one weather reading, one
+-- test type. The detail CSVs pair a single location/weather sample with
+-- many individual launches, so that context lives here and is not repeated
+-- per run.
+--
+-- Deliberately NOT a row in `runs`. A performance session yields ~8 runs in
+-- 90 seconds, and `runs` rows are consumed broadly (charging/range selectors,
+-- chart series, vehicle-card counts) where isChargingRun() treats anything
+-- without has_charging=false as a charging run. Performance data also shares
+-- none of runs' SoC/energy/distance columns.
+--
+-- wind_bearing_deg is METEOROLOGICAL (the direction wind comes FROM, as the
+-- source CSVs report it). This is a different coordinate system from
+-- runs.wind_direction_deg, which is relative to the vehicle's direction of
+-- travel (see migration 035) — hence the distinct name.
+-- ============================================================
+
+CREATE TABLE performance_sessions (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    vehicle_id      bigint NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    -- Which configuration was tested. NULL when the source doesn't say.
+    trim_id         bigint REFERENCES trims(id) ON DELETE SET NULL,
+
+    test_type       text NOT NULL CHECK (test_type IN ('accel','braking')),
+    -- Wall-clock time AT THE TEST SITE. Sources report "(local)" with no UTC
+    -- offset and we can't infer one from lat/long without a tz database, so
+    -- this is deliberately zone-less rather than a falsely-precise instant.
+    tested_at       timestamp,
+
+    -- Location
+    location_name   text,          -- e.g. "North Carolina, United States"
+    latitude        numeric(9,6),
+    longitude       numeric(9,6),
+
+    -- Weather at the time of testing
+    temperature_f   numeric,
+    humidity_pct    numeric,
+    pressure_inhg   numeric,
+    wind_speed_mph  numeric,
+    wind_bearing_deg numeric,      -- meteorological: direction wind comes FROM
+    cloud_cover_pct numeric,
+    visibility_mi   numeric,
+
+    -- Provenance
+    source_name     text,          -- e.g. "Out of Spec Testing"
+    youtube_url     text,
+    spreadsheet_url text,
+    notes           text,
+
+    created_at      timestamptz DEFAULT now()
+);
+
+COMMENT ON COLUMN performance_sessions.wind_bearing_deg IS
+    'Meteorological bearing — the direction the wind is coming FROM (0=N, 90=E). NOT the same as runs.wind_direction_deg, which is relative to direction of travel.';
+
+CREATE INDEX idx_performance_sessions_vehicle ON performance_sessions(vehicle_id);
+
+ALTER TABLE performance_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read performance_sessions"
+    ON performance_sessions FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert performance_sessions"
+    ON performance_sessions FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update performance_sessions"
+    ON performance_sessions FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete performance_sessions"
+    ON performance_sessions FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/037_performance_runs.sql
+++ b/supabase/migrations/037_performance_runs.sql
@@ -1,0 +1,69 @@
+-- ============================================================
+-- Migration 037: Performance testing — Part 2 (individual runs)
+--
+-- One launch (accel) or one stop (braking) within a session. Accel and
+-- braking share this table — test_type is inherited from the parent session
+-- rather than repeated here, so a session can't contain a mix.
+--
+-- ROLLOUT: the two 0-60 figures are NOT interchangeable and are ~0.27 s apart.
+--   zero_to_60_sec          — clock starts at 0 mph ("0–60 mph" in the source
+--                             CSV). This is what publications label "no rollout".
+--   zero_to_60_rollout_sec  — 1-foot rollout, drag-strip convention
+--                             ("0–60(1ft)" in the source CSV).
+-- Swapping them silently corrupts every cross-vehicle comparison, hence the
+-- explicit names over a bare `zero_to_60`.
+-- ============================================================
+
+CREATE TABLE performance_runs (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    session_id      bigint NOT NULL
+                        REFERENCES performance_sessions(id) ON DELETE CASCADE,
+    sequence        integer NOT NULL,   -- order within the session
+
+    -- Vehicle drive-mode setting, e.g. "Insane + Launch Mode", "Chill".
+    -- Repeats across runs — the same mode is usually tested several times.
+    drive_mode      text,
+    run_at          timestamp,   -- wall-clock at the test site; see migration 036
+
+    -- Per-run conditions (these vary between runs in the same session)
+    altitude_ft         numeric,
+    density_altitude_ft numeric,
+    slope_pct           numeric,   -- + = uphill
+    distance_run_ft     numeric,   -- length of the measured run
+
+    -- Results
+    max_g_force             numeric,
+    zero_to_60_sec          numeric,  -- no rollout (see header)
+    zero_to_60_rollout_sec  numeric,  -- 1ft rollout (see header)
+    braking_distance_ft     numeric,
+    braking_from_mph        numeric,
+    braking_to_mph          numeric DEFAULT 0,
+
+    created_at      timestamptz DEFAULT now(),
+
+    UNIQUE (session_id, sequence)
+);
+
+COMMENT ON COLUMN performance_runs.zero_to_60_sec IS
+    'Clock starts at 0 mph — the "no rollout" figure. Distinct from zero_to_60_rollout_sec.';
+COMMENT ON COLUMN performance_runs.zero_to_60_rollout_sec IS
+    '1-foot-rollout figure (drag-strip convention), typically ~0.3s quicker than zero_to_60_sec.';
+
+CREATE INDEX idx_performance_runs_session ON performance_runs(session_id);
+
+ALTER TABLE performance_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read performance_runs"
+    ON performance_runs FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert performance_runs"
+    ON performance_runs FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update performance_runs"
+    ON performance_runs FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete performance_runs"
+    ON performance_runs FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/038_performance_run_points.sql
+++ b/supabase/migrations/038_performance_run_points.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- Migration 038: Performance testing — Part 3 (split series)
+--
+-- The segment splits reported alongside a run. `label` keeps the raw source
+-- name because braking's segment labels aren't known yet, so this stays
+-- freeform rather than a fixed enum. speed_mph/elapsed_s/distance_ft are all
+-- nullable so one table serves both shapes:
+--   accel:   { label: '0-60(1ft)', speed_mph: 60, elapsed_s: 3.300 }
+--   braking: { label: '75-0',      speed_mph: 0,  distance_ft: 188.4 }
+--
+-- This is the series a speed-vs-time acceleration curve is plotted from —
+-- the performance analogue of data_points.
+-- ============================================================
+
+CREATE TABLE performance_run_points (
+    id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    run_id      bigint NOT NULL REFERENCES performance_runs(id) ON DELETE CASCADE,
+    sequence    integer NOT NULL,
+    label       text,
+    speed_mph   numeric,
+    elapsed_s   numeric,
+    distance_ft numeric,
+
+    UNIQUE (run_id, sequence)
+);
+
+CREATE INDEX idx_performance_run_points_run ON performance_run_points(run_id);
+
+ALTER TABLE performance_run_points ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read performance_run_points"
+    ON performance_run_points FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert performance_run_points"
+    ON performance_run_points FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update performance_run_points"
+    ON performance_run_points FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete performance_run_points"
+    ON performance_run_points FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/039_performance_summaries.sql
+++ b/supabase/migrations/039_performance_summaries.sql
@@ -1,0 +1,68 @@
+-- ============================================================
+-- Migration 039: Performance testing — Part 4 (reported results)
+--
+-- A published headline result from ONE source, for a vehicle (optionally a
+-- specific trim). This is the leaderboard layer: often the only data available,
+-- with no backing detail session.
+--
+-- Deliberately NO unique constraint on (vehicle_id, trim_id) — several
+-- publications test the same car and report different numbers, and all of them
+-- are worth keeping. `source_name` distinguishes them.
+--
+-- Stores ENTERED values only (manual or imported). Values derived from detail
+-- sessions are computed at read time by src/utils/performanceDerivations.js and
+-- are never written here — mirroring epaDerivations.js, and avoiding stale
+-- copies when the underlying run data changes. That also sidesteps needing a
+-- session FK: accel and braking figures come from different sessions, so no
+-- single link column could express it.
+--
+-- Separate from the existing vehicle_performance table, which holds
+-- MANUFACTURER-CLAIMED figures. Comparing the two is the point.
+-- ============================================================
+
+CREATE TABLE performance_summaries (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    vehicle_id      bigint NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    trim_id         bigint REFERENCES trims(id) ON DELETE SET NULL,
+    -- Free-text configuration as the source described it (e.g. "Dual Standard
+    -- LFP", "Performance"). Source trim names rarely map onto trims rows, and
+    -- requiring one would add friction to quick manual entry.
+    trim_label      text,
+
+    source_name     text,          -- who tested it, e.g. "Out of Spec"
+
+    zero_to_60_sec          numeric,  -- no rollout (see migration 037 header)
+    zero_to_60_rollout_sec  numeric,  -- 1ft rollout
+    quarter_mile_sec        numeric,
+    quarter_mile_trap_mph   numeric,
+    fifty_to_ninety_sec     numeric,
+    braking_distance_ft     numeric,
+    braking_from_mph        numeric,
+    braking_to_mph          numeric DEFAULT 0,
+
+    youtube_url     text,
+    spreadsheet_url text,
+    notes           text,
+
+    created_at      timestamptz DEFAULT now(),
+    updated_at      timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_performance_summaries_vehicle ON performance_summaries(vehicle_id);
+
+ALTER TABLE performance_summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read performance_summaries"
+    ON performance_summaries FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert performance_summaries"
+    ON performance_summaries FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update performance_summaries"
+    ON performance_summaries FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete performance_summaries"
+    ON performance_summaries FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));

--- a/supabase/migrations/040_performance_intervals.sql
+++ b/supabase/migrations/040_performance_intervals.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- Migration 040: Performance testing — variable speed-window results
+--
+-- Replaces the hardcoded passing/braking columns on performance_summaries.
+-- Those assumed one fixed window each (50-90, and a single braking result),
+-- but real sources vary:
+--   passing  — 50-80 or 50-90, sometimes 30-50 / 40-70
+--   braking  — 75-0, 70-0 or 60-0, often SEVERAL from the same stop
+--              (a 75-0 trace contains the 60-0 distance), and frequently
+--              reported metric (100-0 km/h in metres)
+--
+-- Braking, passing and acceleration are all the same shape — a speed window
+-- yielding either a time or a distance — so one table serves all three.
+--
+-- UNITS: values are stored AS REPORTED, with their unit alongside. "100-0 km/h
+-- in 38.5 m" is the standard European braking figure; normalising it to
+-- "62.1-0 mph" on write would destroy the label and round-trip badly.
+-- Conversion to a common basis happens at read time in
+-- performanceDerivations.js, consistent with how every other derived value in
+-- this codebase works.
+--
+-- 0-60 and quarter-mile stay as promoted COLUMNS on performance_summaries:
+-- they're fixed-window, universal, and read by every card and chart. Same
+-- promoted-field pattern as vehicle_performance vs. the specs JSONB. This
+-- table carries everything else, including extra accel windows (0-100, 0-30).
+-- ============================================================
+
+CREATE TABLE performance_intervals (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    summary_id      bigint NOT NULL
+                        REFERENCES performance_summaries(id) ON DELETE CASCADE,
+
+    kind            text NOT NULL CHECK (kind IN ('accel','passing','braking')),
+
+    -- The window. braking is typically X→0; accel 0→X; passing X→Y.
+    from_speed      numeric NOT NULL,
+    to_speed        numeric NOT NULL DEFAULT 0,
+    speed_unit      text NOT NULL DEFAULT 'mph' CHECK (speed_unit IN ('mph','kph')),
+
+    -- Exactly one of these carries the result: elapsed_s for accel/passing,
+    -- distance for braking.
+    elapsed_s       numeric,
+    distance        numeric,
+    distance_unit   text NOT NULL DEFAULT 'ft' CHECK (distance_unit IN ('ft','m')),
+
+    -- Accel only: whether the figure uses the 1ft drag-strip rollout.
+    rollout         boolean,
+
+    notes           text,
+    created_at      timestamptz DEFAULT now(),
+
+    -- A result is meaningless without a measurement.
+    CONSTRAINT performance_intervals_has_value
+        CHECK (elapsed_s IS NOT NULL OR distance IS NOT NULL),
+    -- One result per window per kind per source.
+    UNIQUE (summary_id, kind, from_speed, to_speed, speed_unit)
+);
+
+COMMENT ON TABLE performance_intervals IS
+    'Variable speed-window results (braking distances, passing times, extra accel windows). Values stored as reported with their units; converted at read time.';
+
+CREATE INDEX idx_performance_intervals_summary ON performance_intervals(summary_id);
+-- Cross-vehicle comparison always filters to one comparable window
+-- ("75-0 mph across all cars"), so index the window itself.
+CREATE INDEX idx_performance_intervals_window
+    ON performance_intervals(kind, from_speed, to_speed, speed_unit);
+
+ALTER TABLE performance_intervals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read performance_intervals"
+    ON performance_intervals FOR SELECT USING (true);
+
+CREATE POLICY "Curators insert performance_intervals"
+    ON performance_intervals FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators update performance_intervals"
+    ON performance_intervals FOR UPDATE
+    USING (current_user_role() IN ('admin','contributor'));
+
+CREATE POLICY "Curators delete performance_intervals"
+    ON performance_intervals FOR DELETE
+    USING (current_user_role() IN ('admin','contributor'));
+
+-- ── Retire the fixed-window columns superseded above ────────────────────────
+-- Safe to drop outright: migrations 036-039 were applied minutes ago and these
+-- columns have never held data.
+ALTER TABLE performance_summaries
+    DROP COLUMN IF EXISTS fifty_to_ninety_sec,
+    DROP COLUMN IF EXISTS braking_distance_ft,
+    DROP COLUMN IF EXISTS braking_from_mph,
+    DROP COLUMN IF EXISTS braking_to_mph;


### PR DESCRIPTION
First of three staged PRs adding independently-tested acceleration and braking
performance data to EVBench. **This PR is data-layer only — no UI yet.**

## Why not extend `runs`?

The first draft of this plan put a `has_performance` flag on `runs`. That was wrong:

- A single testing session yields **~8 launches in 90 seconds**. Each would become a `runs` row.
- [`runUtils.js:10`](../blob/main/src/utils/runUtils.js#L10) is `isChargingRun = (r) => r.has_charging !== false`, and `runs.has_charging` defaults to `true` — so every launch would leak into the charging RunSelectors, charts, and vehicle-card counts across the 15 files consuming `.runs` unless each was defensively filtered.
- `runs`' `start_soc`/`energy_kwh`/`distance_miles`/`is_default` columns are all meaningless for a 3.5-second launch.

So performance data gets its own tables. Accel and braking still share one run table via the session's `test_type`.

## Schema (migrations 036–039)

| Table | Holds |
|---|---|
| `performance_sessions` | One outing — location, weather, source links |
| `performance_runs` | One launch/stop — per-run slope, altitude, results |
| `performance_run_points` | Split series (the acceleration-curve source) |
| `performance_summaries` | Published results from one source |

`performance_summaries` has **no unique constraint** on (vehicle, trim) — several publications test the same car and all their numbers are worth keeping.

## Three correctness details

**Wind bearing vs. wind direction.** Sources report `coming from 71°` — a meteorological bearing. `runs.wind_direction_deg` is documented in migration 035 as *relative to direction of travel* (0°=tailwind). These are different coordinate systems, so this stores `wind_bearing_deg` under a distinct name rather than silently poisoning the wind-correction math from #143/#144.

**Rollout.** `zero_to_60_sec` (no rollout, clock starts at 0 mph) and `zero_to_60_rollout_sec` (1ft, drag-strip convention) are ~0.27s apart and kept explicitly distinct — swapping them corrupts every comparison.

**Timestamps.** `tested_at`/`run_at` are zone-less `timestamp`. Sources say "(local)" with no UTC offset, so `new Date()` would resolve the wall clock against the *importing machine's* timezone and could roll the date across midnight.

## Derivations

`performanceDerivations.js` computes at read time and **never persists**, mirroring `epaDerivations.js` — a stored derived value goes stale when its backing runs change. `resolveMetric()` returns `measured` / `reported` / `claimed` side by side rather than collapsing them, plus `claimedVsMeasured`; the gap between marketing and measurement is the editorial payoff (charted in PR C).

## Verification

Parser exercised against a real 8-run export via a node harness:

- 8 runs, 4 drive modes, 6 splits each, all slopes/G-forces/distances matching source
- Per-run altitude shift at column 5 (143ft → 125ft) preserved
- Edge cases: ASCII hyphens instead of en-dashes, missing bullets, reordered rows, trailing blank column, absent timestamps; throws cleanly on no timing data
- **Cross-validation:** best measured 0-60 came out `3.504s`, exactly matching the independently-reported "0-60 (no rollout)" figure for the same vehicle — confirming the rollout row mapping
- Incidental finding: "Insane − No Launch Mode" (3.504s) beat "Insane + Launch Mode" (3.572s) across all three attempts each

`npm run build` green.

## Also included

Relabels the `performance` spec category to **"Performance (Published)"** with per-field `— claimed` / `— published` suffixes. The category turned out to be mixed provenance: acceleration and top speed are manufacturer claims, but braking/lateral-g/figure-8/moose-test are published road-test results. Nothing in it is measured by EVBench, and the new tested data must not be confused with it.

## Applying

Migrations 036–039 need pasting into the Supabase SQL editor (project's established process). No UI depends on them until PR B.

## Next

- **PR B** — `PerformanceVehicleSection` in Tests & Data: session cards, CSV import, manual entry
- **PR C** — Charts sub-tab, including the claimed-vs-tested delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)