### PR TITLE
Performance testing: data entry in Tests & Data

### DIFF
--- a/src/components/PerformanceImportModal.jsx
+++ b/src/components/PerformanceImportModal.jsx
@@ -14,7 +14,7 @@ export default function PerformanceImportModal({ vehicle, onImport, onClose }) {
     const [fileName, setFileName] = useState(null);
     const [testType, setTestType] = useState('accel');
     const [sourceName, setSourceName] = useState('');
-    const [youtubeUrl, setYoutubeUrl] = useState('');
+    const [sourceUrl, setSourceUrl] = useState('');
     const [busy, setBusy]         = useState(false);
     const [error, setError]       = useState(null);
 
@@ -38,7 +38,7 @@ export default function PerformanceImportModal({ vehicle, onImport, onClose }) {
         try {
             await onImport(vehicle.id, parsed, {
                 sourceName: sourceName.trim() || null,
-                youtubeUrl: youtubeUrl.trim() || null,
+                sourceUrl: sourceUrl.trim() || null,
             });
             onClose();
         } catch (e) {
@@ -80,11 +80,11 @@ export default function PerformanceImportModal({ vehicle, onImport, onClose }) {
                         />
                     </label>
                     <label className="text-xs flex-1 min-w-[12rem]">
-                        <span className="text-muted block mb-0.5">Video link (optional)</span>
+                        <span className="text-muted block mb-0.5">Source link (optional)</span>
                         <input
-                            type="text" value={youtubeUrl}
-                            onChange={e => setYoutubeUrl(e.target.value)}
-                            placeholder="https://youtu.be/…"
+                            type="text" value={sourceUrl}
+                            onChange={e => setSourceUrl(e.target.value)}
+                            placeholder="https://…"
                             className="form-input text-xs py-1 w-full"
                         />
                     </label>

--- a/src/components/PerformanceImportModal.jsx
+++ b/src/components/PerformanceImportModal.jsx
@@ -1,0 +1,177 @@
+/**
+ * Import a GPS performance-testing CSV as one session for a vehicle.
+ *
+ * Parses in the browser and shows what was found before writing anything — the
+ * file format is transposed (one column per run) and easy to mistake for a
+ * different export, so a preview is the cheapest way to catch a wrong file
+ * before it becomes a session with eight bogus runs in it.
+ */
+import { useState } from 'react';
+import { parsePerformanceCSV } from '../utils/parsePerformanceCSV';
+
+export default function PerformanceImportModal({ vehicle, onImport, onClose }) {
+    const [parsed, setParsed]     = useState(null);
+    const [fileName, setFileName] = useState(null);
+    const [testType, setTestType] = useState('accel');
+    const [sourceName, setSourceName] = useState('');
+    const [youtubeUrl, setYoutubeUrl] = useState('');
+    const [busy, setBusy]         = useState(false);
+    const [error, setError]       = useState(null);
+
+    const handleFile = async (file) => {
+        if (!file) return;
+        setError(null);
+        setParsed(null);
+        setFileName(file.name);
+        try {
+            const result = await parsePerformanceCSV(file, { testType });
+            setParsed(result);
+        } catch (e) {
+            setError(e?.message || 'Could not parse this file.');
+        }
+    };
+
+    const handleImport = async () => {
+        if (!parsed) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await onImport(vehicle.id, parsed, {
+                sourceName: sourceName.trim() || null,
+                youtubeUrl: youtubeUrl.trim() || null,
+            });
+            onClose();
+        } catch (e) {
+            setError(e?.message || 'Import failed.');
+            setBusy(false);
+        }
+    };
+
+    const session = parsed?.session;
+
+    return (
+        <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+            <div className="modal-panel rounded-xl p-5 max-w-2xl w-full max-h-[85vh] overflow-y-auto">
+                <h3 className="section-title mb-1">Import performance testing data</h3>
+                <p className="text-xs text-muted mb-3">
+                    For <span className="font-semibold">{vehicle?.name}</span>. Expects a GPS
+                    testing export with one column per run.
+                </p>
+
+                <div className="flex flex-wrap items-end gap-3 mb-3">
+                    <label className="text-xs">
+                        <span className="text-muted block mb-0.5">Test type</span>
+                        <select
+                            value={testType}
+                            onChange={e => { setTestType(e.target.value); setParsed(null); setFileName(null); }}
+                            className="form-input text-xs py-1 w-32"
+                        >
+                            <option value="accel">Acceleration</option>
+                            <option value="braking">Braking</option>
+                        </select>
+                    </label>
+                    <label className="text-xs flex-1 min-w-[10rem]">
+                        <span className="text-muted block mb-0.5">Source (optional)</span>
+                        <input
+                            type="text" value={sourceName}
+                            onChange={e => setSourceName(e.target.value)}
+                            placeholder="e.g. Out of Spec"
+                            className="form-input text-xs py-1 w-full"
+                        />
+                    </label>
+                    <label className="text-xs flex-1 min-w-[12rem]">
+                        <span className="text-muted block mb-0.5">Video link (optional)</span>
+                        <input
+                            type="text" value={youtubeUrl}
+                            onChange={e => setYoutubeUrl(e.target.value)}
+                            placeholder="https://youtu.be/…"
+                            className="form-input text-xs py-1 w-full"
+                        />
+                    </label>
+                </div>
+
+                {testType === 'braking' && (
+                    <p className="text-[11px] text-amber-600 dark:text-amber-400 mb-2">
+                        Braking exports haven’t been seen yet, so the parser is written against the
+                        acceleration layout. If the import looks wrong, enter the figures by hand as
+                        speed windows instead.
+                    </p>
+                )}
+
+                <input
+                    type="file"
+                    accept=".csv,text/csv"
+                    onChange={e => handleFile(e.target.files?.[0])}
+                    className="form-input text-xs w-full py-1"
+                />
+                {fileName && <p className="text-[11px] text-faint mt-1">{fileName}</p>}
+                {error && <p className="text-xs text-red-500 mt-2">{error}</p>}
+
+                {parsed && (
+                    <div className="mt-3 border rounded-lg p-3 border-[var(--color-border)]">
+                        <div className="font-semibold text-sm mb-1">
+                            {parsed.runs.length} run{parsed.runs.length === 1 ? '' : 's'} found
+                        </div>
+                        <div className="text-xs text-muted mb-2">
+                            {session.locationName && <>{session.locationName} · </>}
+                            {session.testedAt?.replace('T', ' ')}
+                            {session.temperatureF != null && <> · {Math.round(session.temperatureF)}°F</>}
+                            {session.windSpeedMph != null && <> · wind {session.windSpeedMph.toFixed(1)} mph</>}
+                        </div>
+
+                        <table className="w-full text-xs">
+                            <thead>
+                                <tr className="text-faint text-[10px] uppercase tracking-wide">
+                                    <th className="text-left font-semibold py-1">Drive mode</th>
+                                    <th className="text-right font-semibold py-1">0–60</th>
+                                    <th className="text-right font-semibold py-1">0–60 (1ft)</th>
+                                    <th className="text-right font-semibold py-1">Max g</th>
+                                    <th className="text-right font-semibold py-1">Splits</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {parsed.runs.map(r => (
+                                    <tr key={r.sequence} className="border-t border-[var(--color-border)]">
+                                        <td className="py-0.5 text-muted truncate max-w-[12rem]">{r.driveMode || '—'}</td>
+                                        <td className="py-0.5 text-right font-mono">
+                                            {r.zeroTo60Sec != null ? r.zeroTo60Sec.toFixed(3) : '—'}
+                                        </td>
+                                        <td className="py-0.5 text-right font-mono text-muted">
+                                            {r.zeroTo60RolloutSec != null ? r.zeroTo60RolloutSec.toFixed(3) : '—'}
+                                        </td>
+                                        <td className="py-0.5 text-right font-mono">
+                                            {r.maxGForce != null ? r.maxGForce.toFixed(3) : '—'}
+                                        </td>
+                                        <td className="py-0.5 text-right font-mono text-faint">{r.splits.length}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+
+                        {parsed.warnings.length > 0 && (
+                            <ul className="mt-2 text-[11px] text-amber-600 dark:text-amber-400 list-disc list-inside">
+                                {parsed.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                            </ul>
+                        )}
+                        <p className="text-[10px] text-faint mt-2">
+                            The two 0–60 columns are different conventions, not a duplicate: the first
+                            starts the clock at 0 mph, the second allows the 1 ft drag-strip rollout.
+                        </p>
+                    </div>
+                )}
+
+                <div className="flex gap-2 mt-4">
+                    <button
+                        type="button" onClick={handleImport} disabled={!parsed || busy}
+                        className="btn btn-primary text-sm disabled:opacity-50"
+                    >
+                        {busy ? 'Importing…' : `Import ${parsed?.runs.length || ''} run${parsed?.runs.length === 1 ? '' : 's'}`}
+                    </button>
+                    <button type="button" onClick={onClose} disabled={busy} className="btn btn-secondary text-sm">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/PerformanceVehicleSection.jsx
+++ b/src/components/PerformanceVehicleSection.jsx
@@ -113,8 +113,9 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
         }
     };
 
-    const saveSummaryField = async (id, field, value) => {
-        await savePerformanceSummary({ id, [field]: value });
+    /** Commit a card's buffered edits in one write. */
+    const saveSummaryFields = async (id, fields) => {
+        await savePerformanceSummary({ id, ...fields });
         reload();
     };
 
@@ -190,7 +191,7 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
                         key={s.id}
                         summary={s}
                         canEdit={canEdit}
-                        onSaveField={saveSummaryField}
+                        onSaveFields={saveSummaryFields}
                         onDelete={handleDeleteSummary}
                         onSaveInterval={handleSaveInterval}
                         onDeleteInterval={handleDeleteInterval}

--- a/src/components/PerformanceVehicleSection.jsx
+++ b/src/components/PerformanceVehicleSection.jsx
@@ -12,7 +12,7 @@
  * Measured values are derived from the sessions at read time and shown in their
  * own panel, so a measured number is never confused with a published claim.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import InfoIcon from './InfoIcon';
 import MeasuredValues from './performance/MeasuredValues';
@@ -37,7 +37,10 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
     } = useAppContext();
 
     const [sessions, setSessions] = useState([]);
-    const [loading, setLoading]   = useState(false);
+    // `loaded`, not `loading`: starting from "not yet loaded" means the empty
+    // state can never flash before the first fetch has had a chance to run.
+    const [loaded, setLoaded]     = useState(false);
+    const [reloadToken, setReloadToken] = useState(0);
     const [showImport, setShowImport] = useState(false);
     const [addingResult, setAddingResult] = useState(false);
     const [newSource, setNewSource] = useState('');
@@ -48,26 +51,41 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
     // charts); sessions are fetched per vehicle since they're only needed here.
     const summaries = vehicle?.performance_summaries ?? [];
 
-    const loadSessions = useCallback(async () => {
-        if (!vehicle?.id) return;
-        setLoading(true);
-        try {
-            setSessions(await getPerformanceSessions(vehicle.id));
-        } finally {
-            setLoading(false);
-        }
-    }, [vehicle?.id, getPerformanceSessions]);
+    // AppContext rebuilds its value object every render, so every function it
+    // hands out is a new identity each time. Depending on one directly would
+    // re-fire this effect on every context render — refetching constantly and
+    // flickering the panel. Read it through a ref so the effect depends only on
+    // what actually changes: the vehicle, and an explicit reload.
+    const getSessionsRef = useRef(getPerformanceSessions);
+    getSessionsRef.current = getPerformanceSessions;
 
-    useEffect(() => { loadSessions(); }, [loadSessions]);
+    useEffect(() => {
+        if (!vehicle?.id) { setSessions([]); setLoaded(true); return; }
+        // Guards against a slow response for a previous vehicle landing after a
+        // faster one for the vehicle now on screen.
+        let cancelled = false;
+        setLoaded(false);
+        (async () => {
+            try {
+                const rows = await getSessionsRef.current(vehicle.id);
+                if (!cancelled) setSessions(rows);
+            } finally {
+                if (!cancelled) setLoaded(true);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [vehicle?.id, reloadToken]);
+
+    const reloadSessions = () => setReloadToken(t => t + 1);
 
     const handleImport = async (vehicleId, parsed, meta) => {
         await importPerformanceSession(vehicleId, parsed, meta);
-        await loadSessions();
+        reloadSessions();
     };
 
     const handleDeleteSession = async (id) => {
         await deletePerformanceSession(id);
-        await loadSessions();
+        reloadSessions();
     };
 
     const handleAddResult = async () => {
@@ -104,7 +122,7 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
             <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
                 Test sessions
             </div>
-            {loading && sessions.length === 0 ? (
+            {!loaded ? (
                 <p className="text-sm text-muted mb-2">Loading…</p>
             ) : sessions.length === 0 ? (
                 <p className="text-sm text-muted mb-2">

--- a/src/components/PerformanceVehicleSection.jsx
+++ b/src/components/PerformanceVehicleSection.jsx
@@ -28,6 +28,7 @@ const SECTION_HELP =
 export default function PerformanceVehicleSection({ vehicle, canEdit }) {
     const {
         getPerformanceSessions,
+        getPerformanceSummaries,
         importPerformanceSession,
         deletePerformanceSession,
         savePerformanceSummary,
@@ -47,28 +48,33 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
     const [newTrim, setNewTrim]     = useState('');
     const [creating, setCreating]   = useState(false);
 
-    // Summaries ride along on the vehicle record (they feed the comparison
-    // charts); sessions are fetched per vehicle since they're only needed here.
-    const summaries = vehicle?.performance_summaries ?? [];
+    // Summaries are fetched here rather than read off the vehicle record:
+    // getVehicles() deliberately does NOT embed them, because a nested select
+    // against a table that doesn't exist yet fails the whole vehicles query and
+    // blanks the app (see the note in DataService.getVehicles).
+    const [summaries, setSummaries] = useState([]);
 
     // AppContext rebuilds its value object every render, so every function it
     // hands out is a new identity each time. Depending on one directly would
     // re-fire this effect on every context render — refetching constantly and
     // flickering the panel. Read it through a ref so the effect depends only on
     // what actually changes: the vehicle, and an explicit reload.
-    const getSessionsRef = useRef(getPerformanceSessions);
-    getSessionsRef.current = getPerformanceSessions;
+    const fetchersRef = useRef(null);
+    fetchersRef.current = { getPerformanceSessions, getPerformanceSummaries };
 
     useEffect(() => {
-        if (!vehicle?.id) { setSessions([]); setLoaded(true); return; }
+        if (!vehicle?.id) { setSessions([]); setSummaries([]); setLoaded(true); return; }
         // Guards against a slow response for a previous vehicle landing after a
         // faster one for the vehicle now on screen.
         let cancelled = false;
         setLoaded(false);
         (async () => {
             try {
-                const rows = await getSessionsRef.current(vehicle.id);
-                if (!cancelled) setSessions(rows);
+                const [s, sum] = await Promise.all([
+                    fetchersRef.current.getPerformanceSessions(vehicle.id),
+                    fetchersRef.current.getPerformanceSummaries(vehicle.id),
+                ]);
+                if (!cancelled) { setSessions(s); setSummaries(sum); }
             } finally {
                 if (!cancelled) setLoaded(true);
             }
@@ -76,16 +82,18 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
         return () => { cancelled = true; };
     }, [vehicle?.id, reloadToken]);
 
-    const reloadSessions = () => setReloadToken(t => t + 1);
+    /** Re-run the fetch effect. Every mutation below routes through this, since
+     *  this component owns the sessions and summaries lists. */
+    const reload = () => setReloadToken(t => t + 1);
 
     const handleImport = async (vehicleId, parsed, meta) => {
         await importPerformanceSession(vehicleId, parsed, meta);
-        reloadSessions();
+        reload();
     };
 
     const handleDeleteSession = async (id) => {
         await deletePerformanceSession(id);
-        reloadSessions();
+        reload();
     };
 
     const handleAddResult = async () => {
@@ -99,13 +107,31 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
             setNewSource('');
             setNewTrim('');
             setAddingResult(false);
+            reload();
         } finally {
             setCreating(false);
         }
     };
 
-    const saveSummaryField = (id, field, value) =>
-        savePerformanceSummary({ id, [field]: value });
+    const saveSummaryField = async (id, field, value) => {
+        await savePerformanceSummary({ id, [field]: value });
+        reload();
+    };
+
+    const handleDeleteSummary = async (id) => {
+        await deletePerformanceSummary(id);
+        reload();
+    };
+
+    const handleSaveInterval = async (row) => {
+        await savePerformanceInterval(row);
+        reload();
+    };
+
+    const handleDeleteInterval = async (id) => {
+        await deletePerformanceInterval(id);
+        reload();
+    };
 
     return (
         <div className="mt-6">
@@ -165,9 +191,9 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
                         summary={s}
                         canEdit={canEdit}
                         onSaveField={saveSummaryField}
-                        onDelete={deletePerformanceSummary}
-                        onSaveInterval={savePerformanceInterval}
-                        onDeleteInterval={deletePerformanceInterval}
+                        onDelete={handleDeleteSummary}
+                        onSaveInterval={handleSaveInterval}
+                        onDeleteInterval={handleDeleteInterval}
                     />
                 ))
             )}

--- a/src/components/PerformanceVehicleSection.jsx
+++ b/src/components/PerformanceVehicleSection.jsx
@@ -1,0 +1,215 @@
+/**
+ * Performance testing section — shown in the Tests & Data (RunsView) panel,
+ * alongside the EPA section.
+ *
+ * Two independent layers, deliberately kept visually separate:
+ *   • Test sessions — detail data imported from a GPS testing export, with
+ *     every individual run and its conditions.
+ *   • Reported results — published figures from a source, often the ONLY data
+ *     available for a car (a 0-60 and a video link, no CSV behind it). This is
+ *     the normal case, not a degraded one.
+ *
+ * Measured values are derived from the sessions at read time and shown in their
+ * own panel, so a measured number is never confused with a published claim.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useAppContext } from '../context/AppContext';
+import InfoIcon from './InfoIcon';
+import MeasuredValues from './performance/MeasuredValues';
+import PerformanceSessionCard from './performance/PerformanceSessionCard';
+import PerformanceSummaryCard from './performance/PerformanceSummaryCard';
+import PerformanceImportModal from './PerformanceImportModal';
+
+const SECTION_HELP =
+    'Independently-tested acceleration and braking results. Separate from the ' +
+    'Performance specs on the vehicle record, which are manufacturer claims and ' +
+    'published road-test figures rather than measurements taken here.';
+
+export default function PerformanceVehicleSection({ vehicle, canEdit }) {
+    const {
+        getPerformanceSessions,
+        importPerformanceSession,
+        deletePerformanceSession,
+        savePerformanceSummary,
+        deletePerformanceSummary,
+        savePerformanceInterval,
+        deletePerformanceInterval,
+    } = useAppContext();
+
+    const [sessions, setSessions] = useState([]);
+    const [loading, setLoading]   = useState(false);
+    const [showImport, setShowImport] = useState(false);
+    const [addingResult, setAddingResult] = useState(false);
+    const [newSource, setNewSource] = useState('');
+    const [newTrim, setNewTrim]     = useState('');
+    const [creating, setCreating]   = useState(false);
+
+    // Summaries ride along on the vehicle record (they feed the comparison
+    // charts); sessions are fetched per vehicle since they're only needed here.
+    const summaries = vehicle?.performance_summaries ?? [];
+
+    const loadSessions = useCallback(async () => {
+        if (!vehicle?.id) return;
+        setLoading(true);
+        try {
+            setSessions(await getPerformanceSessions(vehicle.id));
+        } finally {
+            setLoading(false);
+        }
+    }, [vehicle?.id, getPerformanceSessions]);
+
+    useEffect(() => { loadSessions(); }, [loadSessions]);
+
+    const handleImport = async (vehicleId, parsed, meta) => {
+        await importPerformanceSession(vehicleId, parsed, meta);
+        await loadSessions();
+    };
+
+    const handleDeleteSession = async (id) => {
+        await deletePerformanceSession(id);
+        await loadSessions();
+    };
+
+    const handleAddResult = async () => {
+        setCreating(true);
+        try {
+            await savePerformanceSummary({
+                vehicle_id: vehicle.id,
+                source_name: newSource.trim() || null,
+                trim_label: newTrim.trim() || null,
+            });
+            setNewSource('');
+            setNewTrim('');
+            setAddingResult(false);
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const saveSummaryField = (id, field, value) =>
+        savePerformanceSummary({ id, [field]: value });
+
+    return (
+        <div className="mt-6">
+            <div className="flex items-center justify-between gap-2 mb-3">
+                <h3 className="section-title">
+                    Performance Testing
+                    <InfoIcon text={SECTION_HELP} position="right" className="ml-1" />
+                </h3>
+            </div>
+
+            <MeasuredValues vehicle={vehicle} sessions={sessions} summaries={summaries} />
+
+            {/* ── Test sessions ─────────────────────────────────────────── */}
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                Test sessions
+            </div>
+            {loading && sessions.length === 0 ? (
+                <p className="text-sm text-muted mb-2">Loading…</p>
+            ) : sessions.length === 0 ? (
+                <p className="text-sm text-muted mb-2">
+                    No testing sessions yet.
+                    {canEdit && ' Import a GPS testing export below, or just add a reported result.'}
+                </p>
+            ) : (
+                sessions.map(s => (
+                    <PerformanceSessionCard
+                        key={s.id}
+                        session={s}
+                        canEdit={canEdit}
+                        onDelete={handleDeleteSession}
+                    />
+                ))
+            )}
+
+            {canEdit && (
+                <button
+                    type="button"
+                    onClick={() => setShowImport(true)}
+                    className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+                >
+                    📄 Import testing CSV
+                </button>
+            )}
+
+            {/* ── Reported results ──────────────────────────────────────── */}
+            <div className="text-faint text-[10px] uppercase tracking-wide mt-4 mb-1 font-semibold">
+                Reported results
+            </div>
+            {summaries.length === 0 ? (
+                <p className="text-sm text-muted mb-2">
+                    No published figures recorded.
+                </p>
+            ) : (
+                summaries.map(s => (
+                    <PerformanceSummaryCard
+                        key={s.id}
+                        summary={s}
+                        canEdit={canEdit}
+                        onSaveField={saveSummaryField}
+                        onDelete={deletePerformanceSummary}
+                        onSaveInterval={savePerformanceInterval}
+                        onDeleteInterval={deletePerformanceInterval}
+                    />
+                ))
+            )}
+
+            {canEdit && !addingResult && (
+                <button
+                    type="button"
+                    onClick={() => setAddingResult(true)}
+                    className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+                >
+                    + Add reported result
+                </button>
+            )}
+
+            {canEdit && addingResult && (
+                <div className="border rounded-lg p-3 border-[var(--color-border)]">
+                    <div className="flex flex-wrap items-end gap-2">
+                        <label className="text-xs">
+                            <span className="text-muted block mb-0.5">Source</span>
+                            <input
+                                type="text" autoFocus value={newSource}
+                                onChange={e => setNewSource(e.target.value)}
+                                placeholder="e.g. Out of Spec"
+                                className="form-input text-xs py-1 w-44"
+                            />
+                        </label>
+                        <label className="text-xs">
+                            <span className="text-muted block mb-0.5">Trim / config</span>
+                            <input
+                                type="text" value={newTrim}
+                                onChange={e => setNewTrim(e.target.value)}
+                                placeholder="e.g. Dual Standard LFP"
+                                className="form-input text-xs py-1 w-48"
+                            />
+                        </label>
+                    </div>
+                    <p className="text-[10px] text-faint mt-1">
+                        Creates an empty result — fill in whichever figures the source actually
+                        reports. Several sources can report the same car.
+                    </p>
+                    <div className="flex gap-2 mt-2">
+                        <button type="button" onClick={handleAddResult} disabled={creating}
+                            className="btn btn-primary text-xs py-1 px-3 disabled:opacity-50">
+                            {creating ? 'Adding…' : 'Add'}
+                        </button>
+                        <button type="button" onClick={() => setAddingResult(false)} disabled={creating}
+                            className="btn btn-secondary text-xs py-1 px-3">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {showImport && (
+                <PerformanceImportModal
+                    vehicle={vehicle}
+                    onImport={handleImport}
+                    onClose={() => setShowImport(false)}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -2803,6 +2803,15 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 </div>
             )}
 
+            {/* ── Performance Testing (acceleration / braking) ──────────────── */}
+            {/* Above EPA: both are independently-measured test data, so they sit
+                next to the charging/range runs, while EPA is certification
+                reference data and reads last. */}
+            <PerformanceVehicleSection
+                vehicle={vehicle}
+                canEdit={isContributor && canEdit(vehicle)}
+            />
+
             {/* ── EPA Testing Data ──────────────────────────────────────────── */}
             <EpaVehicleSection
                 vehicle={vehicle}
@@ -2815,12 +2824,6 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 onUpdateDisplayName={(testGroupId, name) =>
                     updateEpaTestGroup(testGroupId, { display_name: name || null })
                 }
-            />
-
-            {/* ── Performance Testing (acceleration / braking) ──────────────── */}
-            <PerformanceVehicleSection
-                vehicle={vehicle}
-                canEdit={isContributor && canEdit(vehicle)}
             />
         </div>
     );

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -11,6 +11,7 @@ import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 import { RunVoteButtons } from './VoteButtons';
 import EpaVehicleSection from './EpaVehicleSection';
+import PerformanceVehicleSection from './PerformanceVehicleSection';
 import { deriveChargingAxis } from '../utils/deriveChargingAxis';
 import { isTimestampValue, timestampToMs } from '../utils/parseElapsedTime';
 
@@ -2814,6 +2815,12 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                 onUpdateDisplayName={(testGroupId, name) =>
                     updateEpaTestGroup(testGroupId, { display_name: name || null })
                 }
+            />
+
+            {/* ── Performance Testing (acceleration / braking) ──────────────── */}
+            <PerformanceVehicleSection
+                vehicle={vehicle}
+                canEdit={isContributor && canEdit(vehicle)}
             />
         </div>
     );

--- a/src/components/performance/MeasuredValues.jsx
+++ b/src/components/performance/MeasuredValues.jsx
@@ -1,0 +1,81 @@
+/**
+ * Read-only panel of values derived from this vehicle's own test sessions,
+ * shown beside the reported figures so measured and published numbers stay
+ * visually distinct.
+ *
+ * Nothing here is stored — every value is recomputed from the session data by
+ * performanceDerivations, so it can never drift from the runs behind it. The
+ * badges expose the provenance record's own confidence rather than presenting
+ * one confident number.
+ */
+import { PERFORMANCE_METRICS, resolveAll } from '../../utils/performanceDerivations';
+
+const FLAG_NOTES = {
+    'single-run': 'Backed by a single run — could be a fluke.',
+    'steep-grade': 'Best run was on a noticeable grade, which flatters or penalises the time.',
+    'multiple-sources': 'Sources disagree on this figure.',
+    'rollout-convention-unknown': 'The manufacturer does not state whether this uses rollout.',
+};
+
+function SourceBadge({ record }) {
+    if (!record?.source) return null;
+    const style = record.source === 'measured'
+        ? (record.certain
+            ? 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-900/30 dark:border-green-700'
+            : 'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-900/30 dark:border-amber-700')
+        : 'text-muted bg-[var(--color-surface-muted)] border-[var(--color-border)]';
+    return (
+        <span className={`text-[9px] px-1 py-0.5 rounded border font-medium ${style}`}>
+            {record.source}
+        </span>
+    );
+}
+
+export default function MeasuredValues({ vehicle, sessions = [], summaries = [] }) {
+    const resolved = resolveAll(vehicle, sessions, summaries);
+    const rows = PERFORMANCE_METRICS
+        .map(m => ({ ...m, r: resolved[m.field] }))
+        .filter(({ r }) => r.measured.value != null);
+
+    if (rows.length === 0) return null;
+
+    return (
+        <div className="card p-3 mb-3">
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                Measured from test sessions
+            </div>
+            {rows.map(({ field, label, unit, note, r }) => {
+                const m = r.measured;
+                const flagText = m.flags.map(f => FLAG_NOTES[f]).filter(Boolean).join(' ');
+                return (
+                    <div key={field} className="flex items-center justify-between gap-3 py-0.5 text-xs">
+                        <span className="text-muted flex items-center gap-1 min-w-0">
+                            <span className="truncate">{label}</span>
+                            {note && <span className="text-faint text-[10px]">({note})</span>}
+                            <SourceBadge record={m} />
+                            {flagText && (
+                                <span className="text-amber-500 text-[9px]" title={flagText}>⚠</span>
+                            )}
+                        </span>
+                        <span className="font-mono shrink-0" title={
+                            m.basis?.drive_mode
+                                ? `Best of ${m.basis.comparable_run_count} run(s) in "${m.basis.drive_mode}"`
+                                : undefined
+                        }>
+                            {m.value.toFixed(3)} {unit}
+                            {m.basis?.spread && (
+                                <span className="text-faint ml-1">
+                                    ({m.basis.spread.min.toFixed(3)}–{m.basis.spread.max.toFixed(3)})
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                );
+            })}
+            <p className="text-[10px] text-faint mt-1">
+                Best run, with the spread across comparable runs in the same drive mode.
+                Recomputed from the session data — never stored.
+            </p>
+        </div>
+    );
+}

--- a/src/components/performance/PerformanceIntervals.jsx
+++ b/src/components/performance/PerformanceIntervals.jsx
@@ -1,0 +1,232 @@
+/**
+ * Speed-window results for one reported result — braking distances, passing
+ * times, and any acceleration window beyond the promoted 0-60.
+ *
+ * Windows vary by source (75-0 / 70-0 / 60-0; 50-80 / 50-90) and may be metric,
+ * so each row carries its own from/to speeds and units rather than assuming a
+ * fixed set. Values are stored exactly as reported; the average-rate column is
+ * derived at read time so windows that aren't otherwise comparable can still be
+ * read against each other.
+ */
+import { useState } from 'react';
+import { normaliseInterval } from '../../utils/performanceDerivations';
+
+const BLANK = {
+    kind: 'braking',
+    from_speed: '',
+    to_speed: '0',
+    speed_unit: 'mph',
+    elapsed_s: '',
+    distance: '',
+    distance_unit: 'ft',
+};
+
+/** Rate cell — braking is trustworthy across windows, timed windows are not. */
+function RateCell({ row }) {
+    const n = normaliseInterval(row);
+    if (n.rateG == null) return <span className="text-faint">—</span>;
+    return (
+        <span
+            className={n.rateCertain ? 'font-mono' : 'font-mono text-muted italic'}
+            title={n.rateCertain
+                ? 'Average deceleration. Braking is grip-limited, so this is comparable across different speed windows.'
+                : 'Average acceleration — indicative only. The rate falls away at higher speeds, so windows covering different speed ranges are not directly comparable.'}
+        >
+            {n.rateG.toFixed(3)} g{!n.rateCertain && '*'}
+        </span>
+    );
+}
+
+export default function PerformanceIntervals({ intervals = [], canEdit, onSave, onDelete }) {
+    const [draft, setDraft]   = useState(null);   // null = not adding
+    const [saving, setSaving] = useState(false);
+    const [error, setError]   = useState(null);
+
+    const isBraking = draft?.kind === 'braking';
+
+    const submit = async () => {
+        setError(null);
+        const from = Number(draft.from_speed);
+        if (!Number.isFinite(from)) { setError('From speed is required.'); return; }
+        const measure = isBraking ? Number(draft.distance) : Number(draft.elapsed_s);
+        if (!Number.isFinite(measure)) {
+            setError(isBraking ? 'Distance is required.' : 'Time is required.');
+            return;
+        }
+        setSaving(true);
+        try {
+            await onSave({
+                kind: draft.kind,
+                from_speed: from,
+                to_speed: Number(draft.to_speed) || 0,
+                speed_unit: draft.speed_unit,
+                elapsed_s: isBraking ? null : measure,
+                distance: isBraking ? measure : null,
+                distance_unit: draft.distance_unit,
+            });
+            setDraft(null);
+        } catch (e) {
+            setError(e?.message || 'Save failed');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="mt-2">
+            <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                Speed windows
+            </div>
+
+            {intervals.length === 0 && !draft && (
+                <p className="text-faint text-[11px] italic">
+                    No braking or passing figures yet.
+                </p>
+            )}
+
+            {intervals.length > 0 && (
+                <table className="w-full text-xs">
+                    <tbody>
+                        {intervals.map(iv => {
+                            const n = normaliseInterval(iv);
+                            return (
+                                <tr key={iv.id} className="border-b border-[var(--color-border)] last:border-0">
+                                    <td className="py-0.5 pr-2 text-muted">{n.label}</td>
+                                    <td className="py-0.5 pr-2 capitalize text-faint">{iv.kind}</td>
+                                    <td className="py-0.5 pr-2 font-mono text-right">
+                                        {n.value} {n.displayUnit}
+                                    </td>
+                                    <td className="py-0.5 pr-2 text-right"><RateCell row={iv} /></td>
+                                    {canEdit && (
+                                        <td className="py-0.5 text-right w-6">
+                                            <button
+                                                type="button"
+                                                onClick={() => onDelete(iv.id)}
+                                                className="text-faint hover:text-red-500"
+                                                title="Remove this window"
+                                            >
+                                                ×
+                                            </button>
+                                        </td>
+                                    )}
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            )}
+
+            {canEdit && !draft && (
+                <button
+                    type="button"
+                    onClick={() => { setDraft({ ...BLANK }); setError(null); }}
+                    className="text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline mt-1"
+                >
+                    + Add braking / passing figure
+                </button>
+            )}
+
+            {draft && (
+                <div className="mt-2 border rounded-lg p-2 border-[var(--color-border)]">
+                    <div className="flex flex-wrap items-end gap-2">
+                        <label className="text-[11px]">
+                            <span className="text-muted block">Type</span>
+                            <select
+                                value={draft.kind}
+                                onChange={e => setDraft(d => ({
+                                    ...d,
+                                    kind: e.target.value,
+                                    // Braking runs to a stop; accel starts from one.
+                                    to_speed: e.target.value === 'accel' ? d.to_speed : '0',
+                                    from_speed: e.target.value === 'accel' ? '0' : d.from_speed,
+                                }))}
+                                className="form-input text-xs py-0.5 w-24 mt-0.5"
+                            >
+                                <option value="braking">Braking</option>
+                                <option value="passing">Passing</option>
+                                <option value="accel">Accel</option>
+                            </select>
+                        </label>
+                        <label className="text-[11px]">
+                            <span className="text-muted block">From</span>
+                            <input
+                                type="number" value={draft.from_speed} autoFocus
+                                onChange={e => setDraft(d => ({ ...d, from_speed: e.target.value }))}
+                                className="form-input text-xs py-0.5 w-16 mt-0.5 font-mono"
+                            />
+                        </label>
+                        <label className="text-[11px]">
+                            <span className="text-muted block">To</span>
+                            <input
+                                type="number" value={draft.to_speed}
+                                onChange={e => setDraft(d => ({ ...d, to_speed: e.target.value }))}
+                                className="form-input text-xs py-0.5 w-16 mt-0.5 font-mono"
+                            />
+                        </label>
+                        <label className="text-[11px]">
+                            <span className="text-muted block">Speed unit</span>
+                            <select
+                                value={draft.speed_unit}
+                                onChange={e => setDraft(d => ({ ...d, speed_unit: e.target.value }))}
+                                className="form-input text-xs py-0.5 w-20 mt-0.5"
+                            >
+                                <option value="mph">mph</option>
+                                <option value="kph">km/h</option>
+                            </select>
+                        </label>
+
+                        {isBraking ? (
+                            <>
+                                <label className="text-[11px]">
+                                    <span className="text-muted block">Distance</span>
+                                    <input
+                                        type="number" step="0.1" value={draft.distance}
+                                        onChange={e => setDraft(d => ({ ...d, distance: e.target.value }))}
+                                        className="form-input text-xs py-0.5 w-20 mt-0.5 font-mono"
+                                    />
+                                </label>
+                                <label className="text-[11px]">
+                                    <span className="text-muted block">Unit</span>
+                                    <select
+                                        value={draft.distance_unit}
+                                        onChange={e => setDraft(d => ({ ...d, distance_unit: e.target.value }))}
+                                        className="form-input text-xs py-0.5 w-16 mt-0.5"
+                                    >
+                                        <option value="ft">ft</option>
+                                        <option value="m">m</option>
+                                    </select>
+                                </label>
+                            </>
+                        ) : (
+                            <label className="text-[11px]">
+                                <span className="text-muted block">Time (s)</span>
+                                <input
+                                    type="number" step="0.001" value={draft.elapsed_s}
+                                    onChange={e => setDraft(d => ({ ...d, elapsed_s: e.target.value }))}
+                                    className="form-input text-xs py-0.5 w-20 mt-0.5 font-mono"
+                                />
+                            </label>
+                        )}
+                    </div>
+
+                    <p className="text-[10px] text-faint mt-1">
+                        Entered as reported — a metric 100–0 km/h stays metric, and is converted
+                        only when comparing.
+                    </p>
+                    {error && <p className="text-[11px] text-red-500 mt-1">{error}</p>}
+
+                    <div className="flex gap-2 mt-2">
+                        <button type="button" onClick={submit} disabled={saving}
+                            className="btn btn-primary text-[11px] py-0.5 px-2 disabled:opacity-50">
+                            {saving ? 'Saving…' : 'Add'}
+                        </button>
+                        <button type="button" onClick={() => setDraft(null)} disabled={saving}
+                            className="btn btn-secondary text-[11px] py-0.5 px-2">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/performance/PerformanceSessionCard.jsx
+++ b/src/components/performance/PerformanceSessionCard.jsx
@@ -1,0 +1,181 @@
+/**
+ * One testing session — a single outing, with its individual runs collapsed
+ * behind a disclosure.
+ *
+ * A session is typically eight launches inside ninety seconds, so the runs are
+ * hidden by default and the card leads with the conditions they share. Per-run
+ * grade and altitude are shown because they vary between runs in the same
+ * session and materially affect the result.
+ */
+import { useState } from 'react';
+import { groupByDriveMode } from '../../utils/performanceDerivations';
+
+const fmt = (v, dp = 1, suffix = '') =>
+    v == null ? null : `${Number(v).toFixed(dp)}${suffix}`;
+
+/** "24 Jul 2026, 10:48" from a zone-less wall-clock string. */
+function formatTestedAt(raw) {
+    if (!raw) return null;
+    const [date, time] = String(raw).split('T');
+    if (!date) return raw;
+    const [y, m, d] = date.split('-').map(Number);
+    const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    const day = `${d} ${months[(m || 1) - 1]} ${y}`;
+    return time ? `${day}, ${time.slice(0, 5)}` : day;
+}
+
+/** Compass point for a meteorological bearing, e.g. 71° → ENE. */
+function compass(deg) {
+    if (deg == null) return '';
+    const points = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
+    return points[Math.round(((deg % 360) / 22.5)) % 16];
+}
+
+function Condition({ label, value }) {
+    if (value == null) return null;
+    return (
+        <span className="text-xs text-muted">
+            <span className="text-faint">{label}</span> {value}
+        </span>
+    );
+}
+
+export default function PerformanceSessionCard({ session, canEdit, onDelete }) {
+    const [open, setOpen]         = useState(false);
+    const [deleting, setDeleting] = useState(false);
+
+    const runs = session.performance_runs || [];
+    const isAccel = session.test_type === 'accel';
+    // Grouping by drive mode is the point of an accel session — it's how you see
+    // what the modes actually cost you.
+    const groups = isAccel ? groupByDriveMode([session], 'zero_to_60_sec') : [];
+
+    const handleDelete = async () => {
+        if (!window.confirm(
+            `Delete this ${session.test_type} session and all ${runs.length} of its runs?\n\nThis cannot be undone.`
+        )) return;
+        setDeleting(true);
+        try { await onDelete(session.id); } finally { setDeleting(false); }
+    };
+
+    return (
+        <div className="card p-3 mb-2">
+            <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                        <span className="font-semibold text-sm">
+                            {formatTestedAt(session.tested_at) || 'Undated session'}
+                        </span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded border font-medium capitalize text-muted bg-[var(--color-surface-muted)] border-[var(--color-border)]">
+                            {session.test_type}
+                        </span>
+                        <span className="text-xs text-faint">{runs.length} runs</span>
+                    </div>
+                    {session.location_name && (
+                        <div className="text-xs text-muted mt-0.5">{session.location_name}</div>
+                    )}
+                    {session.source_name && (
+                        <div className="text-xs text-faint mt-0.5">{session.source_name}</div>
+                    )}
+                </div>
+                {canEdit && (
+                    <button
+                        type="button" onClick={handleDelete} disabled={deleting}
+                        className="btn btn-danger text-xs py-0.5 px-2 disabled:opacity-40"
+                    >
+                        {deleting ? '…' : 'Delete'}
+                    </button>
+                )}
+            </div>
+
+            {/* Conditions shared by every run in the session */}
+            <div className="flex flex-wrap gap-x-4 gap-y-0.5 mt-2">
+                <Condition label="Temp" value={fmt(session.temperature_f, 0, '°F')} />
+                <Condition label="Humidity" value={fmt(session.humidity_pct, 0, '%')} />
+                <Condition label="Pressure" value={fmt(session.pressure_inhg, 2, ' inHg')} />
+                <Condition
+                    label="Wind"
+                    value={session.wind_speed_mph == null ? null
+                        : `${fmt(session.wind_speed_mph, 1, ' mph')}${
+                            session.wind_bearing_deg != null
+                                ? ` from ${Math.round(session.wind_bearing_deg)}° ${compass(session.wind_bearing_deg)}`
+                                : ''}`}
+                />
+                <Condition label="Cloud" value={fmt(session.cloud_cover_pct, 0, '%')} />
+            </div>
+
+            {/* Best per drive mode — the headline comparison for an accel session */}
+            {groups.length > 0 && (
+                <div className="mt-2 pt-2 border-t border-[var(--color-border)]">
+                    <div className="text-faint text-[10px] uppercase tracking-wide mb-1 font-semibold">
+                        Best 0–60 by drive mode
+                    </div>
+                    {groups.map(g => (
+                        <div key={g.driveMode} className="flex justify-between gap-4 text-xs py-0.5">
+                            <span className="text-muted truncate">{g.driveMode}</span>
+                            <span className="font-mono shrink-0">
+                                {g.best.toFixed(3)} s
+                                <span className="text-faint ml-1">({g.count})</span>
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <button
+                type="button"
+                onClick={() => setOpen(o => !o)}
+                className="mt-2 text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+                {open ? '▾ Hide individual runs' : `▸ Show all ${runs.length} runs`}
+            </button>
+
+            {open && (
+                <div className="mt-2 overflow-x-auto">
+                    <table className="w-full text-xs">
+                        <thead>
+                            <tr className="text-faint text-[10px] uppercase tracking-wide">
+                                <th className="text-left font-semibold py-1">#</th>
+                                <th className="text-left font-semibold py-1">Mode</th>
+                                <th className="text-right font-semibold py-1">
+                                    {isAccel ? '0–60' : 'Distance'}
+                                </th>
+                                {isAccel && <th className="text-right font-semibold py-1">0–60 (1ft)</th>}
+                                <th className="text-right font-semibold py-1">Max g</th>
+                                <th className="text-right font-semibold py-1">Grade</th>
+                                <th className="text-right font-semibold py-1">Alt</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {runs.map(r => (
+                                <tr key={r.id} className="border-t border-[var(--color-border)]">
+                                    <td className="py-0.5 text-faint">{(r.sequence ?? 0) + 1}</td>
+                                    <td className="py-0.5 text-muted truncate max-w-[10rem]">{r.drive_mode || '—'}</td>
+                                    <td className="py-0.5 text-right font-mono">
+                                        {isAccel ? fmt(r.zero_to_60_sec, 3, ' s') : fmt(r.braking_distance_ft, 1, ' ft')}
+                                    </td>
+                                    {isAccel && (
+                                        <td className="py-0.5 text-right font-mono text-muted">
+                                            {fmt(r.zero_to_60_rollout_sec, 3) ?? '—'}
+                                        </td>
+                                    )}
+                                    <td className="py-0.5 text-right font-mono">{fmt(r.max_g_force, 3) ?? '—'}</td>
+                                    <td className="py-0.5 text-right font-mono text-muted">
+                                        {r.slope_pct == null ? '—' : `${r.slope_pct > 0 ? '+' : ''}${Number(r.slope_pct).toFixed(2)}%`}
+                                    </td>
+                                    <td className="py-0.5 text-right font-mono text-muted">
+                                        {fmt(r.altitude_ft, 0) ?? '—'}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    <p className="text-[10px] text-faint mt-1">
+                        Grade is signed: + is uphill. Runs on a steeper grade flatter or penalise
+                        the result and are flagged when used as a measured figure.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/performance/PerformanceSummaryCard.jsx
+++ b/src/components/performance/PerformanceSummaryCard.jsx
@@ -1,0 +1,120 @@
+/**
+ * One reported performance result — a published set of figures from a single
+ * source, with its speed-window rows.
+ *
+ * This is the sparse path: most sources supply only a couple of these fields
+ * and a link, with no backing test data, so every field is independently
+ * optional and saved on blur.
+ */
+import { useState } from 'react';
+import CuratorField from '../epa/CuratorField';
+import PerformanceIntervals from './PerformanceIntervals';
+
+export default function PerformanceSummaryCard({
+    summary,
+    canEdit,
+    onSaveField,
+    onDelete,
+    onSaveInterval,
+    onDeleteInterval,
+}) {
+    const [deleting, setDeleting] = useState(false);
+
+    const save = (field) => (value) => onSaveField(summary.id, field, value);
+
+    const handleDelete = async () => {
+        const who = summary.source_name || 'this source';
+        if (!window.confirm(`Delete the reported result from ${who}?`)) return;
+        setDeleting(true);
+        try { await onDelete(summary.id); } finally { setDeleting(false); }
+    };
+
+    return (
+        <div className="card p-3 mb-2">
+            <div className="flex items-start justify-between gap-3 mb-2">
+                <div className="min-w-0 flex-1">
+                    <div className="font-semibold text-sm truncate">
+                        {summary.source_name || <span className="text-faint italic">Unattributed source</span>}
+                    </div>
+                    {summary.trim_label && (
+                        <div className="text-xs text-muted mt-0.5">{summary.trim_label}</div>
+                    )}
+                </div>
+                {canEdit && (
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={deleting}
+                        className="btn btn-danger text-xs py-0.5 px-2 disabled:opacity-40"
+                    >
+                        {deleting ? '…' : 'Delete'}
+                    </button>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
+                <div>
+                    <CuratorField
+                        label="0–60 mph" unit="s" type="number" step="0.001"
+                        tooltip="Clock starts at 0 mph — the figure usually published as “no rollout”."
+                        value={summary.zero_to_60_sec} canEdit={canEdit}
+                        onSave={save('zero_to_60_sec')}
+                    />
+                    <CuratorField
+                        label="0–60 (1ft)" unit="s" type="number" step="0.001"
+                        tooltip="1-foot-rollout figure, the drag-strip convention. Typically ~0.3 s quicker than the no-rollout time — the two are not interchangeable."
+                        value={summary.zero_to_60_rollout_sec} canEdit={canEdit}
+                        onSave={save('zero_to_60_rollout_sec')}
+                    />
+                </div>
+                <div>
+                    <CuratorField
+                        label="¼ mile" unit="s" type="number" step="0.001"
+                        value={summary.quarter_mile_sec} canEdit={canEdit}
+                        onSave={save('quarter_mile_sec')}
+                    />
+                    <CuratorField
+                        label="¼ mile trap" unit="mph" type="number" step="0.01"
+                        value={summary.quarter_mile_trap_mph} canEdit={canEdit}
+                        onSave={save('quarter_mile_trap_mph')}
+                    />
+                </div>
+            </div>
+
+            <PerformanceIntervals
+                intervals={summary.performance_intervals || []}
+                canEdit={canEdit}
+                onSave={(row) => onSaveInterval({ ...row, summary_id: summary.id })}
+                onDelete={onDeleteInterval}
+            />
+
+            {/* Source links — the provenance for figures with no backing data */}
+            <div className="mt-2 pt-2 border-t border-[var(--color-border)] grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
+                <CuratorField
+                    label="Video" value={summary.youtube_url} canEdit={canEdit}
+                    placeholder="https://youtu.be/…" onSave={save('youtube_url')}
+                />
+                <CuratorField
+                    label="Spreadsheet" value={summary.spreadsheet_url} canEdit={canEdit}
+                    placeholder="https://docs.google.com/…" onSave={save('spreadsheet_url')}
+                />
+            </div>
+            {(summary.youtube_url || summary.spreadsheet_url) && (
+                <div className="flex gap-3 mt-1">
+                    {summary.youtube_url && (
+                        <a href={summary.youtube_url} target="_blank" rel="noopener noreferrer"
+                            className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline">
+                            Watch ↗
+                        </a>
+                    )}
+                    {summary.spreadsheet_url && (
+                        <a href={summary.spreadsheet_url} target="_blank" rel="noopener noreferrer"
+                            className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline">
+                            Source data ↗
+                        </a>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/performance/PerformanceSummaryCard.jsx
+++ b/src/components/performance/PerformanceSummaryCard.jsx
@@ -4,23 +4,77 @@
  *
  * This is the sparse path: most sources supply only a couple of these fields
  * and a link, with no backing test data, so every field is independently
- * optional and saved on blur.
+ * optional.
+ *
+ * Edits are BUFFERED and committed with Save, rather than written on every
+ * field exit. Entering a published result means typing six or seven numbers off
+ * one page in a row, and a write per blur turns that into a burst of saves —
+ * noisy, and each one a chance to half-commit a result. Same buffered pattern
+ * the EPA curator form uses; CuratorField already renders a pending marker for it.
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import CuratorField from '../epa/CuratorField';
 import PerformanceIntervals from './PerformanceIntervals';
+
+/** Scalar fields, in entry order. Speed windows are handled separately. */
+const FIELDS = [
+    {
+        key: 'zero_to_60_sec', label: '0–60 mph', unit: 's', step: '0.001',
+        tooltip: 'Clock starts at 0 mph, with no rollout allowance. Sources differ on which of the two 0–60 figures they headline — check the source’s own footnote before entering.',
+    },
+    {
+        key: 'zero_to_60_rollout_sec', label: '0–60 (1ft)', unit: 's', step: '0.001',
+        tooltip: 'The 1-foot-rollout figure, drag-strip convention — about 0.3 s quicker than the no-rollout time. The two are not interchangeable.',
+    },
+    { key: 'quarter_mile_sec',      label: '¼ mile',       unit: 's',   step: '0.001' },
+    { key: 'quarter_mile_trap_mph', label: '¼ mile trap',  unit: 'mph', step: '0.01'  },
+    {
+        key: 'top_speed_mph', label: 'Top speed', unit: 'mph', step: '0.1',
+        tooltip: 'Measured top speed. Often governor-limited rather than aerodynamically limited.',
+    },
+    {
+        key: 'skidpad_g', label: 'Skidpad', unit: 'g', step: '0.001',
+        tooltip: 'Lateral grip, conventionally measured on a 300 ft skidpad.',
+    },
+];
 
 export default function PerformanceSummaryCard({
     summary,
     canEdit,
-    onSaveField,
+    onSaveFields,
     onDelete,
     onSaveInterval,
     onDeleteInterval,
 }) {
+    const [edits, setEdits]       = useState({});
+    const [saving, setSaving]     = useState(false);
     const [deleting, setDeleting] = useState(false);
 
-    const save = (field) => (value) => onSaveField(summary.id, field, value);
+    const dirty = Object.keys(edits).length > 0;
+
+    // A published result is several numbers typed in one sitting; losing them to
+    // a stray refresh would mean re-reading the source.
+    useEffect(() => {
+        if (!dirty) return;
+        const warn = (e) => { e.preventDefault(); e.returnValue = ''; };
+        window.addEventListener('beforeunload', warn);
+        return () => window.removeEventListener('beforeunload', warn);
+    }, [dirty]);
+
+    /** DB truth with buffered edits laid over it. */
+    const shown  = (field) => (field in edits ? edits[field] : summary[field]);
+    const mark   = (field) => (field in edits ? 'pending' : undefined);
+    const buffer = (field) => (value) => setEdits(e => ({ ...e, [field]: value }));
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await onSaveFields(summary.id, edits);
+            setEdits({});
+        } finally {
+            setSaving(false);
+        }
+    };
 
     const handleDelete = async () => {
         const who = summary.source_name || 'this source';
@@ -29,12 +83,19 @@ export default function PerformanceSummaryCard({
         try { await onDelete(summary.id); } finally { setDeleting(false); }
     };
 
+    const changeCount = Object.keys(edits).length;
+
     return (
         <div className="card p-3 mb-2">
             <div className="flex items-start justify-between gap-3 mb-2">
                 <div className="min-w-0 flex-1">
                     <div className="font-semibold text-sm truncate">
                         {summary.source_name || <span className="text-faint italic">Unattributed source</span>}
+                        {dirty && (
+                            <span className="ml-2 text-amber-500 text-[10px] font-normal" title="Unsaved edits">
+                                ● unsaved
+                            </span>
+                        )}
                     </div>
                     {summary.trim_label && (
                         <div className="text-xs text-muted mt-0.5">{summary.trim_label}</div>
@@ -42,9 +103,7 @@ export default function PerformanceSummaryCard({
                 </div>
                 {canEdit && (
                     <button
-                        type="button"
-                        onClick={handleDelete}
-                        disabled={deleting}
+                        type="button" onClick={handleDelete} disabled={deleting || saving}
                         className="btn btn-danger text-xs py-0.5 px-2 disabled:opacity-40"
                     >
                         {deleting ? '…' : 'Delete'}
@@ -53,34 +112,21 @@ export default function PerformanceSummaryCard({
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
-                <div>
+                {FIELDS.map(f => (
                     <CuratorField
-                        label="0–60 mph" unit="s" type="number" step="0.001"
-                        tooltip="Clock starts at 0 mph — the figure usually published as “no rollout”."
-                        value={summary.zero_to_60_sec} canEdit={canEdit}
-                        onSave={save('zero_to_60_sec')}
+                        key={f.key}
+                        label={f.label} unit={f.unit} type="number" step={f.step}
+                        tooltip={f.tooltip}
+                        value={shown(f.key)}
+                        overrideSource={mark(f.key)}
+                        canEdit={canEdit}
+                        onSave={buffer(f.key)}
                     />
-                    <CuratorField
-                        label="0–60 (1ft)" unit="s" type="number" step="0.001"
-                        tooltip="1-foot-rollout figure, the drag-strip convention. Typically ~0.3 s quicker than the no-rollout time — the two are not interchangeable."
-                        value={summary.zero_to_60_rollout_sec} canEdit={canEdit}
-                        onSave={save('zero_to_60_rollout_sec')}
-                    />
-                </div>
-                <div>
-                    <CuratorField
-                        label="¼ mile" unit="s" type="number" step="0.001"
-                        value={summary.quarter_mile_sec} canEdit={canEdit}
-                        onSave={save('quarter_mile_sec')}
-                    />
-                    <CuratorField
-                        label="¼ mile trap" unit="mph" type="number" step="0.01"
-                        value={summary.quarter_mile_trap_mph} canEdit={canEdit}
-                        onSave={save('quarter_mile_trap_mph')}
-                    />
-                </div>
+                ))}
             </div>
 
+            {/* Speed windows write immediately — each is a whole row added or
+                removed in one action, not a field in a form being filled in. */}
             <PerformanceIntervals
                 intervals={summary.performance_intervals || []}
                 canEdit={canEdit}
@@ -91,20 +137,23 @@ export default function PerformanceSummaryCard({
             {/* Source links — the provenance for figures with no backing data */}
             <div className="mt-2 pt-2 border-t border-[var(--color-border)] grid grid-cols-1 sm:grid-cols-2 gap-x-6 text-xs">
                 <CuratorField
-                    label="Video" value={summary.youtube_url} canEdit={canEdit}
-                    placeholder="https://youtu.be/…" onSave={save('youtube_url')}
+                    label="Source link" value={shown('source_url')} canEdit={canEdit}
+                    overrideSource={mark('source_url')}
+                    tooltip="Article, video or post the figures came from."
+                    placeholder="https://…" onSave={buffer('source_url')}
                 />
                 <CuratorField
-                    label="Spreadsheet" value={summary.spreadsheet_url} canEdit={canEdit}
-                    placeholder="https://docs.google.com/…" onSave={save('spreadsheet_url')}
+                    label="Spreadsheet" value={shown('spreadsheet_url')} canEdit={canEdit}
+                    overrideSource={mark('spreadsheet_url')}
+                    placeholder="https://docs.google.com/…" onSave={buffer('spreadsheet_url')}
                 />
             </div>
-            {(summary.youtube_url || summary.spreadsheet_url) && (
+            {(summary.source_url || summary.spreadsheet_url) && (
                 <div className="flex gap-3 mt-1">
-                    {summary.youtube_url && (
-                        <a href={summary.youtube_url} target="_blank" rel="noopener noreferrer"
+                    {summary.source_url && (
+                        <a href={summary.source_url} target="_blank" rel="noopener noreferrer"
                             className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline">
-                            Watch ↗
+                            Open source ↗
                         </a>
                     )}
                     {summary.spreadsheet_url && (
@@ -113,6 +162,23 @@ export default function PerformanceSummaryCard({
                             Source data ↗
                         </a>
                     )}
+                </div>
+            )}
+
+            {canEdit && dirty && (
+                <div className="flex items-center gap-2 mt-3 pt-2 border-t border-[var(--color-border)]">
+                    <button
+                        type="button" onClick={handleSave} disabled={saving}
+                        className="btn btn-primary text-xs py-1 px-3 disabled:opacity-50"
+                    >
+                        {saving ? 'Saving…' : `Save ${changeCount} change${changeCount === 1 ? '' : 's'}`}
+                    </button>
+                    <button
+                        type="button" onClick={() => setEdits({})} disabled={saving}
+                        className="btn btn-secondary text-xs py-1 px-3"
+                    >
+                        Discard
+                    </button>
                 </div>
             )}
         </div>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1091,6 +1091,90 @@ export function AppProvider({ children }) {
     const getEpaAuditForGroup = (testGroupId, childRowIds) =>
         dataService.getEpaAuditForGroup(testGroupId, childRowIds);
 
+    // ── Performance testing (acceleration / braking) ────────────────────────
+
+    /** Sessions (with runs and splits) for one vehicle. Read-only, no refresh. */
+    const getPerformanceSessions = (vehicleId) => dataService.getPerformanceSessions(vehicleId);
+
+    /** Reported summaries with their speed-window intervals, for one vehicle. */
+    const getPerformanceSummaries = (vehicleId) => dataService.getPerformanceSummaries(vehicleId);
+
+    /**
+     * Import a parsed performance CSV as one session with its runs and splits.
+     * `parsed` is the output of parsePerformanceCSV().
+     */
+    const importPerformanceSession = async (vehicleId, parsed, meta) => {
+        try {
+            const session = await dataService.importPerformanceSession(vehicleId, parsed, meta);
+            showSuccess(`Imported ${parsed.runs.length} run${parsed.runs.length === 1 ? '' : 's'}.`);
+            return session;
+        } catch (error) {
+            showError('Import failed: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deletePerformanceSession = async (id) => {
+        try {
+            await dataService.deletePerformanceSession(id);
+            showSuccess('Testing session deleted.');
+        } catch (error) {
+            showError('Delete failed: ' + error.message);
+            throw error;
+        }
+    };
+
+    /**
+     * Save a reported result. Refreshes vehicles because summaries ride along on
+     * the vehicle record and feed the comparison charts.
+     */
+    const savePerformanceSummary = async (row) => {
+        try {
+            const saved = await dataService.savePerformanceSummary(row);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            return saved;
+        } catch (error) {
+            showError('Save failed: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deletePerformanceSummary = async (id) => {
+        try {
+            await dataService.deletePerformanceSummary(id);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            showSuccess('Result deleted.');
+        } catch (error) {
+            showError('Delete failed: ' + error.message);
+            throw error;
+        }
+    };
+
+    const savePerformanceInterval = async (row) => {
+        try {
+            const saved = await dataService.savePerformanceInterval(row);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+            return saved;
+        } catch (error) {
+            showError('Save failed: ' + error.message);
+            throw error;
+        }
+    };
+
+    const deletePerformanceInterval = async (id) => {
+        try {
+            await dataService.deletePerformanceInterval(id);
+            const updated = await dataService.getVehicles();
+            setVehicles(updated);
+        } catch (error) {
+            showError('Delete failed: ' + error.message);
+            throw error;
+        }
+    };
+
     /** Delete an EPA test group and its vehicle mappings, then refresh vehicles. */
     const deleteEpaTestGroup = async (testGroupId) => {
         try {
@@ -1242,6 +1326,15 @@ export function AppProvider({ children }) {
         deleteEpaTestGroup,
         updateEpaLabelMethod,
         updateEpaTestGroup,
+        // Performance testing (acceleration / braking)
+        getPerformanceSessions,
+        getPerformanceSummaries,
+        importPerformanceSession,
+        deletePerformanceSession,
+        savePerformanceSummary,
+        deletePerformanceSummary,
+        savePerformanceInterval,
+        deletePerformanceInterval,
         // EPA curator hierarchy
         getEpaTestGroupFull,
         saveEpaCoefficientSet,

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1128,12 +1128,13 @@ export function AppProvider({ children }) {
      * Save a reported result. Refreshes vehicles because summaries ride along on
      * the vehicle record and feed the comparison charts.
      */
+    // These do NOT refresh the vehicles list. Summaries aren't embedded in
+    // getVehicles (see the note there), so refetching every vehicle on each
+    // field blur would cost a full reload and change nothing on screen — the
+    // performance section owns and reloads its own data.
     const savePerformanceSummary = async (row) => {
         try {
-            const saved = await dataService.savePerformanceSummary(row);
-            const updated = await dataService.getVehicles();
-            setVehicles(updated);
-            return saved;
+            return await dataService.savePerformanceSummary(row);
         } catch (error) {
             showError('Save failed: ' + error.message);
             throw error;
@@ -1143,8 +1144,6 @@ export function AppProvider({ children }) {
     const deletePerformanceSummary = async (id) => {
         try {
             await dataService.deletePerformanceSummary(id);
-            const updated = await dataService.getVehicles();
-            setVehicles(updated);
             showSuccess('Result deleted.');
         } catch (error) {
             showError('Delete failed: ' + error.message);
@@ -1154,10 +1153,7 @@ export function AppProvider({ children }) {
 
     const savePerformanceInterval = async (row) => {
         try {
-            const saved = await dataService.savePerformanceInterval(row);
-            const updated = await dataService.getVehicles();
-            setVehicles(updated);
-            return saved;
+            return await dataService.savePerformanceInterval(row);
         } catch (error) {
             showError('Save failed: ' + error.message);
             throw error;
@@ -1167,8 +1163,6 @@ export function AppProvider({ children }) {
     const deletePerformanceInterval = async (id) => {
         try {
             await dataService.deletePerformanceInterval(id);
-            const updated = await dataService.getVehicles();
-            setVehicles(updated);
         } catch (error) {
             showError('Delete failed: ' + error.message);
             throw error;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1580,7 +1580,7 @@ class DataService {
    *
    * @param {number} vehicleId
    * @param {{session: object, runs: object[]}} parsed
-   * @param {{trimId?: number, sourceName?: string, youtubeUrl?: string,
+   * @param {{trimId?: number, sourceName?: string, sourceUrl?: string,
    *          spreadsheetUrl?: string, notes?: string}} [meta]
    * @returns {Promise<object>} the created session row
    */
@@ -1604,7 +1604,7 @@ class DataService {
       cloud_cover_pct: session.cloudCoverPct ?? null,
       visibility_mi: session.visibilityMi ?? null,
       source_name: meta.sourceName ?? null,
-      youtube_url: meta.youtubeUrl ?? null,
+      source_url: meta.sourceUrl ?? null,
       spreadsheet_url: meta.spreadsheetUrl ?? null,
       notes: meta.notes ?? null,
     });

--- a/src/utils/performanceDerivations.js
+++ b/src/utils/performanceDerivations.js
@@ -183,7 +183,7 @@ export function deriveFromSummaries(summaries = [], field) {
             summary_id: pick.id ?? null,
             source_name: pick.source_name ?? null,
             trim_label: pick.trim_label ?? null,
-            url: pick.youtube_url || pick.spreadsheet_url || null,
+            url: pick.source_url || pick.spreadsheet_url || null,
             all: sorted.map(s => ({
                 summary_id: s.id ?? null,
                 source_name: s.source_name ?? null,

--- a/supabase/migrations/041_performance_source_and_fields.sql
+++ b/supabase/migrations/041_performance_source_and_fields.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- Migration 041: Performance testing — source links and extra measured fields
+--
+-- 1. youtube_url → source_url (both tables).
+--    The column was named for the first source that turned up. In practice
+--    results are cited from written road tests as often as videos — a Car and
+--    Driver article is neither a video nor a spreadsheet — and a column called
+--    youtube_url holding a magazine URL is a name that lies about its contents.
+--    RENAME preserves the rows already entered.
+--
+-- 2. Two more measured figures that published test blocks routinely report and
+--    the schema had no home for:
+--      top_speed_mph — measured top speed (often governor-limited)
+--      skidpad_g     — lateral grip on a 300 ft skidpad
+--    Both are single scalars with no speed window, so they don't fit
+--    performance_intervals. Distinct from the specs.performance fields of
+--    similar name, which are published claims rather than measurements taken
+--    under a known protocol.
+--
+--    Note: 0-100 mph and rolling-start figures (e.g. 5-60 mph) need no schema
+--    change — they are speed windows and already fit performance_intervals.
+-- ============================================================
+
+ALTER TABLE performance_sessions  RENAME COLUMN youtube_url TO source_url;
+ALTER TABLE performance_summaries RENAME COLUMN youtube_url TO source_url;
+
+COMMENT ON COLUMN performance_sessions.source_url IS
+    'Link to the source of this session — video, article, or post.';
+COMMENT ON COLUMN performance_summaries.source_url IS
+    'Link to the source of these figures — video, article, or post.';
+
+ALTER TABLE performance_summaries
+    ADD COLUMN IF NOT EXISTS top_speed_mph numeric,
+    ADD COLUMN IF NOT EXISTS skidpad_g     numeric;
+
+COMMENT ON COLUMN performance_summaries.top_speed_mph IS
+    'Measured top speed. Frequently governor-limited rather than aerodynamically limited — the source usually says which.';
+COMMENT ON COLUMN performance_summaries.skidpad_g IS
+    'Lateral grip, conventionally measured on a 300 ft skidpad.';


### PR DESCRIPTION
Second of three PRs. Builds the UI on top of the schema, parser and derivations from #146, so acceleration and braking results can actually be entered per vehicle.

## What's here

`PerformanceVehicleSection` sits beside `EpaVehicleSection` at the bottom of `RunsView`, with two deliberately separate layers:

| Layer | What it is |
|---|---|
| **Test sessions** | Detail data imported from a GPS testing export — every run, plus the conditions it was set under |
| **Reported results** | Published figures from a source — often the **only** data available for a car |

The sparse path is treated as the normal case, not a degraded one: a source with just a 0-60 and a YouTube link is a complete, valid entry. Every field is independently optional and saves on blur.

## Measured vs. reported stays visible

Values derived from sessions get their own read-only panel, so a number EVBench measured is never presented like a number someone published. It surfaces the provenance record's own confidence rather than one confident figure — best run, the spread across comparable runs, and warnings when a figure rests on a single run or one taken on a noticeable grade.

## Two details carried through from #146

- **The two 0-60 fields** are labelled and tooltipped as distinct conventions (clock-at-0 vs 1 ft rollout, ~0.3 s apart) rather than looking like a duplicate someone should tidy up.
- **Speed windows** are entered with their own units (mph/km-h, ft/m) and displayed with an average rate in g, so windows that aren't otherwise comparable can be read against each other. Braking rates show plainly; timed windows are marked *indicative*, since acceleration rate collapses at higher speeds and windows over different speed ranges don't compare.

## Structure

Modular per CLAUDE.md, mirroring the `epa/` subfolder convention, and reusing `epa/CuratorField` for the save-on-blur field pattern rather than duplicating it:

```
PerformanceVehicleSection.jsx
PerformanceImportModal.jsx
performance/MeasuredValues.jsx
performance/PerformanceSessionCard.jsx
performance/PerformanceSummaryCard.jsx
performance/PerformanceIntervals.jsx
```

Session runs collapse behind a disclosure — a session is typically eight launches in ninety seconds — with shared conditions on the card and per-run grade and altitude in the table, since those vary within a session and move the result.

## Verification

Driven against the live database:

- Section renders in Tests & Data below EPA Testing Data, with correct empty states
- Edit controls correctly hidden for signed-out users (`canEdit` gating)
- All four tables reachable — migrations 036–040 confirmed live
- Parser and derivations run inside the app bundle, not just under node: rollout split stays separate (3.572 vs 3.300), wall-clock timestamp preserved, drive-mode grouping correct, and a metric 38.5 m window converts to 126.31 ft at 1.022 g
- No console or server errors; `npm run build` green

**Not verified:** DB writes. I'm signed out, and inserts require admin/contributor under RLS — so the import and manual-entry write paths need your eyes before merge.

## Known gap

**Braking import is not wired up.** No braking export has been seen, so the modal warns and points at manual entry rather than guessing a format. Manual braking entry works fully via speed windows.

## Next

PR C adds the Performance chart category — including the claimed-vs-measured delta — as a fourth entry in `chartNav.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)