### PR TITLE
Add bulk vehicle import from CSV or JSON

### DIFF
--- a/src/components/ImportVehiclesModal.jsx
+++ b/src/components/ImportVehiclesModal.jsx
@@ -1,0 +1,387 @@
+/**
+ * Bulk vehicle import modal — drop a CSV or JSON file to create vehicles and fill
+ * in their specs in one pass.
+ *
+ * Flow: upload → review (a per-row plan you can tick through) → done.
+ * Parsing and planning are pure utils (parseVehicleImport / vehicleImportPlan);
+ * this component is presentation plus the apply call.
+ *
+ * Merge policy is fill-blanks — existing values are never overwritten, so the
+ * same file can be re-uploaded after it grows more columns.
+ */
+import { Fragment, useMemo, useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+import { parseVehicleImportText } from '../utils/parseVehicleImport';
+import {
+    buildImportPlan, selectPlanRows, fieldPathLabel,
+    buildCsvTemplate, buildJsonTemplate,
+} from '../utils/vehicleImportPlan';
+
+const ACTION_STYLES = {
+    create: { label: '＋ new',    className: 'import-badge-create' },
+    update: { label: '✎ fill',    className: 'import-badge-update' },
+    skip:   { label: '– nothing', className: 'import-badge-skip' },
+    error:  { label: '⚠ error',   className: 'import-badge-error' },
+};
+
+function downloadText(filename, text, mime) {
+    const url = URL.createObjectURL(new Blob([text], { type: mime }));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+/** Expanded detail for one planned row: what gets written, what is left alone. */
+function RowDetail({ row }) {
+    const coreWrites = Object.entries(row.coreWrites);
+    return (
+        <div className="import-row-detail">
+            {row.manufacturerName && (
+                <p>Brand: <span className="font-medium">{row.manufacturerName}</span>
+                    {row.manufacturerIsNew && <span className="text-amber-600 dark:text-amber-400"> (new)</span>}</p>
+            )}
+            {row.inherit && <p>Inherits specs from <span className="font-medium">{row.inheritRef}</span></p>}
+            {row.tagNames.length > 0 && <p>Tags added: {row.tagNames.join(', ')}</p>}
+
+            {(coreWrites.length > 0 || row.specWrites.length > 0) && (
+                <>
+                    <p className="font-medium mt-1">Writes</p>
+                    <ul className="import-detail-list">
+                        {coreWrites.map(([key, value]) => (
+                            <li key={key}>{key} → <span className="font-mono">{String(value)}</span></li>
+                        ))}
+                        {row.specWrites.map(w => (
+                            <li key={w.path}>
+                                {fieldPathLabel(w.path)} → <span className="font-mono">{String(w.value)}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {row.specSkips.length > 0 && (
+                <>
+                    <p className="font-medium mt-1">Kept (already set)</p>
+                    <ul className="import-detail-list text-faint">
+                        {row.specSkips.map(s => (
+                            <li key={s.path}>
+                                {fieldPathLabel(s.path)} — keeping <span className="font-mono">{String(s.current)}</span>,
+                                ignoring <span className="font-mono">{String(s.value)}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {row.errors.map((e, i) => <p key={`e${i}`} className="text-red-600 dark:text-red-400">⚠ {e}</p>)}
+            {row.warnings.map((w, i) => <p key={`w${i}`} className="text-amber-600 dark:text-amber-400">{w}</p>)}
+        </div>
+    );
+}
+
+export default function ImportVehiclesModal({ onClose }) {
+    const { vehicles, manufacturers, tags, importVehicles } = useAppContext();
+
+    const [step, setStep]         = useState('upload'); // upload | review | done
+    const [fileName, setFileName] = useState('');
+    const [parsed, setParsed]     = useState(null);
+    const [plan, setPlan]         = useState(null);
+    const [selected, setSelected] = useState(new Set());
+    const [expanded, setExpanded] = useState(new Set());
+    const [dragOver, setDragOver] = useState(false);
+    const [busy, setBusy]         = useState(false);
+    const [error, setError]       = useState(null);
+    const [result, setResult]     = useState(null);
+    const [showHelp, setShowHelp] = useState(false);
+
+    const processFile = async (file) => {
+        if (!file) return;
+        setBusy(true);
+        setError(null);
+        setFileName(file.name);
+        try {
+            const text = await file.text();
+            const parsedFile = parseVehicleImportText(text, file.name);
+            if (parsedFile.fileError) { setError(parsedFile.fileError); return; }
+            if (parsedFile.rows.length === 0) { setError('No vehicle rows found in this file.'); return; }
+
+            const built = buildImportPlan(parsedFile.rows, { vehicles, manufacturers, tags });
+            setParsed(parsedFile);
+            setPlan(built);
+            setSelected(new Set(
+                built.rows.flatMap((r, i) => (r.action === 'create' || r.action === 'update') ? [i] : [])
+            ));
+            setExpanded(new Set());
+            setStep('review');
+        } catch (e) {
+            setError(e.message || 'Could not read that file.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const toggleRow = (i) => setSelected(prev => {
+        const next = new Set(prev);
+        next.has(i) ? next.delete(i) : next.add(i);
+        return next;
+    });
+
+    const toggleExpanded = (i) => setExpanded(prev => {
+        const next = new Set(prev);
+        next.has(i) ? next.delete(i) : next.add(i);
+        return next;
+    });
+
+    const selectablePlanRows = plan
+        ? plan.rows.flatMap((r, i) => (r.action === 'create' || r.action === 'update') ? [i] : [])
+        : [];
+    const allSelected = selectablePlanRows.length > 0 && selectablePlanRows.every(i => selected.has(i));
+
+    const applyPlan = useMemo(
+        () => (plan ? selectPlanRows(plan, selected) : null),
+        [plan, selected],
+    );
+
+    const handleApply = async () => {
+        if (!applyPlan) return;
+        setBusy(true);
+        setError(null);
+        try {
+            const res = await importVehicles(applyPlan);
+            setResult(res);
+            setStep('done');
+        } catch (e) {
+            setError(e.message || 'Import failed.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const summary = applyPlan?.summary;
+    const canApply = !!summary && (summary.creates + summary.updates) > 0;
+
+    return (
+        <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+            <div
+                className="modal-panel rounded-xl p-5"
+                style={{ maxWidth: '900px', width: '96vw', maxHeight: '90vh', overflowY: 'auto' }}
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between mb-4">
+                    <h3 className="section-title mb-0">Bulk Import Vehicles</h3>
+                    <button onClick={onClose} className="text-faint hover:text-secondary text-xl leading-none" aria-label="Close">×</button>
+                </div>
+
+                {error && (
+                    <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm">⚠️ {error}</div>
+                )}
+
+                {step === 'upload' && (
+                    <>
+                        <div
+                            onDrop={e => { e.preventDefault(); setDragOver(false); processFile(e.dataTransfer.files[0]); }}
+                            onDragOver={e => { e.preventDefault(); setDragOver(true); }}
+                            onDragLeave={() => setDragOver(false)}
+                            className={`border-2 border-dashed rounded-lg p-10 text-center ${dragOver ? 'border-indigo-400 bg-indigo-50/40' : 'border-[var(--color-border)]'}`}
+                        >
+                            <p className="text-body text-muted mb-3">
+                                {busy ? 'Reading file…' : 'Drop a CSV or JSON file here, or'}
+                            </p>
+                            <label className="btn btn-secondary text-sm cursor-pointer">
+                                Choose file
+                                <input
+                                    type="file"
+                                    accept=".csv,.json,.txt,text/csv,application/json"
+                                    className="hidden"
+                                    onChange={e => { processFile(e.target.files[0]); e.target.value = ''; }}
+                                />
+                            </label>
+                            <p className="text-hint mt-3">Parsed in your browser — nothing is uploaded until you confirm.</p>
+                        </div>
+
+                        <div className="flex flex-wrap items-center gap-2 mt-4">
+                            <span className="text-label">Templates:</span>
+                            <button
+                                className="btn btn-secondary text-sm"
+                                onClick={() => downloadText('evbench-vehicles-template.csv', buildCsvTemplate(), 'text/csv')}
+                            >
+                                CSV
+                            </button>
+                            <button
+                                className="btn btn-secondary text-sm"
+                                onClick={() => downloadText('evbench-vehicles-template.json', buildJsonTemplate(), 'application/json')}
+                            >
+                                JSON
+                            </button>
+                            <button className="btn btn-secondary text-sm ml-auto" onClick={() => setShowHelp(v => !v)}>
+                                {showHelp ? 'Hide' : 'What can the file contain?'}
+                            </button>
+                        </div>
+
+                        {showHelp && (
+                            <div className="notice-info mt-3 text-body">
+                                <p className="mb-2">
+                                    One row (or JSON object) per vehicle or trim. Column names are matched loosely —
+                                    use the field key, the qualified path, or the label shown in Compare Specs.
+                                </p>
+                                <ul className="import-detail-list">
+                                    <li><span className="font-mono">name</span> — required; the display name, also used to match an existing vehicle</li>
+                                    <li><span className="font-mono">manufacturer</span> / <span className="font-mono">make</span>, <span className="font-mono">model</span>, <span className="font-mono">trim</span>, <span className="font-mono">year</span>, <span className="font-mono">battery</span>, <span className="font-mono">range</span></li>
+                                    <li><span className="font-mono">tags</span> — comma-separated; missing tags are created</li>
+                                    <li><span className="font-mono">inherits_from</span> — another vehicle's name or id (may be a row in this same file)</li>
+                                    <li><span className="font-mono">powertrain.horsepower_hp</span> — any spec as <span className="font-mono">category.field</span>, or just <span className="font-mono">horsepower_hp</span></li>
+                                    <li><span className="font-mono">powertrain._custom.gear_ratio</span> — free-form custom fields</li>
+                                    <li>JSON may also nest specs under <span className="font-mono">specs: {'{'} category: {'{'} field: value {'}}'}</span></li>
+                                </ul>
+                                <p className="mt-2 text-hint">
+                                    Values already set on a vehicle are never overwritten — an import only fills blanks.
+                                </p>
+                            </div>
+                        )}
+                    </>
+                )}
+
+                {step === 'review' && plan && (
+                    <>
+                        <p className="text-body text-muted mb-2">
+                            <span className="font-medium">{fileName}</span> · {parsed.format.toUpperCase()} ·{' '}
+                            {plan.summary.total} row(s)
+                        </p>
+
+                        <div className="import-summary-row">
+                            <span className="import-badge-create">{summary.creates} to create</span>
+                            <span className="import-badge-update">{summary.updates} to fill in</span>
+                            {plan.summary.skips > 0 && <span className="import-badge-skip">{plan.summary.skips} already complete</span>}
+                            {plan.summary.errors > 0 && <span className="import-badge-error">{plan.summary.errors} with errors</span>}
+                        </div>
+
+                        {(summary.newManufacturers.length > 0 || summary.newTags.length > 0) && (
+                            <p className="text-hint mt-2">
+                                Will also create
+                                {summary.newManufacturers.length > 0 && <> brand(s): <span className="font-medium">{summary.newManufacturers.join(', ')}</span></>}
+                                {summary.newManufacturers.length > 0 && summary.newTags.length > 0 && ' and'}
+                                {summary.newTags.length > 0 && <> tag(s): <span className="font-medium">{summary.newTags.join(', ')}</span></>}
+                            </p>
+                        )}
+
+                        {parsed.columnIssues.length > 0 && (
+                            <ul className="mt-2 text-caption text-amber-600 dark:text-amber-400 list-disc pl-5">
+                                {parsed.columnIssues.map((issue, i) => (
+                                    <li key={i}>
+                                        {issue.kind === 'ambiguous'
+                                            ? `Column "${issue.header}" is ambiguous (${issue.candidates.join(', ')}) — ignored. Qualify it as category.field.`
+                                            : `Column "${issue.header}" matched no known field — ignored.`}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+
+                        <div className="import-table-container mt-3">
+                            <table className="w-full text-caption">
+                                <thead className="bg-[var(--color-surface-muted)] sticky top-0">
+                                    <tr className="text-left text-muted">
+                                        <th className="p-2 w-8">
+                                            <input
+                                                type="checkbox"
+                                                checked={allSelected}
+                                                onChange={() => setSelected(allSelected ? new Set() : new Set(selectablePlanRows))}
+                                                title="Select all / none"
+                                            />
+                                        </th>
+                                        <th className="p-2">Vehicle</th>
+                                        <th className="p-2">Action</th>
+                                        <th className="p-2">Matched by</th>
+                                        <th className="p-2">Fills</th>
+                                        <th className="p-2 w-8"></th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y">
+                                    {plan.rows.map((row, i) => {
+                                        const selectable = row.action === 'create' || row.action === 'update';
+                                        const isSelected = selected.has(i);
+                                        const style = ACTION_STYLES[row.action];
+                                        const fills = Object.keys(row.coreWrites).length + row.specWrites.length;
+                                        return (
+                                            <Fragment key={i}>
+                                                <tr className={selectable && isSelected ? '' : 'opacity-50'}>
+                                                    <td className="p-2">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={isSelected}
+                                                            disabled={!selectable}
+                                                            onChange={() => toggleRow(i)}
+                                                        />
+                                                    </td>
+                                                    <td className="p-2">{row.label}</td>
+                                                    <td className="p-2"><span className={style.className}>{style.label}</span></td>
+                                                    <td className="p-2 text-muted">{row.matchedBy ?? '—'}</td>
+                                                    <td className="p-2 font-mono">
+                                                        {fills || '—'}
+                                                        {row.tagNames.length > 0 && <span className="text-muted"> +{row.tagNames.length} tag</span>}
+                                                    </td>
+                                                    <td className="p-2">
+                                                        <button
+                                                            onClick={() => toggleExpanded(i)}
+                                                            className="text-faint hover:text-secondary"
+                                                            title="Show details"
+                                                        >
+                                                            {expanded.has(i) ? '▾' : '▸'}
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                                {expanded.has(i) && (
+                                                    <tr>
+                                                        <td colSpan={6} className="p-0"><RowDetail row={row} /></td>
+                                                    </tr>
+                                                )}
+                                            </Fragment>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div className="flex items-center gap-2 mt-4">
+                            <span className="text-hint flex-1">
+                                {summary.fieldWrites > 0
+                                    ? 'Only blank fields are filled — existing values stay as they are.'
+                                    : 'Nothing selected to write.'}
+                            </span>
+                            <button onClick={() => { setStep('upload'); setPlan(null); setError(null); }} className="btn btn-secondary text-sm" disabled={busy}>
+                                Back
+                            </button>
+                            <button onClick={handleApply} className="btn btn-primary text-sm" disabled={busy || !canApply}>
+                                {busy ? 'Importing…' : `Import ${summary.creates + summary.updates} vehicle(s)`}
+                            </button>
+                        </div>
+                    </>
+                )}
+
+                {step === 'done' && result && (
+                    <div className="py-4 text-center">
+                        <p className="text-2xl mb-2">✓</p>
+                        <p className="text-body">
+                            {result.created} vehicle(s) created · {result.updated} updated.
+                        </p>
+                        {result.failures.length > 0 && (
+                            <ul className="mt-3 text-caption text-red-600 dark:text-red-400 list-disc pl-5 text-left">
+                                {result.failures.map((f, i) => <li key={i}>{f.label}: {f.message}</li>)}
+                            </ul>
+                        )}
+                        <div className="flex justify-center gap-2 mt-4">
+                            <button
+                                onClick={() => { setStep('upload'); setPlan(null); setResult(null); setFileName(''); }}
+                                className="btn btn-secondary text-sm"
+                            >
+                                Import another file
+                            </button>
+                            <button onClick={onClose} className="btn btn-primary text-sm">Done</button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/ImportVehiclesModal.jsx
+++ b/src/components/ImportVehiclesModal.jsx
@@ -13,7 +13,7 @@ import { Fragment, useMemo, useState } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { parseVehicleImportText } from '../utils/parseVehicleImport';
 import {
-    buildImportPlan, selectPlanRows, fieldPathLabel,
+    buildImportPlan, selectPlanRows, fieldPathLabel, fieldShortLabel,
     buildCsvTemplate, buildJsonTemplate,
 } from '../utils/vehicleImportPlan';
 
@@ -31,6 +31,44 @@ function downloadText(filename, text, mime) {
     a.download = filename;
     a.click();
     URL.revokeObjectURL(url);
+}
+
+/**
+ * Inline note cell — names the fields that were adjusted or skipped rather than
+ * only counting them, so the table itself answers "which ones?". The full
+ * before/after text is in the title attribute and in the expanded detail.
+ */
+function RowNotes({ row }) {
+    if (row.coercions.length === 0 && row.fieldSkips.length === 0) {
+        return <span className="text-faint">—</span>;
+    }
+
+    // Two names inline, the rest as "+n" — keeps the column from wrapping.
+    const nameList = paths => {
+        const names = paths.map(fieldShortLabel);
+        return names.slice(0, 2).join(', ') + (names.length > 2 ? ` +${names.length - 2}` : '');
+    };
+
+    return (
+        <span className="import-note-cell">
+            {row.coercions.length > 0 && (
+                <span
+                    className="import-note-info"
+                    title={row.coercions.map(c => `${fieldPathLabel(c.path)}: "${c.from}" → "${c.to}"`).join('\n')}
+                >
+                    ⓘ {nameList(row.coercions.map(c => c.path))} adjusted
+                </span>
+            )}
+            {row.fieldSkips.length > 0 && (
+                <span
+                    className="import-note-warn"
+                    title={row.fieldSkips.map(s => `${fieldPathLabel(s.path)}: ${s.reason}`).join('\n')}
+                >
+                    ⚠ {nameList(row.fieldSkips.map(s => s.path))} skipped
+                </span>
+            )}
+        </span>
+    );
 }
 
 /** Expanded detail for one planned row: what gets written, what is left alone. */
@@ -77,7 +115,7 @@ function RowDetail({ row }) {
             {row.fieldSkips.length > 0 && (
                 <>
                     <p className="font-medium mt-1">Skipped — value not understood</p>
-                    <ul className="import-detail-list text-amber-600 dark:text-amber-400">
+                    <ul className="import-detail-list text-red-600 dark:text-red-400">
                         {row.fieldSkips.map(s => (
                             <li key={s.path}>{fieldPathLabel(s.path)}: {s.reason}</li>
                         ))}
@@ -161,6 +199,13 @@ export default function ImportVehiclesModal({ onClose }) {
     const selectablePlanRows = plan
         ? plan.rows.flatMap((r, i) => (r.action === 'create' || r.action === 'update') ? [i] : [])
         : [];
+
+    // Rows carrying an adjusted or skipped value — the ones worth reading in full.
+    const notedPlanRows = plan
+        ? plan.rows.flatMap((r, i) => (r.coercions.length > 0 || r.fieldSkips.length > 0) ? [i] : [])
+        : [];
+    const allNotedExpanded = notedPlanRows.length > 0 && notedPlanRows.every(i => expanded.has(i));
+    const toggleAllNoted = () => setExpanded(allNotedExpanded ? new Set() : new Set(notedPlanRows));
     const allSelected = selectablePlanRows.length > 0 && selectablePlanRows.every(i => selected.has(i));
 
     const applyPlan = useMemo(
@@ -285,7 +330,9 @@ export default function ImportVehiclesModal({ onClose }) {
                             <p className="text-hint mt-2">
                                 {plan.summary.coercions > 0 && <>ⓘ {plan.summary.coercions} value(s) adjusted to a schema option. </>}
                                 {plan.summary.fieldSkips > 0 && <>⚠ {plan.summary.fieldSkips} value(s) couldn't be read and will be left blank. </>}
-                                Expand a row to see which.
+                                <button type="button" onClick={toggleAllNoted} className="import-link-button">
+                                    {allNotedExpanded ? 'Hide the details' : 'Show which fields'}
+                                </button>
                             </p>
                         )}
 
@@ -326,7 +373,8 @@ export default function ImportVehiclesModal({ onClose }) {
                                         <th className="p-2">Action</th>
                                         <th className="p-2">Matched by</th>
                                         <th className="p-2">Fills</th>
-                                        <th className="p-2 w-8"></th>
+                                        <th className="p-2">Notes</th>
+                                        <th className="p-2 w-20"></th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y">
@@ -337,8 +385,12 @@ export default function ImportVehiclesModal({ onClose }) {
                                         const fills = Object.keys(row.coreWrites).length + row.specWrites.length;
                                         return (
                                             <Fragment key={i}>
-                                                <tr className={selectable && isSelected ? '' : 'opacity-50'}>
-                                                    <td className="p-2">
+                                                {/* Whole row toggles its detail panel — the checkbox cell opts out. */}
+                                                <tr
+                                                    className={`import-row ${selectable && isSelected ? '' : 'opacity-50'}`}
+                                                    onClick={() => toggleExpanded(i)}
+                                                >
+                                                    <td className="p-2" onClick={e => e.stopPropagation()}>
                                                         <input
                                                             type="checkbox"
                                                             checked={isSelected}
@@ -352,26 +404,19 @@ export default function ImportVehiclesModal({ onClose }) {
                                                     <td className="p-2 font-mono">
                                                         {fills || '—'}
                                                         {row.tagNames.length > 0 && <span className="text-muted"> +{row.tagNames.length} tag</span>}
-                                                        {(row.coercions.length > 0 || row.fieldSkips.length > 0) && (
-                                                            <span className="text-amber-600 dark:text-amber-400">
-                                                                {row.coercions.length > 0 && ` ⓘ${row.coercions.length}`}
-                                                                {row.fieldSkips.length > 0 && ` ⚠${row.fieldSkips.length}`}
-                                                            </span>
-                                                        )}
                                                     </td>
                                                     <td className="p-2">
-                                                        <button
-                                                            onClick={() => toggleExpanded(i)}
-                                                            className="text-faint hover:text-secondary"
-                                                            title="Show details"
-                                                        >
-                                                            {expanded.has(i) ? '▾' : '▸'}
-                                                        </button>
+                                                        <RowNotes row={row} />
+                                                    </td>
+                                                    <td className="p-2 text-right">
+                                                        <span className="import-detail-toggle">
+                                                            {expanded.has(i) ? 'Hide ▾' : 'Details ▸'}
+                                                        </span>
                                                     </td>
                                                 </tr>
                                                 {expanded.has(i) && (
                                                     <tr>
-                                                        <td colSpan={6} className="p-0"><RowDetail row={row} /></td>
+                                                        <td colSpan={7} className="p-0"><RowDetail row={row} /></td>
                                                     </tr>
                                                 )}
                                             </Fragment>

--- a/src/components/ImportVehiclesModal.jsx
+++ b/src/components/ImportVehiclesModal.jsx
@@ -61,6 +61,30 @@ function RowDetail({ row }) {
                 </>
             )}
 
+            {row.coercions.length > 0 && (
+                <>
+                    <p className="font-medium mt-1">Adjusted to a schema value</p>
+                    <ul className="import-detail-list text-amber-600 dark:text-amber-400">
+                        {row.coercions.map(c => (
+                            <li key={c.path}>
+                                {fieldPathLabel(c.path)}: <span className="font-mono">{c.from}</span> → <span className="font-mono">{String(c.to)}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {row.fieldSkips.length > 0 && (
+                <>
+                    <p className="font-medium mt-1">Skipped — value not understood</p>
+                    <ul className="import-detail-list text-amber-600 dark:text-amber-400">
+                        {row.fieldSkips.map(s => (
+                            <li key={s.path}>{fieldPathLabel(s.path)}: {s.reason}</li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
             {row.specSkips.length > 0 && (
                 <>
                     <p className="font-medium mt-1">Kept (already set)</p>
@@ -257,6 +281,14 @@ export default function ImportVehiclesModal({ onClose }) {
                             {plan.summary.errors > 0 && <span className="import-badge-error">{plan.summary.errors} with errors</span>}
                         </div>
 
+                        {(plan.summary.coercions > 0 || plan.summary.fieldSkips > 0) && (
+                            <p className="text-hint mt-2">
+                                {plan.summary.coercions > 0 && <>ⓘ {plan.summary.coercions} value(s) adjusted to a schema option. </>}
+                                {plan.summary.fieldSkips > 0 && <>⚠ {plan.summary.fieldSkips} value(s) couldn't be read and will be left blank. </>}
+                                Expand a row to see which.
+                            </p>
+                        )}
+
                         {(summary.newManufacturers.length > 0 || summary.newTags.length > 0) && (
                             <p className="text-hint mt-2">
                                 Will also create
@@ -320,6 +352,12 @@ export default function ImportVehiclesModal({ onClose }) {
                                                     <td className="p-2 font-mono">
                                                         {fills || '—'}
                                                         {row.tagNames.length > 0 && <span className="text-muted"> +{row.tagNames.length} tag</span>}
+                                                        {(row.coercions.length > 0 || row.fieldSkips.length > 0) && (
+                                                            <span className="text-amber-600 dark:text-amber-400">
+                                                                {row.coercions.length > 0 && ` ⓘ${row.coercions.length}`}
+                                                                {row.fieldSkips.length > 0 && ` ⚠${row.fieldSkips.length}`}
+                                                            </span>
+                                                        )}
                                                     </td>
                                                     <td className="p-2">
                                                         <button

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -6,6 +6,7 @@ import DeleteQueueBar from './DeleteQueueBar';
 import EditVehicleForm from './EditVehicleForm';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
+import ImportVehiclesModal from './ImportVehiclesModal';
 
 // ── Test-count row ────────────────────────────────────────────────────────────
 
@@ -81,6 +82,7 @@ export default function VehiclesView({
     const [vehiclePage, setVehiclePage] = useState(savedState?.vehiclePage ?? 1);
     const [specsEditingVehicle, setSpecsEditingVehicle] = useState(null);
     const [specsViewingVehicle, setSpecsViewingVehicle] = useState(null);
+    const [showImportModal, setShowImportModal] = useState(false);
     const VEHICLES_PER_PAGE = 24;
 
     // Keep a ref always pointing at latest filter/sort/page so the unmount
@@ -518,12 +520,21 @@ export default function VehiclesView({
                         </button>
                     </div>
                     {canCreate && (
-                        <button
-                            onClick={() => { setEditingId(null); setShowForm(!showForm); }}
-                            className="btn btn-primary"
-                        >
-                            {showForm && !editingId ? 'Cancel' : '+ Add Vehicle'}
-                        </button>
+                        <>
+                            <button
+                                onClick={() => setShowImportModal(true)}
+                                className="btn btn-secondary"
+                                title="Bulk-add vehicles and specs from a CSV or JSON file"
+                            >
+                                Import…
+                            </button>
+                            <button
+                                onClick={() => { setEditingId(null); setShowForm(!showForm); }}
+                                className="btn btn-primary"
+                            >
+                                {showForm && !editingId ? 'Cancel' : '+ Add Vehicle'}
+                            </button>
+                        </>
                     )}
                 </div>
             </div>
@@ -993,6 +1004,11 @@ export default function VehiclesView({
                     vehicle={specsViewingVehicle}
                     onClose={() => setSpecsViewingVehicle(null)}
                 />
+            )}
+
+            {/* Bulk import modal (contributors/owners) */}
+            {showImportModal && (
+                <ImportVehiclesModal onClose={() => setShowImportModal(false)} />
             )}
         </div>
     );

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -534,6 +534,123 @@ export function AppProvider({ children }) {
         }
     };
 
+    /**
+     * Execute a bulk vehicle import plan (see utils/vehicleImportPlan.js).
+     *
+     * Runs in dependency order: new manufacturers and tags first, then every
+     * vehicle create/update, then specs + tags + inheritance links — so a row
+     * may inherit from a vehicle created earlier in the same file.
+     *
+     * Per-row failures are collected rather than aborting the run; the caller
+     * shows them in the import modal.
+     */
+    const importVehicles = async (plan) => {
+        const failures = [];
+        let created = 0, updated = 0;
+
+        // 1. Reference data the rows depend on.
+        const mfgByName = new Map(manufacturers.map(m => [m.name.toLowerCase(), m]));
+        for (const name of plan.summary.newManufacturers) {
+            try {
+                const mfg = await dataService.addManufacturer(name);
+                mfgByName.set(name.toLowerCase(), mfg);
+            } catch (error) {
+                failures.push({ label: name, message: `Manufacturer: ${error.message}` });
+            }
+        }
+
+        const tagByName = new Map(tags.map(t => [t.name.toLowerCase(), t]));
+        for (const name of plan.summary.newTags) {
+            try {
+                const tag = await dataService.createTag(name);
+                tagByName.set(name.toLowerCase(), tag);
+            } catch (error) {
+                failures.push({ label: name, message: `Tag: ${error.message}` });
+            }
+        }
+
+        // 2. Create / update the vehicle rows. rowVehicleIds lets pass 3 resolve
+        //    inherits_from references that point at rows in this same file.
+        const actionable = plan.rows
+            .map((row, planIndex) => ({ row, planIndex }))
+            .filter(({ row }) => row.action === 'create' || row.action === 'update');
+        const rowVehicleIds = new Map(); // plan-row array index → vehicle id
+        const done = [];
+
+        for (const { row, planIndex } of actionable) {
+            const mfgId = row.manufacturerName
+                ? mfgByName.get(row.manufacturerName.toLowerCase())?.id ?? null
+                : null;
+            try {
+                if (row.action === 'create') {
+                    const newVehicle = await dataService.addVehicle({
+                        ...row.coreWrites,
+                        ...(mfgId ? { manufacturer_id: mfgId } : {}),
+                    });
+                    rowVehicleIds.set(planIndex, newVehicle.id);
+                    created++;
+                } else {
+                    const updates = { ...row.coreWrites };
+                    if (mfgId) updates.manufacturer_id = mfgId;
+                    if (Object.keys(updates).length > 0) {
+                        // updateVehicle writes every core column, so send the
+                        // vehicle's current values for anything not being filled.
+                        const current = vehicles.find(v => v.id === row.vehicleId) || {};
+                        await dataService.updateVehicle(row.vehicleId, {
+                            name: current.name, make: current.make, model: current.model,
+                            trim: current.trim, year: current.year, battery: current.battery,
+                            range: current.range, power: current.power,
+                            ...updates,
+                        });
+                    }
+                    rowVehicleIds.set(planIndex, row.vehicleId);
+                    updated++;
+                }
+                done.push({ row, planIndex });
+            } catch (error) {
+                logIfUnauthorized('import_vehicle', 'vehicle', row.vehicleId, error);
+                failures.push({ label: row.label, message: error.message });
+            }
+        }
+
+        // 3. Specs, tags and inheritance — all vehicle ids are known by now.
+        for (const { row, planIndex } of done) {
+            const vehicleId = rowVehicleIds.get(planIndex);
+            try {
+                if (row.tagNames.length > 0) {
+                    const existingIds = (vehicles.find(v => v.id === vehicleId)?.tags || []).map(t => t.id);
+                    const newIds = row.tagNames
+                        .map(name => tagByName.get(name.toLowerCase())?.id)
+                        .filter(id => id != null);
+                    await dataService.syncVehicleTags(vehicleId, [...new Set([...existingIds, ...newIds])]);
+                }
+
+                const parentId = row.inherit
+                    ? (row.inherit.vehicleId ?? rowVehicleIds.get(row.inherit.rowIndex) ?? null)
+                    : undefined;
+                if (row.needsSpecWrite) {
+                    await dataService.updateVehicleSpecs(vehicleId, row.mergedSpecs, parentId);
+                }
+            } catch (error) {
+                logIfUnauthorized('import_vehicle_specs', 'vehicle', vehicleId, error);
+                failures.push({ label: row.label, message: error.message });
+            }
+        }
+
+        // Refresh without initializeApp()'s loading flag — that would unmount the
+        // import modal before it can show the result.
+        const [vehiclesData, tagsData, mfgData] = await Promise.all([
+            dataService.getVehicles(),
+            dataService.useSupabase ? dataService.getTags() : Promise.resolve(tags),
+            dataService.useSupabase ? dataService.getManufacturers() : Promise.resolve(manufacturers),
+        ]);
+        setVehicles(vehiclesData);
+        setTags(tagsData);
+        setManufacturers(mfgData);
+
+        return { created, updated, failures };
+    };
+
     const uploadVehicleImage = async (vehicleId, file) => {
         try {
             const imageUrl = await dataService.uploadVehicleImage(vehicleId, file);
@@ -1065,6 +1182,7 @@ export function AppProvider({ children }) {
         clearAllSelections,
         setVehicleSelection,
         addVehicle,
+        importVehicles,
         updateVehicle,
         reorderVehicles,
         duplicateVehicle,

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,43 @@ body {
     width: min(90vw, 420px);
 }
 
+/* ── Bulk vehicle import modal ──────────────────────────────────────────────── */
+
+/* Scrollable preview table of planned rows */
+.import-table-container {
+    @apply rounded-lg border overflow-auto;
+    max-height: 22rem;
+    border-color: var(--color-border);
+}
+
+/* Chip row summarising the plan (create / fill / skip / error counts) */
+.import-summary-row {
+    @apply flex flex-wrap items-center gap-2;
+}
+
+/* Per-action status badges — also used as the row badge in the table */
+.import-badge-create,
+.import-badge-update,
+.import-badge-skip,
+.import-badge-error {
+    @apply text-xs font-medium px-2 py-0.5 rounded-full whitespace-nowrap;
+}
+.import-badge-create { @apply bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200; }
+.import-badge-update { @apply bg-blue-100  text-blue-800  dark:bg-blue-900  dark:text-blue-200; }
+.import-badge-skip   { @apply bg-gray-100  text-gray-600  dark:bg-slate-700 dark:text-slate-300; }
+.import-badge-error  { @apply bg-red-100   text-red-800   dark:bg-red-900   dark:text-red-200; }
+
+/* Expanded per-row detail panel inside the preview table */
+.import-row-detail {
+    @apply px-4 py-2 text-xs;
+    background-color: var(--color-surface-sunken);
+}
+
+/* Compact bulleted list used in the row detail and the format help */
+.import-detail-list {
+    @apply list-disc pl-5 space-y-0.5;
+}
+
 /* ── Forms ──────────────────────────────────────────────────────────────────── */
 
 /* Two-column form field grid; gap added inline (gap-3 or gap-4) */

--- a/src/index.css
+++ b/src/index.css
@@ -538,6 +538,37 @@ body {
 .import-badge-skip   { @apply bg-gray-100  text-gray-600  dark:bg-slate-700 dark:text-slate-300; }
 .import-badge-error  { @apply bg-red-100   text-red-800   dark:bg-red-900   dark:text-red-200; }
 
+/* Preview table row — clicking anywhere on it opens the detail panel */
+.import-row {
+    @apply cursor-pointer transition;
+}
+.import-row:hover {
+    background-color: var(--color-surface-muted);
+}
+
+/* Right-hand expand affordance; reads as a control rather than a bare glyph */
+.import-detail-toggle {
+    @apply text-xs whitespace-nowrap;
+    color: var(--color-primary);
+}
+
+/* Inline note cell naming adjusted / skipped fields */
+.import-note-cell {
+    @apply flex flex-col gap-0.5;
+}
+.import-note-info,
+.import-note-warn {
+    @apply text-xs whitespace-nowrap cursor-help;
+}
+.import-note-info { @apply text-amber-600 dark:text-amber-400; }
+.import-note-warn { @apply text-red-600   dark:text-red-400; }
+
+/* Inline text button used in the summary line above the table */
+.import-link-button {
+    @apply underline;
+    color: var(--color-primary);
+}
+
 /* Expanded per-row detail panel inside the preview table */
 .import-row-detail {
     @apply px-4 py-2 text-xs;

--- a/src/utils/parseVehicleImport.js
+++ b/src/utils/parseVehicleImport.js
@@ -144,7 +144,45 @@ function coerceNumber(raw, { integer = false } = {}) {
     return { value: integer ? Math.round(n) : n };
 }
 
-/** Coerce a raw cell/JSON value for a schema field. Returns { value } or { error }. */
+const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Match a value against an enum's options, tolerating values that are more
+ * specific than the schema's vocabulary:
+ *   "NACS (SAE J3400)"                    → NACS
+ *   "Permanent Magnet Synchronous (E-GMP)" → Permanent Magnet
+ *
+ * An option must match at a word boundary, and exactly one option may match —
+ * anything ambiguous or unrecognised is still rejected. A loose match reports
+ * `coercedFrom` so the import preview can show what it decided.
+ */
+function matchEnumOption(raw, options) {
+    const s = String(raw).trim();
+    const lower = s.toLowerCase();
+
+    const exact = options.find(o => o.toLowerCase() === lower);
+    if (exact) return { value: exact };
+
+    // Leading match: the option opens the value and ends on a word boundary.
+    const prefix = options.filter(o => {
+        const ol = o.toLowerCase();
+        return lower.startsWith(ol) && !/[a-z0-9]/.test(lower[ol.length] ?? ' ');
+    });
+    if (prefix.length === 1) return { value: prefix[0], coercedFrom: s };
+
+    // Otherwise the option may appear as a whole word anywhere in the value.
+    const contained = options.filter(o =>
+        new RegExp(`\\b${escapeRegExp(o.toLowerCase())}\\b`).test(lower)
+    );
+    if (contained.length === 1) return { value: contained[0], coercedFrom: s };
+
+    return { error: `"${raw}" is not one of: ${options.join(', ')}` };
+}
+
+/**
+ * Coerce a raw cell/JSON value for a schema field.
+ * Returns { value }, { value, coercedFrom } for a loose enum match, or { error }.
+ */
 export function coerceValue(raw, field) {
     if (field.type === 'boolean') {
         if (typeof raw === 'boolean') return { value: raw };
@@ -153,12 +191,7 @@ export function coerceValue(raw, field) {
         if (FALSE_WORDS.has(s)) return { value: false };
         return { error: `"${raw}" is not Yes/No` };
     }
-    if (field.type === 'enum') {
-        const s = String(raw).trim();
-        const match = field.options.find(o => o.toLowerCase() === s.toLowerCase());
-        if (match) return { value: match };
-        return { error: `"${raw}" is not one of: ${field.options.join(', ')}` };
-    }
+    if (field.type === 'enum') return matchEnumOption(raw, field.options);
     if (field.type === 'integer') return coerceNumber(raw, { integer: true });
     if (field.type === 'number')  return coerceNumber(raw);
     return { value: String(raw).trim() };
@@ -185,12 +218,19 @@ function emptyRow(index) {
         custom: {},            // { [catKey]: { [customKey]: value } }
         tagNames: [],
         inheritsFrom: null,    // raw reference (id or vehicle name) — resolved later
-        errors: [],
+        skipped: [],           // [{ path, reason }] values that could not be read
+        coercions: [],         // [{ path, from, to }] loose enum matches, for the preview
+        errors: [],            // row-fatal problems only (identity, duplicates)
         warnings: [],
     };
 }
 
-/** Write one resolved column's value into the row being built. */
+/**
+ * Write one resolved column's value into the row being built.
+ *
+ * A value that cannot be coerced is recorded on `skipped` rather than failing
+ * the row — one over-specific string shouldn't discard the other 30 good fields.
+ */
 function applyCell(row, target, raw) {
     if (isBlankCell(raw)) return;
 
@@ -201,7 +241,7 @@ function applyCell(row, target, raw) {
         if (key === 'manufacturer') { row.manufacturerName = String(raw).trim(); return; }
         if (NUMERIC_CORE.has(key)) {
             const { value, error } = coerceNumber(raw);
-            if (error) row.errors.push(`${key}: ${error}`);
+            if (error) row.skipped.push({ path: key, reason: error });
             else row.core[key] = value;
             return;
         }
@@ -217,10 +257,12 @@ function applyCell(row, target, raw) {
     }
 
     if (target.kind === 'spec') {
-        const { value, error } = coerceValue(raw, target.field);
+        const path = `${target.catKey}.${target.fieldKey}`;
+        const { value, error, coercedFrom } = coerceValue(raw, target.field);
         if (error) {
-            row.errors.push(`${target.catKey}.${target.fieldKey}: ${error}`);
+            row.skipped.push({ path, reason: error });
         } else {
+            if (coercedFrom !== undefined) row.coercions.push({ path, from: coercedFrom, to: value });
             row.specs[target.catKey] = { ...row.specs[target.catKey], [target.fieldKey]: value };
         }
         return;
@@ -242,6 +284,7 @@ function rowIsEmpty(row) {
         && Object.keys(row.custom).length === 0
         && row.tagNames.length === 0
         && !row.inheritsFrom
+        && row.skipped.length === 0
         && row.errors.length === 0;
 }
 

--- a/src/utils/parseVehicleImport.js
+++ b/src/utils/parseVehicleImport.js
@@ -1,0 +1,385 @@
+/**
+ * Bulk vehicle import parser — turns a CSV or JSON file into normalised rows
+ * that buildImportPlan() can diff against the existing vehicle list.
+ *
+ * The parser is deliberately forgiving about column naming so a spreadsheet
+ * assembled by hand still lands. A column may be written as:
+ *   • a core vehicle field or alias      — "name", "brand", "epa range"
+ *   • a qualified spec path              — "powertrain.horsepower_hp"
+ *   • a bare spec field key              — "horsepower_hp"
+ *   • the schema's display label         — "Horsepower (hp)", "0–60 mph (sec)"
+ *   • a custom field path                — "powertrain._custom.gear_ratio"
+ *
+ * Values are coerced per the schema field type; anything that can't be coerced
+ * becomes a row-level error rather than silently writing junk to the DB.
+ *
+ * Pure module — no React, no network. Everything runs in the browser.
+ */
+import Papa from 'papaparse';
+import { SPEC_CATEGORIES, normalizeCustomKey } from './vehicleSpecSchema';
+
+// ── Header normalisation ─────────────────────────────────────────────────────
+
+/**
+ * Fold a header/key to a comparison form: camelCase split, lowercased, non-word
+ * runs collapsed to underscores, dots preserved so qualified paths survive.
+ * e.g. "0–60 mph (sec)" → "0_60_mph_sec"; "vehicleName" → "vehicle_name";
+ *      "Powertrain.Horsepower (hp)" → "powertrain.horsepower_hp"
+ */
+export function normKey(raw) {
+    return String(raw ?? '')
+        .trim()
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')   // camelCase → camel_Case
+        .toLowerCase()
+        .replace(/[^\w.]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^[._]+|[._]+$/g, '');
+}
+
+// ── Core vehicle columns ─────────────────────────────────────────────────────
+
+// Columns stored directly on the `vehicles` row (plus the two link columns).
+// First alias in each list is the canonical name used in templates.
+const CORE_ALIASES = {
+    id:            ['id', 'vehicle_id'],
+    name:          ['name', 'vehicle', 'vehicle_name', 'display_name'],
+    manufacturer:  ['manufacturer', 'brand'],
+    make:          ['make'],
+    model:         ['model'],
+    trim:          ['trim'],
+    year:          ['year', 'model_year'],
+    battery:       ['battery', 'battery_kwh'],
+    range:         ['range', 'epa_range', 'epa_range_mi', 'range_mi'],
+    power:         ['power', 'power_kw'],
+    tags:          ['tags', 'tag'],
+    inherits_from: ['inherits_from', 'inherit_from', 'inherits', 'spec_source', 'spec_parent', 'parent'],
+};
+
+const CORE_INDEX = new Map();
+for (const [key, aliases] of Object.entries(CORE_ALIASES)) {
+    for (const alias of aliases) CORE_INDEX.set(normKey(alias), key);
+}
+
+// Core fields that must parse as a number.
+const NUMERIC_CORE = new Set(['battery', 'range', 'power']);
+
+// ── Spec column indexes (built once from the schema) ─────────────────────────
+
+const QUALIFIED_INDEX = new Map(); // "powertrain.horsepower_hp" → entry
+const BARE_INDEX      = new Map(); // "horsepower_hp"            → [entry, …]
+const LABEL_INDEX     = new Map(); // "horsepower_hp" (from label) → [entry, …]
+
+for (const cat of SPEC_CATEGORIES) {
+    for (const field of cat.fields) {
+        const entry = { catKey: cat.key, fieldKey: field.key, field };
+        QUALIFIED_INDEX.set(normKey(`${cat.key}.${field.key}`), entry);
+        for (const [index, key] of [[BARE_INDEX, field.key], [LABEL_INDEX, field.label]]) {
+            const n = normKey(key);
+            if (!index.has(n)) index.set(n, []);
+            index.get(n).push(entry);
+        }
+        // Category-qualified label, e.g. "Powertrain.Horsepower (hp)"
+        QUALIFIED_INDEX.set(normKey(`${cat.key}.${field.label}`), entry);
+    }
+}
+
+const CATEGORY_BY_KEY = new Map(SPEC_CATEGORIES.map(c => [normKey(c.key), c]));
+
+/**
+ * Resolve a column header to a destination.
+ * Returns one of:
+ *   { kind: 'core',   key }
+ *   { kind: 'spec',   catKey, fieldKey, field }
+ *   { kind: 'custom', catKey, customKey }
+ *   { kind: 'unknown' | 'ambiguous', header, candidates? }
+ */
+export function resolveColumn(header) {
+    const n = normKey(header);
+    if (!n) return { kind: 'unknown', header };
+
+    if (CORE_INDEX.has(n)) return { kind: 'core', key: CORE_INDEX.get(n) };
+
+    // Strip an optional "specs." prefix so exported envelopes paste in cleanly.
+    const path = n.startsWith('specs.') ? n.slice('specs.'.length) : n;
+
+    // Custom field: "<category>._custom.<key>" (also accepts "<category>.custom.<key>")
+    const customMatch = path.match(/^([\w]+)\.(?:_custom|custom)\.(.+)$/);
+    if (customMatch) {
+        const cat = CATEGORY_BY_KEY.get(customMatch[1]);
+        if (cat) return { kind: 'custom', catKey: cat.key, customKey: normalizeCustomKey(customMatch[2]) };
+        return { kind: 'unknown', header };
+    }
+
+    if (QUALIFIED_INDEX.has(path)) return { kind: 'spec', ...QUALIFIED_INDEX.get(path) };
+
+    for (const index of [BARE_INDEX, LABEL_INDEX]) {
+        const hits = index.get(path);
+        if (hits?.length === 1) return { kind: 'spec', ...hits[0] };
+        if (hits?.length > 1) {
+            return {
+                kind: 'ambiguous',
+                header,
+                candidates: hits.map(h => `${h.catKey}.${h.fieldKey}`),
+            };
+        }
+    }
+
+    return { kind: 'unknown', header };
+}
+
+// ── Value coercion ───────────────────────────────────────────────────────────
+
+const TRUE_WORDS  = new Set(['true', 'yes', 'y', '1', 'std', 'standard']);
+const FALSE_WORDS = new Set(['false', 'no', 'n', '0', 'none', 'n/a', 'na']);
+
+function coerceNumber(raw, { integer = false } = {}) {
+    if (typeof raw === 'number') {
+        return Number.isFinite(raw) ? { value: integer ? Math.round(raw) : raw } : { error: 'not a number' };
+    }
+    // Tolerate thousands separators, currency symbols, and a trailing unit.
+    const cleaned = String(raw).replace(/[,$\s]/g, '').replace(/[a-z%°"']+$/i, '');
+    if (cleaned === '' || !/^-?\d*\.?\d+$/.test(cleaned)) return { error: `"${raw}" is not a number` };
+    const n = Number(cleaned);
+    if (!Number.isFinite(n)) return { error: `"${raw}" is not a number` };
+    return { value: integer ? Math.round(n) : n };
+}
+
+/** Coerce a raw cell/JSON value for a schema field. Returns { value } or { error }. */
+export function coerceValue(raw, field) {
+    if (field.type === 'boolean') {
+        if (typeof raw === 'boolean') return { value: raw };
+        const s = String(raw).trim().toLowerCase();
+        if (TRUE_WORDS.has(s))  return { value: true };
+        if (FALSE_WORDS.has(s)) return { value: false };
+        return { error: `"${raw}" is not Yes/No` };
+    }
+    if (field.type === 'enum') {
+        const s = String(raw).trim();
+        const match = field.options.find(o => o.toLowerCase() === s.toLowerCase());
+        if (match) return { value: match };
+        return { error: `"${raw}" is not one of: ${field.options.join(', ')}` };
+    }
+    if (field.type === 'integer') return coerceNumber(raw, { integer: true });
+    if (field.type === 'number')  return coerceNumber(raw);
+    return { value: String(raw).trim() };
+}
+
+function isBlankCell(v) {
+    return v === null || v === undefined || (typeof v === 'string' && v.trim() === '');
+}
+
+/** Split a tag cell ("suv, awd" or ["suv","awd"]) into a clean name list. */
+function parseTagList(raw) {
+    const list = Array.isArray(raw) ? raw : String(raw).split(/[,;|]/);
+    return [...new Set(list.map(t => String(t).trim()).filter(Boolean))];
+}
+
+// ── Row assembly ─────────────────────────────────────────────────────────────
+
+function emptyRow(index) {
+    return {
+        index,                 // 0-based position in the file (for "Row 3" messages)
+        core: {},              // { name, model, year, battery, … }
+        manufacturerName: null,
+        specs: {},             // { [catKey]: { [fieldKey]: value } }
+        custom: {},            // { [catKey]: { [customKey]: value } }
+        tagNames: [],
+        inheritsFrom: null,    // raw reference (id or vehicle name) — resolved later
+        errors: [],
+        warnings: [],
+    };
+}
+
+/** Write one resolved column's value into the row being built. */
+function applyCell(row, target, raw) {
+    if (isBlankCell(raw)) return;
+
+    if (target.kind === 'core') {
+        const { key } = target;
+        if (key === 'tags') { row.tagNames = parseTagList(raw); return; }
+        if (key === 'inherits_from') { row.inheritsFrom = String(raw).trim(); return; }
+        if (key === 'manufacturer') { row.manufacturerName = String(raw).trim(); return; }
+        if (NUMERIC_CORE.has(key)) {
+            const { value, error } = coerceNumber(raw);
+            if (error) row.errors.push(`${key}: ${error}`);
+            else row.core[key] = value;
+            return;
+        }
+        if (key === 'id') {
+            const { value, error } = coerceNumber(raw, { integer: true });
+            if (error) row.errors.push(`id: ${error}`);
+            else row.core.id = value;
+            return;
+        }
+        // name / make / model / trim / year are free text (year can be "2022-2024")
+        row.core[key] = String(raw).trim();
+        return;
+    }
+
+    if (target.kind === 'spec') {
+        const { value, error } = coerceValue(raw, target.field);
+        if (error) {
+            row.errors.push(`${target.catKey}.${target.fieldKey}: ${error}`);
+        } else {
+            row.specs[target.catKey] = { ...row.specs[target.catKey], [target.fieldKey]: value };
+        }
+        return;
+    }
+
+    if (target.kind === 'custom') {
+        row.custom[target.catKey] = {
+            ...row.custom[target.catKey],
+            [target.customKey]: String(raw).trim(),
+        };
+    }
+}
+
+/** True when a row carries nothing but blanks. */
+function rowIsEmpty(row) {
+    return Object.keys(row.core).length === 0
+        && !row.manufacturerName
+        && Object.keys(row.specs).length === 0
+        && Object.keys(row.custom).length === 0
+        && row.tagNames.length === 0
+        && !row.inheritsFrom
+        && row.errors.length === 0;
+}
+
+/**
+ * Build a row from a flat key→value object (a CSV record, or a JSON object's
+ * top-level keys). Unknown/ambiguous headers are collected on `columnIssues`.
+ */
+function rowFromFlatObject(obj, index, columnIssues) {
+    const row = emptyRow(index);
+    for (const [header, raw] of Object.entries(obj)) {
+        if (isBlankCell(raw)) continue;
+        const target = resolveColumn(header);
+        if (target.kind === 'unknown' || target.kind === 'ambiguous') {
+            columnIssues.set(header, target);
+            continue;
+        }
+        applyCell(row, target, raw);
+    }
+    return row;
+}
+
+/** Merge a nested `specs: { category: { field: value } }` object into a row. */
+function applyNestedSpecs(row, specsObj, columnIssues) {
+    for (const [catName, catData] of Object.entries(specsObj || {})) {
+        const cat = CATEGORY_BY_KEY.get(normKey(catName));
+        if (!cat || typeof catData !== 'object' || catData === null) {
+            if (!cat) columnIssues.set(`specs.${catName}`, { kind: 'unknown', header: `specs.${catName}` });
+            continue;
+        }
+        for (const [fieldName, raw] of Object.entries(catData)) {
+            if (normKey(fieldName) === '_custom' || normKey(fieldName) === 'custom') {
+                for (const [customKey, customVal] of Object.entries(raw || {})) {
+                    if (isBlankCell(customVal)) continue;
+                    applyCell(row, {
+                        kind: 'custom',
+                        catKey: cat.key,
+                        customKey: normalizeCustomKey(customKey),
+                    }, customVal);
+                }
+                continue;
+            }
+            if (isBlankCell(raw)) continue;
+            const target = resolveColumn(`${cat.key}.${fieldName}`);
+            if (target.kind === 'unknown' || target.kind === 'ambiguous') {
+                columnIssues.set(`${cat.key}.${fieldName}`, target);
+                continue;
+            }
+            applyCell(row, target, raw);
+        }
+    }
+}
+
+// ── Public entry points ──────────────────────────────────────────────────────
+
+/**
+ * Parse JSON text into rows. Accepted shapes:
+ *   [ {...}, {...} ]                    — array of vehicles
+ *   { vehicles: [ … ] }                 — wrapped array
+ *   { name: …, specs: { … } }           — a single vehicle
+ *   { vehicleName: …, specs: { … } }    — the Edit Specs export envelope
+ * Each vehicle may carry specs nested under `specs`, or as flat dotted keys.
+ */
+function parseJsonRows(text) {
+    let parsed;
+    try {
+        parsed = JSON.parse(text);
+    } catch (e) {
+        return { rows: [], columnIssues: new Map(), fileError: `Invalid JSON — ${e.message}` };
+    }
+
+    let list;
+    if (Array.isArray(parsed)) list = parsed;
+    else if (Array.isArray(parsed?.vehicles)) list = parsed.vehicles;
+    else if (parsed && typeof parsed === 'object') list = [parsed];
+    else return { rows: [], columnIssues: new Map(), fileError: 'JSON must be a vehicle object or an array of them.' };
+
+    const columnIssues = new Map();
+    const rows = list.map((entry, i) => {
+        if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+            const row = emptyRow(i);
+            row.errors.push('Entry is not a vehicle object.');
+            return row;
+        }
+        const { specs, ...flat } = entry;
+        const row = rowFromFlatObject(flat, i, columnIssues);
+        if (specs && typeof specs === 'object') applyNestedSpecs(row, specs, columnIssues);
+        return row;
+    });
+
+    return { rows, columnIssues, fileError: null };
+}
+
+/** Parse CSV text into rows using the header line as column names. */
+function parseCsvRows(text) {
+    const result = Papa.parse(text, {
+        header: true,
+        skipEmptyLines: 'greedy',
+        dynamicTyping: false,
+        transformHeader: h => String(h).trim(),
+    });
+
+    if (!result.meta?.fields?.length) {
+        return { rows: [], columnIssues: new Map(), fileError: 'CSV has no header row.' };
+    }
+
+    const columnIssues = new Map();
+    const rows = result.data.map((record, i) => rowFromFlatObject(record, i, columnIssues));
+    return { rows, columnIssues, fileError: null };
+}
+
+/**
+ * Parse an uploaded file's text into import rows.
+ *
+ * @param {string} text     raw file contents
+ * @param {string} fileName used (with a content sniff) to pick the format
+ * @returns {{ rows, format, columnIssues: Array, fileError: string|null }}
+ *          `rows` excludes entirely-blank rows; each row keeps its original
+ *          file index so messages can say "Row 4".
+ */
+export function parseVehicleImportText(text, fileName = '') {
+    const trimmed = String(text || '').trim();
+    if (!trimmed) return { rows: [], format: null, columnIssues: [], fileError: 'File is empty.' };
+
+    const looksJson = /\.json$/i.test(fileName) || trimmed.startsWith('{') || trimmed.startsWith('[');
+    const format = looksJson ? 'json' : 'csv';
+    const { rows, columnIssues, fileError } = looksJson ? parseJsonRows(trimmed) : parseCsvRows(trimmed);
+
+    const kept = rows.filter(r => !rowIsEmpty(r));
+    for (const row of kept) {
+        if (!row.core.name && !(row.core.make || row.manufacturerName) && !row.core.model && !row.core.id) {
+            row.errors.push('No name (or make + model) — cannot identify this vehicle.');
+        }
+    }
+
+    return {
+        rows: kept,
+        format,
+        columnIssues: [...columnIssues.values()],
+        fileError,
+    };
+}

--- a/src/utils/vehicleImportPlan.js
+++ b/src/utils/vehicleImportPlan.js
@@ -223,8 +223,10 @@ export function buildImportPlan(rows, { vehicles = [], manufacturers = [], tags 
                 warnings.push(`Already inherits from another vehicle — "${row.inheritsFrom}" ignored.`);
             } else {
                 const resolved = resolveInheritRef(row.inheritsFrom, vehicles, rowsByName);
-                if (resolved.error) errors.push(`inherits_from: ${resolved.error}`);
-                else if (resolved.rowIndex === i) errors.push('inherits_from: a vehicle cannot inherit from itself.');
+                // An unusable link is reported and dropped, not fatal — the rest
+                // of the row is still worth importing.
+                if (resolved.error) warnings.push(`inherits_from: ${resolved.error} — link skipped.`);
+                else if (resolved.rowIndex === i) warnings.push('inherits_from: a vehicle cannot inherit from itself — link skipped.');
                 else inherit = resolved;
             }
         }
@@ -259,6 +261,8 @@ export function buildImportPlan(rows, { vehicles = [], manufacturers = [], tags 
             tagNames,
             inherit,
             inheritRef: inherit ? row.inheritsFrom : null,
+            fieldSkips: row.skipped,   // values that could not be read — reported, not written
+            coercions: row.coercions,  // loose enum matches, shown so they can be checked
             errors,
             warnings,
         };
@@ -273,6 +277,8 @@ export function buildImportPlan(rows, { vehicles = [], manufacturers = [], tags 
         fieldWrites: planned
             .filter(r => r.action !== 'error')
             .reduce((n, r) => n + r.specWrites.length + Object.keys(r.coreWrites).length, 0),
+        fieldSkips:  planned.reduce((n, r) => n + r.fieldSkips.length, 0),
+        coercions:   planned.reduce((n, r) => n + r.coercions.length, 0),
         newManufacturers: [...newManufacturers.values()],
         newTags: [...newTags.values()],
     };

--- a/src/utils/vehicleImportPlan.js
+++ b/src/utils/vehicleImportPlan.js
@@ -1,0 +1,355 @@
+/**
+ * Bulk vehicle import planner — diffs parsed rows (from parseVehicleImport) against
+ * the vehicles already in the database and produces an executable, reviewable plan.
+ *
+ * Merge policy is fill-blanks: an existing non-empty value is never overwritten.
+ * A row that matches an existing vehicle only writes the fields that are currently
+ * empty, so the same file can be re-uploaded safely after it has been expanded.
+ *
+ * Pure module — the plan it returns is handed to AppContext.importVehicles() to run.
+ */
+import { SPEC_CATEGORIES } from './vehicleSpecSchema';
+import { vehicleLabel } from './specHelpers';
+
+const isBlank = v => v === null || v === undefined || v === '';
+
+const lower = s => String(s ?? '').trim().toLowerCase();
+
+// Core columns written straight to the vehicles row (manufacturer is resolved separately).
+const CORE_WRITE_FIELDS = ['name', 'make', 'model', 'trim', 'year', 'battery', 'range', 'power'];
+
+const FIELD_LABELS = new Map();
+for (const cat of SPEC_CATEGORIES) {
+    for (const field of cat.fields) {
+        FIELD_LABELS.set(`${cat.key}.${field.key}`, `${cat.label} › ${field.label}`);
+    }
+}
+
+/** Human-readable label for a written field path, for the preview table. */
+export function fieldPathLabel(path) {
+    return FIELD_LABELS.get(path) ?? path;
+}
+
+// ── Matching ─────────────────────────────────────────────────────────────────
+
+/**
+ * Find the existing vehicle a row refers to: explicit id wins, then an exact
+ * (case-insensitive) name match, then a full make/model/trim/year match.
+ * Returns { vehicle, by } or { vehicle: null }.
+ */
+function matchExisting(row, vehicles) {
+    if (row.core.id != null) {
+        const byId = vehicles.find(v => Number(v.id) === Number(row.core.id));
+        return { vehicle: byId ?? null, by: byId ? 'id' : null, missingId: !byId };
+    }
+    if (row.core.name) {
+        const byName = vehicles.find(v => lower(v.name) === lower(row.core.name));
+        if (byName) return { vehicle: byName, by: 'name' };
+    }
+    const { make, model, trim, year } = row.core;
+    const makeName = make || row.manufacturerName;
+    if (makeName && model) {
+        const byParts = vehicles.find(v =>
+            lower(v.make) === lower(makeName) &&
+            lower(v.model) === lower(model) &&
+            lower(v.trim) === lower(trim) &&
+            lower(v.year) === lower(year)
+        );
+        if (byParts) return { vehicle: byParts, by: 'make/model/trim/year' };
+    }
+    return { vehicle: null, by: null };
+}
+
+/**
+ * Resolve an "inherits from" reference to an existing vehicle id, or to another
+ * row in the same file (resolved after that row's vehicle is created).
+ */
+function resolveInheritRef(ref, vehicles, rowsByName) {
+    const asNumber = Number(ref);
+    if (Number.isFinite(asNumber) && String(asNumber) === String(ref).trim()) {
+        const byId = vehicles.find(v => Number(v.id) === asNumber);
+        return byId ? { vehicleId: byId.id } : { error: `No vehicle with id ${ref}` };
+    }
+    const key = lower(ref);
+    const byName = vehicles.find(v => lower(v.name) === key || lower(vehicleLabel(v)) === key);
+    if (byName) return { vehicleId: byName.id };
+    if (rowsByName.has(key)) return { rowIndex: rowsByName.get(key) };
+    return { error: `"${ref}" matches no existing vehicle or row in this file` };
+}
+
+// ── Spec merging ─────────────────────────────────────────────────────────────
+
+/**
+ * Merge a row's specs into a vehicle's own specs, filling blanks only.
+ *
+ * Returns the full merged blob (updateVehicleSpecs replaces the whole JSONB
+ * column, so the caller must send everything), plus the written/skipped paths
+ * for the preview.
+ */
+function mergeSpecs(existingSpecs, row) {
+    const merged = {};
+    for (const [catKey, catData] of Object.entries(existingSpecs || {})) {
+        merged[catKey] = { ...catData, ...(catData?._custom ? { _custom: { ...catData._custom } } : {}) };
+    }
+
+    const written = [];
+    const skipped = [];
+
+    for (const [catKey, fields] of Object.entries(row.specs)) {
+        for (const [fieldKey, value] of Object.entries(fields)) {
+            const current = merged[catKey]?.[fieldKey];
+            const path = `${catKey}.${fieldKey}`;
+            if (isBlank(current)) {
+                merged[catKey] = { ...merged[catKey], [fieldKey]: value };
+                written.push({ path, value });
+            } else {
+                skipped.push({ path, value, current });
+            }
+        }
+    }
+
+    for (const [catKey, customFields] of Object.entries(row.custom)) {
+        for (const [customKey, value] of Object.entries(customFields)) {
+            const current = merged[catKey]?._custom?.[customKey];
+            const path = `${catKey}._custom.${customKey}`;
+            if (isBlank(current)) {
+                merged[catKey] = {
+                    ...merged[catKey],
+                    _custom: { ...(merged[catKey]?._custom || {}), [customKey]: value },
+                };
+                written.push({ path, value });
+            } else {
+                skipped.push({ path, value, current });
+            }
+        }
+    }
+
+    return { merged, written, skipped };
+}
+
+// ── Plan builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the import plan.
+ *
+ * @param {Array}  rows            parsed rows from parseVehicleImportText
+ * @param {Object} ctx             { vehicles, manufacturers, tags } current app state
+ * @returns {{ rows: Array, summary: Object }}
+ *
+ * Each planned row carries everything the executor needs:
+ *   action           'create' | 'update' | 'skip' | 'error'
+ *   label            display name for the preview
+ *   vehicleId        matched existing vehicle (update only)
+ *   coreWrites       { field: value } to write to the vehicles row
+ *   mergedSpecs      full specs blob to persist (write it only if needsSpecWrite)
+ *   specWrites       [{ path, value }] filled fields, for the preview
+ *   specSkips        [{ path, value, current }] fields left alone
+ *   manufacturerName brand to attach (existing or newly created)
+ *   tagNames         tags to attach (union with the vehicle's current tags)
+ *   inherit          { vehicleId } | { rowIndex } | null
+ */
+export function buildImportPlan(rows, { vehicles = [], manufacturers = [], tags = [] } = {}) {
+    // Name → row index, so inherits_from can point at a vehicle created by this same file.
+    const rowsByName = new Map();
+    rows.forEach((row, i) => {
+        if (row.core.name) rowsByName.set(lower(row.core.name), i);
+    });
+
+    const seenNames = new Set();
+    const newManufacturers = new Map(); // lowercased name → display name
+    const newTags = new Map();
+
+    const planned = rows.map((row, i) => {
+        const errors = [...row.errors];
+        const warnings = [...row.warnings];
+
+        const { vehicle: existing, by, missingId } = matchExisting(row, vehicles);
+        if (missingId) errors.push(`No vehicle with id ${row.core.id}.`);
+
+        const label = row.core.name
+            || [row.core.year, row.manufacturerName || row.core.make, row.core.model, row.core.trim].filter(Boolean).join(' ')
+            || (existing ? vehicleLabel(existing) : `Row ${row.index + 1}`);
+
+        // Duplicate names inside one file would race each other on create.
+        const nameKey = lower(row.core.name);
+        if (nameKey) {
+            if (seenNames.has(nameKey)) errors.push('Duplicate of an earlier row with the same name.');
+            else seenNames.add(nameKey);
+        }
+
+        // ── Manufacturer ──
+        let manufacturerName = null;
+        let manufacturerIsNew = false;
+        const mfgRef = row.manufacturerName || (!existing ? row.core.make : null);
+        if (mfgRef) {
+            const found = manufacturers.find(m => lower(m.name) === lower(mfgRef));
+            // Only attach a brand when the vehicle doesn't already have one (fill-blanks).
+            if (!existing || !existing.manufacturer) {
+                manufacturerName = found ? found.name : mfgRef;
+                manufacturerIsNew = !found;
+                if (!found) newManufacturers.set(lower(mfgRef), mfgRef);
+            }
+        }
+
+        // ── Core fields ──
+        const coreWrites = {};
+        for (const key of CORE_WRITE_FIELDS) {
+            const incoming = row.core[key];
+            if (isBlank(incoming)) continue;
+            if (!existing || isBlank(existing[key])) coreWrites[key] = incoming;
+        }
+        // A brand implies the make text when the vehicle has none of its own.
+        if (manufacturerName && isBlank(coreWrites.make) && (!existing || isBlank(existing.make))) {
+            coreWrites.make = manufacturerName;
+        }
+        if (!existing && !coreWrites.name) {
+            coreWrites.name = label;
+        }
+
+        // ── Specs ──
+        const { merged, written, skipped } = mergeSpecs(existing?.specs, row);
+
+        // ── Tags ──
+        const currentTagNames = new Set((existing?.tags || []).map(t => lower(t.name)));
+        const tagNames = row.tagNames.filter(name => !currentTagNames.has(lower(name)));
+        for (const name of tagNames) {
+            if (!tags.some(t => lower(t.name) === lower(name))) newTags.set(lower(name), name);
+        }
+
+        // ── Inheritance link ──
+        let inherit = null;
+        if (row.inheritsFrom) {
+            if (existing?.spec_source_vehicle_id) {
+                warnings.push(`Already inherits from another vehicle — "${row.inheritsFrom}" ignored.`);
+            } else {
+                const resolved = resolveInheritRef(row.inheritsFrom, vehicles, rowsByName);
+                if (resolved.error) errors.push(`inherits_from: ${resolved.error}`);
+                else if (resolved.rowIndex === i) errors.push('inherits_from: a vehicle cannot inherit from itself.');
+                else inherit = resolved;
+            }
+        }
+
+        const hasWork = Object.keys(coreWrites).length > 0
+            || written.length > 0
+            || tagNames.length > 0
+            || !!manufacturerName
+            || !!inherit;
+
+        let action;
+        if (errors.length) action = 'error';
+        else if (!existing) action = 'create';
+        else if (hasWork) action = 'update';
+        else action = 'skip';
+
+        return {
+            index: row.index,
+            label,
+            action,
+            matchedBy: by,
+            vehicleId: existing?.id ?? null,
+            coreWrites,
+            // Always the FULL blob — updateVehicleSpecs replaces the whole JSONB
+            // column, so a link-only write must still carry the existing specs.
+            mergedSpecs: merged,
+            needsSpecWrite: written.length > 0 || !!inherit,
+            specWrites: written,
+            specSkips: skipped,
+            manufacturerName,
+            manufacturerIsNew,
+            tagNames,
+            inherit,
+            inheritRef: inherit ? row.inheritsFrom : null,
+            errors,
+            warnings,
+        };
+    });
+
+    const summary = {
+        total:    planned.length,
+        creates:  planned.filter(r => r.action === 'create').length,
+        updates:  planned.filter(r => r.action === 'update').length,
+        skips:    planned.filter(r => r.action === 'skip').length,
+        errors:   planned.filter(r => r.action === 'error').length,
+        fieldWrites: planned
+            .filter(r => r.action !== 'error')
+            .reduce((n, r) => n + r.specWrites.length + Object.keys(r.coreWrites).length, 0),
+        newManufacturers: [...newManufacturers.values()],
+        newTags: [...newTags.values()],
+    };
+
+    return { rows: planned, summary };
+}
+
+/**
+ * Narrow a plan to the rows the user ticked in the preview.
+ *
+ * Deselected rows are demoted to 'skip' rather than removed — inherits_from
+ * references point at plan-row indexes, so the array must keep its shape.
+ */
+export function selectPlanRows(plan, selectedIndexes) {
+    const rows = plan.rows.map((row, i) =>
+        selectedIndexes.has(i) ? row : { ...row, action: 'skip' }
+    );
+    const kept = rows.filter(r => r.action === 'create' || r.action === 'update');
+    const keptTagNames = new Set(kept.flatMap(r => r.tagNames.map(lower)));
+
+    return {
+        rows,
+        summary: {
+            ...plan.summary,
+            creates: kept.filter(r => r.action === 'create').length,
+            updates: kept.filter(r => r.action === 'update').length,
+            fieldWrites: kept.reduce((n, r) => n + r.specWrites.length + Object.keys(r.coreWrites).length, 0),
+            newManufacturers: [...new Set(
+                kept.filter(r => r.manufacturerIsNew && r.manufacturerName).map(r => r.manufacturerName)
+            )],
+            newTags: plan.summary.newTags.filter(name => keptTagNames.has(lower(name))),
+        },
+    };
+}
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+// Columns every template leads with, in the order a person would fill them in.
+const TEMPLATE_CORE = ['name', 'manufacturer', 'model', 'trim', 'year', 'battery', 'range', 'tags', 'inherits_from'];
+
+/** Header row + one example row covering every core column and spec field. */
+export function buildCsvTemplate() {
+    const specColumns = SPEC_CATEGORIES.flatMap(cat => cat.fields.map(f => `${cat.key}.${f.key}`));
+    const header = [...TEMPLATE_CORE, ...specColumns];
+    const example = header.map(col => {
+        switch (col) {
+            case 'name':          return 'Model 3 Long Range 2026';
+            case 'manufacturer':  return 'Tesla';
+            case 'model':         return 'Model 3';
+            case 'trim':          return 'Long Range AWD';
+            case 'year':          return '2026';
+            case 'battery':       return '75';
+            case 'range':         return '363';
+            case 'tags':          return 'sedan;awd';
+            case 'inherits_from': return '';
+            default:              return '';
+        }
+    });
+    return `${header.join(',')}\n${example.join(',')}\n`;
+}
+
+/** A single-vehicle JSON skeleton with every spec field present and null. */
+export function buildJsonTemplate() {
+    const specs = {};
+    for (const cat of SPEC_CATEGORIES) {
+        specs[cat.key] = Object.fromEntries(cat.fields.map(f => [f.key, null]));
+    }
+    return JSON.stringify([{
+        name: 'Model 3 Long Range 2026',
+        manufacturer: 'Tesla',
+        model: 'Model 3',
+        trim: 'Long Range AWD',
+        year: 2026,
+        battery: 75,
+        range: 363,
+        tags: ['sedan', 'awd'],
+        inherits_from: null,
+        specs,
+    }], null, 2);
+}

--- a/src/utils/vehicleImportPlan.js
+++ b/src/utils/vehicleImportPlan.js
@@ -8,7 +8,7 @@
  *
  * Pure module — the plan it returns is handed to AppContext.importVehicles() to run.
  */
-import { SPEC_CATEGORIES } from './vehicleSpecSchema';
+import { SPEC_CATEGORIES, formatCustomKey } from './vehicleSpecSchema';
 import { vehicleLabel } from './specHelpers';
 
 const isBlank = v => v === null || v === undefined || v === '';
@@ -28,6 +28,17 @@ for (const cat of SPEC_CATEGORIES) {
 /** Human-readable label for a written field path, for the preview table. */
 export function fieldPathLabel(path) {
     return FIELD_LABELS.get(path) ?? path;
+}
+
+/**
+ * Just the field's own label, without its category — for tight columns where
+ * "Motor Type" reads better than "Powertrain › Motor Type".
+ */
+export function fieldShortLabel(path) {
+    const full = FIELD_LABELS.get(path);
+    if (full) return full.split(' › ').pop();
+    // Custom field path ("interior._custom.cup_holders") or a core column name.
+    return formatCustomKey(path.split('.').pop());
 }
 
 // ── Matching ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds an **Import…** button on the Vehicles tab (contributors/owners) that bulk-creates vehicles and fills in their specs from a single CSV or JSON file — so a whole trim lineup can be added without walking the Add Vehicle form once per car.

## Flow

Drop a file → per-row preview of exactly what will be written → apply. Templates (a 72-column CSV covering every spec field, and a JSON skeleton with all fields present as `null`) download from the modal.

## Loose column matching

A spec field can be named any of these, in snake_case or camelCase:

- qualified path — `powertrain.horsepower_hp`
- bare field key — `horsepower_hp`
- the Compare Specs label — `Horsepower (hp)`
- custom fields — `interior._custom.cup_holders`

Because `vehicleName` / `vehicleId` resolve too, a JSON file exported from the **Edit Specs** modal re-imports as an update with no hand-editing — export a per-vehicle template, fill it in, upload it back.

Columns that match nothing are listed as ignored rather than failing the file; ambiguous ones say to qualify them as `category.field`.

## Cross-linking

Resolved by name, all case-insensitive:

- `manufacturer` — matched to an existing brand, created when missing
- `tags` — comma-separated, matched or created, unioned with current tags (never removes)
- `inherits_from` — another vehicle by name or id, **including a vehicle created by a later row in the same file** (resolved in a second pass)

## Merge policy: fill-blanks

A row matching an existing vehicle (by `id`, then name, then make/model/trim/year) writes only the fields that are currently empty. Existing values are never overwritten, so the same file can be re-uploaded safely as it grows more columns. The preview shows both sides:

> **Writes** — Powertrain › Drive Type → AWD
> **Kept (already set)** — Battery & Charging › Max DC Charge Rate — keeping 250, ignoring 350

Values that can't be coerced (a bad enum, `not-a-number`, `maybe` for a boolean) make the row an error instead of writing junk. Each row has a checkbox if you only want some of them.

## Files

| File | Role |
|---|---|
| `src/utils/parseVehicleImport.js` | file → normalised rows, per-field type coercion |
| `src/utils/vehicleImportPlan.js` | rows → reviewable plan, plus the templates |
| `src/components/ImportVehiclesModal.jsx` | upload → preview → apply |
| `AppContext.importVehicles()` | executes a plan in dependency order (brands/tags → vehicles → specs/tags/links) |

Parsing and planning are pure modules; the modal is presentation plus the apply call. New semantic classes (`.import-table-container`, `.import-badge-*`, `.import-row-detail`, `.import-detail-list`) live in `src/index.css`.

## Testing

Build is green; app loads with zero console or server errors. Parser and planner were exercised against a fixture harness covering enum coercion (`awd`→`AWD`, `SPACESHIP`→error listing valid options), booleans (`yes`/`n`/`maybe`→error), a non-numeric battery, an unknown column, a same-file inheritance reference, a dangling one (→error), fill-blank skips against pre-set specs, and both templates round-tripping with zero unknown columns.

**Not yet exercised:** an actual write against Supabase — the executor path is untested until a real file is run. Suggest a 2-row file for the first go.

**Out of scope:** run `spec_links` (inheriting another vehicle's charging curve) — not included in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)