### PR TITLE
Performance charts: Compare and Acceleration Curve

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import SpecsView from './components/SpecsView';
 import SpecsChartView from './components/SpecsChartView';
 import SpecsScatterView from './components/SpecsScatterView';
 import EpaCurvesView from './components/EpaCurvesView';
+import PerformanceCompareView from './components/PerformanceCompareView';
+import PerformanceCurveView from './components/PerformanceCurveView';
 import AdminView from './components/AdminView';
 import { CHART_CATEGORIES, DEFAULT_CHART_MODE, ALL_CHART_MODES, categoryForMode, categoryByKey, isChartCategory } from './constants/chartNav';
 
@@ -760,7 +762,7 @@ export default function App() {
                       * listed here, so every new chart mode must be added to this
                       * exclusion list or it silently renders the charging chart
                       * instead of itself. */}
-                    {activeChartCategory && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'specstable' && chartMode !== 'specscatter' && chartMode !== 'roadtrip' && chartMode !== 'epacurves' && (
+                    {activeChartCategory && selectedVehicles.length > 0 && chartMode !== 'compare' && chartMode !== 'specs' && chartMode !== 'specstable' && chartMode !== 'specscatter' && chartMode !== 'roadtrip' && chartMode !== 'epacurves' && chartMode !== 'perfcompare' && chartMode !== 'perfcurve' && (
                         <ChargingView
                             vehicles={vehicles}
                             selectedVehicleIds={selectedVehicles}
@@ -817,6 +819,18 @@ export default function App() {
                             setEpaConfig={setEpaConfig}
                             autoColor={chartConfig.autoColor ?? true}
                             setChartConfig={setChartConfig}
+                        />
+                    )}
+                    {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'perfcompare' && (
+                        <PerformanceCompareView
+                            vehicles={vehicles}
+                            selectedVehicleIds={selectedVehicles}
+                        />
+                    )}
+                    {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'perfcurve' && (
+                        <PerformanceCurveView
+                            vehicles={vehicles}
+                            selectedVehicleIds={selectedVehicles}
                         />
                     )}
                     {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'specstable' && (

--- a/src/components/PerformanceCompareView.jsx
+++ b/src/components/PerformanceCompareView.jsx
@@ -44,6 +44,7 @@ export default function PerformanceCompareView({ vehicles, selectedVehicleIds, p
     const chartRef   = useRef(null);
 
     const [basis, setBasis]   = useState('measured');
+    const [sortDir, setSortDir] = useState('best');
     const [metric, setMetric] = useState('zero_to_60_sec');
     const [data, setData]     = useState(null);   // { [vehicleId]: {sessions, summaries} }
     const [loading, setLoading] = useState(true);
@@ -148,9 +149,12 @@ export default function PerformanceCompareView({ vehicles, selectedVehicleIds, p
     const withoutData = rows.filter(r => r.value == null);
 
     const sorted = useMemo(() => {
-        const lower = activeMetric.lowerIsBetter !== false;
-        return [...withData].sort((a, b) => lower ? a.value - b.value : b.value - a.value);
-    }, [withData, activeMetric]);
+        // "Best" depends on the metric: quicker is better for a time, but higher
+        // is better for a trap speed.
+        const lowerIsBest = activeMetric.lowerIsBetter !== false;
+        const bestFirst = sortDir === 'best' ? lowerIsBest : !lowerIsBest;
+        return [...withData].sort((a, b) => bestFirst ? a.value - b.value : b.value - a.value);
+    }, [withData, activeMetric, sortDir]);
 
     // ── Chart ───────────────────────────────────────────────────────────────
     useEffect(() => {
@@ -255,30 +259,28 @@ export default function PerformanceCompareView({ vehicles, selectedVehicleIds, p
     if (loading) return <LoadingSpinner />;
 
     return (
-        <div className="chart-card">
-            {!presentationMode && (
-                <div className="flex flex-wrap items-end gap-4 mb-3">
+        <>
+            {!presentationMode && <div className="card mb-6">
+                <div className="axis-selectors">
                     <div>
-                        <span className="text-xs text-muted block mb-1">Compare using</span>
-                        <div className="flex gap-0.5">
+                        <label className="block font-medium mb-2">Compare using:</label>
+                        <select
+                            value={basis}
+                            onChange={e => setBasis(e.target.value)}
+                            className="border p-2 rounded w-full"
+                            title={BASES.find(b => b.key === basis)?.hint}
+                        >
                             {BASES.map(b => (
-                                <button
-                                    key={b.key}
-                                    onClick={() => setBasis(b.key)}
-                                    title={b.hint}
-                                    className={`btn-chart-mode ${basis === b.key ? 'active' : ''}`}
-                                >
-                                    {b.label}
-                                </button>
+                                <option key={b.key} value={b.key}>{b.label}</option>
                             ))}
-                        </div>
+                        </select>
                     </div>
-                    <label className="text-xs">
-                        <span className="text-muted block mb-1">Metric</span>
+                    <div>
+                        <label className="block font-medium mb-2">Metric:</label>
                         <select
                             value={metric}
                             onChange={e => setMetric(e.target.value)}
-                            className="form-input text-sm py-1 min-w-[14rem]"
+                            className="border p-2 rounded w-full"
                         >
                             {SCALAR_METRICS.map(m => (
                                 <option key={m.key} value={m.key}>{m.label}</option>
@@ -293,41 +295,59 @@ export default function PerformanceCompareView({ vehicles, selectedVehicleIds, p
                                 </optgroup>
                             )}
                         </select>
-                    </label>
+                    </div>
+                    <div>
+                        <label className="block font-medium mb-2">Sort:</label>
+                        <select
+                            value={sortDir}
+                            onChange={e => setSortDir(e.target.value)}
+                            className="border p-2 rounded w-full"
+                        >
+                            <option value="best">Best first</option>
+                            <option value="worst">Worst first</option>
+                        </select>
+                    </div>
                 </div>
-            )}
-
-            <h3 className="chart-title">
-                {activeMetric.label}
-                <span className="text-muted font-normal"> · {basis}</span>
-            </h3>
-
-            {sorted.length === 0 ? (
-                <p className="text-sm text-muted py-8 text-center">
-                    None of the selected vehicles has {basis} data for this metric.
-                    {basis === 'measured'
-                        ? ' Import a testing CSV in Tests & Data, or switch to Reported.'
-                        : ' Add a reported result in Tests & Data, or switch to Measured.'}
+                <p className="text-xs text-muted">
+                    Every bar comes from the basis selected above — measured against
+                    measured, reported against reported. Vehicles without data on that
+                    basis are listed under the chart rather than filled in from the other.
                 </p>
-            ) : (
-                <div style={{ height: Math.max(180, sorted.length * 46) }}>
-                    <canvas ref={canvasRef} />
-                </div>
-            )}
+            </div>}
 
-            {/* Absent vehicles are acknowledged rather than dropped, so a missing
-                bar doesn't read as a vehicle that simply performed badly. Named
-                only while the list is short enough to be worth reading — most
-                selections have far more vehicles without data than with. */}
-            {withoutData.length > 0 && sorted.length > 0 && (
-                <p className="text-xs text-faint mt-2">
-                    {withoutData.length <= 6
-                        ? `No ${basis} data for: ${withoutData.map(r => r.name).join(', ')}`
-                        : `${withoutData.length} other selected vehicles have no ${basis} data.`}
-                </p>
-            )}
+            <div className="card mb-4">
+                <h3 className="text-lg font-semibold mb-3">
+                    {activeMetric.label}
+                    <span className="text-muted font-normal text-sm"> · {basis}</span>
+                </h3>
+
+                {sorted.length === 0 ? (
+                    <p className="text-sm text-muted py-8 text-center">
+                        None of the selected vehicles has {basis} data for this metric.
+                        {basis === 'measured'
+                            ? ' Import a testing CSV in Tests & Data, or switch to Reported.'
+                            : ' Add a reported result in Tests & Data, or switch to Measured.'}
+                    </p>
+                ) : (
+                    <div style={{ height: Math.max(180, sorted.length * 46) }}>
+                        <canvas ref={canvasRef} />
+                    </div>
+                )}
+
+                {/* Absent vehicles are acknowledged rather than dropped, so a missing
+                    bar doesn't read as a vehicle that simply performed badly. Named
+                    only while the list is short enough to be worth reading — most
+                    selections have far more vehicles without data than with. */}
+                {withoutData.length > 0 && sorted.length > 0 && (
+                    <p className="text-xs text-faint mt-2">
+                        {withoutData.length <= 6
+                            ? `No ${basis} data for: ${withoutData.map(r => r.name).join(', ')}`
+                            : `${withoutData.length} other selected vehicles have no ${basis} data.`}
+                    </p>
+                )}
+            </div>
 
             {!presentationMode && <ChartInfoBubble chartKey="perfcompare" />}
-        </div>
+        </>
     );
 }

--- a/src/components/PerformanceCompareView.jsx
+++ b/src/components/PerformanceCompareView.jsx
@@ -1,0 +1,333 @@
+/**
+ * Performance Compare — one bar per vehicle for a chosen metric.
+ *
+ * ── LIKE FOR LIKE IS THE WHOLE POINT ────────────────────────────────────────
+ *
+ * Every bar on the chart comes from the SAME kind of source, chosen by the
+ * basis selector: measured against measured, or reported against reported.
+ * A vehicle with no data on the selected basis is shown explicitly as having
+ * none — it is never quietly filled in from the other basis.
+ *
+ * This is why the chart does NOT use resolveMetric().preferred, which falls
+ * back measured → reported → claimed. That fallback is right for a single
+ * vehicle's summary panel, but on a comparison it would silently put one
+ * vehicle's stopwatch next to another vehicle's press release and draw them as
+ * if they were the same measurement.
+ */
+import { useState, useEffect, useMemo, useRef } from 'react';
+import Chart from 'chart.js/auto';
+import { dataService } from '../services/DataService';
+import { vehicleLabel } from '../utils/specHelpers';
+import { useTheme } from '../hooks/useTheme';
+import LoadingSpinner from './LoadingSpinner';
+import ChartInfoBubble from './ChartInfoBubble';
+import {
+    deriveFromRuns, deriveFromSummaries, groupIntervals, normaliseInterval,
+} from '../utils/performanceDerivations';
+
+/** Metrics stored as promoted columns, available on both bases. */
+const SCALAR_METRICS = [
+    { key: 'zero_to_60_sec',         label: '0–60 mph (no rollout)', unit: 's',   lowerIsBetter: true  },
+    { key: 'zero_to_60_rollout_sec', label: '0–60 mph (1 ft)',        unit: 's',   lowerIsBetter: true  },
+    { key: 'quarter_mile_sec',       label: '¼ mile',                 unit: 's',   lowerIsBetter: true  },
+    { key: 'quarter_mile_trap_mph',  label: '¼ mile trap',            unit: 'mph', lowerIsBetter: false },
+];
+
+const BASES = [
+    { key: 'measured', label: 'Measured', hint: 'Derived from testing sessions imported into EVBench.' },
+    { key: 'reported', label: 'Reported', hint: 'Published figures entered from a source.' },
+];
+
+export default function PerformanceCompareView({ vehicles, selectedVehicleIds, presentationMode }) {
+    const { isDark } = useTheme();
+    const canvasRef  = useRef(null);
+    const chartRef   = useRef(null);
+
+    const [basis, setBasis]   = useState('measured');
+    const [metric, setMetric] = useState('zero_to_60_sec');
+    const [data, setData]     = useState(null);   // { [vehicleId]: {sessions, summaries} }
+    const [loading, setLoading] = useState(true);
+
+    const selected = useMemo(
+        () => selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean),
+        [selectedVehicleIds, vehicles],
+    );
+
+    // Fetch straight from dataService, matching how the other chart views load
+    // their series rather than routing bulk reads through context.
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        (async () => {
+            const ids = selected.map(v => v.id);
+            // Two queries total, not two per vehicle — a wide selection is the
+            // normal case here, and per-vehicle fetching meant ~100 round trips.
+            const [allSessions, allSummaries] = await Promise.all([
+                dataService.getPerformanceSessions(ids),
+                dataService.getPerformanceSummaries(ids),
+            ]);
+            const next = {};
+            for (const id of ids) next[id] = { sessions: [], summaries: [] };
+            for (const s of allSessions)  next[s.vehicle_id]?.sessions.push(s);
+            for (const s of allSummaries) next[s.vehicle_id]?.summaries.push(s);
+            if (!cancelled) { setData(next); setLoading(false); }
+        })();
+        return () => { cancelled = true; };
+    }, [selected.map(v => v.id).join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Speed windows are only ever reported, so they appear as metric options
+    // only on that basis — and only the windows some selected vehicle actually has.
+    const windowOptions = useMemo(() => {
+        if (!data || basis !== 'reported') return [];
+        const seen = new Map();
+        for (const v of selected) {
+            for (const b of groupIntervals(data[v.id]?.summaries || [])) {
+                if (!seen.has(b.key)) seen.set(b.key, { key: b.key, label: b.label, kind: b.kind });
+            }
+        }
+        return [...seen.values()];
+    }, [data, selected, basis]);
+
+    // Selecting a window then switching to Measured would leave an impossible
+    // metric selected; fall back rather than rendering an empty chart.
+    useEffect(() => {
+        const isWindow = metric.includes(':');
+        if (isWindow && (basis !== 'reported' || !windowOptions.some(w => w.key === metric))) {
+            setMetric('zero_to_60_sec');
+        }
+    }, [basis, windowOptions, metric]);
+
+    const activeMetric = useMemo(() => {
+        if (metric.includes(':')) {
+            const w = windowOptions.find(o => o.key === metric);
+            return w
+                ? { key: w.key, label: w.label, isWindow: true, kind: w.kind, lowerIsBetter: true }
+                : SCALAR_METRICS[0];
+        }
+        return SCALAR_METRICS.find(m => m.key === metric) || SCALAR_METRICS[0];
+    }, [metric, windowOptions]);
+
+    /** One row per selected vehicle on the ACTIVE BASIS ONLY. */
+    const rows = useMemo(() => {
+        if (!data) return [];
+        return selected.map(v => {
+            const bucket = data[v.id] || { sessions: [], summaries: [] };
+            const name = vehicleLabel(v);
+
+            if (activeMetric.isWindow) {
+                const b = groupIntervals(bucket.summaries).find(x => x.key === activeMetric.key);
+                const best = b?.rows?.[0];
+                return {
+                    id: v.id, name,
+                    value: best?.comparable ?? null,
+                    display: best ? `${best.value} ${best.displayUnit}` : null,
+                    sub: best?.source_name ?? null,
+                    rateG: best ? normaliseInterval(best).rateG : null,
+                    unit: best?.displayUnit ?? '',
+                };
+            }
+
+            const rec = basis === 'measured'
+                ? deriveFromRuns(bucket.sessions, activeMetric.key)
+                : deriveFromSummaries(bucket.summaries, activeMetric.key);
+
+            return {
+                id: v.id, name,
+                value: rec.value,
+                display: rec.value != null ? `${rec.value.toFixed(3)} ${activeMetric.unit}` : null,
+                sub: basis === 'measured'
+                    ? (rec.basis?.drive_mode || null)
+                    : (rec.basis?.source_name || null),
+                flags: rec.flags || [],
+                unit: activeMetric.unit,
+            };
+        });
+    }, [data, selected, activeMetric, basis]);
+
+    const withData    = rows.filter(r => r.value != null);
+    const withoutData = rows.filter(r => r.value == null);
+
+    const sorted = useMemo(() => {
+        const lower = activeMetric.lowerIsBetter !== false;
+        return [...withData].sort((a, b) => lower ? a.value - b.value : b.value - a.value);
+    }, [withData, activeMetric]);
+
+    // ── Chart ───────────────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!canvasRef.current || sorted.length === 0) {
+            chartRef.current?.destroy();
+            chartRef.current = null;
+            return;
+        }
+        chartRef.current?.destroy();
+
+        const grid = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+        const tick = isDark ? '#cbd5e1' : '#475569';
+
+        const labelPlugin = {
+            id: 'perfBarLabels',
+            afterDatasetsDraw(chart) {
+                const ctx = chart.ctx;
+                const meta = chart.getDatasetMeta(0);
+                meta.data.forEach((bar, i) => {
+                    const row = sorted[i];
+                    if (!row) return;
+                    const pills = [row.display];
+                    if (row.rateG != null) pills.push(`${row.rateG.toFixed(3)} g`);
+                    if (row.sub) pills.push(row.sub);
+
+                    let x = bar.base + 8;
+                    const y = bar.y - 7;
+                    pills.forEach((text, idx) => {
+                        ctx.save();
+                        ctx.font = idx === 0 ? 'bold 11px sans-serif' : '10px sans-serif';
+                        const w = ctx.measureText(text).width + 10;
+                        if (x + w > bar.x - 2) { ctx.restore(); return; }
+                        ctx.fillStyle = 'rgba(0,0,0,0.28)';
+                        ctx.beginPath();
+                        ctx.roundRect(x, y, w, 15, 3);
+                        ctx.fill();
+                        ctx.fillStyle = '#fff';
+                        ctx.textAlign = 'center';
+                        ctx.textBaseline = 'middle';
+                        ctx.fillText(text, x + w / 2, y + 7.5);
+                        ctx.restore();
+                        x += w + 4;
+                    });
+                });
+            },
+        };
+
+        chartRef.current = new Chart(canvasRef.current, {
+            type: 'bar',
+            data: {
+                labels: sorted.map(r => r.name),
+                datasets: [{
+                    data: sorted.map(r => r.value),
+                    backgroundColor: sorted.map((_, i) =>
+                        `hsl(${(210 + i * 26) % 360} 70% ${isDark ? 45 : 55}%)`),
+                    borderRadius: 4,
+                }],
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: (c) => {
+                                const r = sorted[c.dataIndex];
+                                const lines = [r.display];
+                                if (r.rateG != null) lines.push(`Average rate: ${r.rateG.toFixed(3)} g`);
+                                if (r.sub) lines.push(r.sub);
+                                if (r.flags?.includes('single-run')) lines.push('⚠ Single run only');
+                                if (r.flags?.includes('steep-grade')) lines.push('⚠ Best run was on a grade');
+                                if (r.flags?.includes('multiple-sources')) lines.push('⚠ Sources disagree');
+                                return lines;
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid: { color: grid },
+                        ticks: { color: tick },
+                        title: {
+                            display: true,
+                            color: tick,
+                            text: activeMetric.isWindow
+                                ? (activeMetric.kind === 'braking' ? 'Distance (ft)' : 'Time (s)')
+                                : `${activeMetric.label} (${activeMetric.unit})`,
+                        },
+                    },
+                    y: { grid: { display: false }, ticks: { color: tick } },
+                },
+            },
+            plugins: [labelPlugin],
+        });
+
+        return () => { chartRef.current?.destroy(); chartRef.current = null; };
+    }, [sorted, isDark, activeMetric]);
+
+    if (loading) return <LoadingSpinner />;
+
+    return (
+        <div className="chart-card">
+            {!presentationMode && (
+                <div className="flex flex-wrap items-end gap-4 mb-3">
+                    <div>
+                        <span className="text-xs text-muted block mb-1">Compare using</span>
+                        <div className="flex gap-0.5">
+                            {BASES.map(b => (
+                                <button
+                                    key={b.key}
+                                    onClick={() => setBasis(b.key)}
+                                    title={b.hint}
+                                    className={`btn-chart-mode ${basis === b.key ? 'active' : ''}`}
+                                >
+                                    {b.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                    <label className="text-xs">
+                        <span className="text-muted block mb-1">Metric</span>
+                        <select
+                            value={metric}
+                            onChange={e => setMetric(e.target.value)}
+                            className="form-input text-sm py-1 min-w-[14rem]"
+                        >
+                            {SCALAR_METRICS.map(m => (
+                                <option key={m.key} value={m.key}>{m.label}</option>
+                            ))}
+                            {windowOptions.length > 0 && (
+                                <optgroup label="Speed windows">
+                                    {windowOptions.map(w => (
+                                        <option key={w.key} value={w.key}>
+                                            {w.label} ({w.kind})
+                                        </option>
+                                    ))}
+                                </optgroup>
+                            )}
+                        </select>
+                    </label>
+                </div>
+            )}
+
+            <h3 className="chart-title">
+                {activeMetric.label}
+                <span className="text-muted font-normal"> · {basis}</span>
+            </h3>
+
+            {sorted.length === 0 ? (
+                <p className="text-sm text-muted py-8 text-center">
+                    None of the selected vehicles has {basis} data for this metric.
+                    {basis === 'measured'
+                        ? ' Import a testing CSV in Tests & Data, or switch to Reported.'
+                        : ' Add a reported result in Tests & Data, or switch to Measured.'}
+                </p>
+            ) : (
+                <div style={{ height: Math.max(180, sorted.length * 46) }}>
+                    <canvas ref={canvasRef} />
+                </div>
+            )}
+
+            {/* Absent vehicles are acknowledged rather than dropped, so a missing
+                bar doesn't read as a vehicle that simply performed badly. Named
+                only while the list is short enough to be worth reading — most
+                selections have far more vehicles without data than with. */}
+            {withoutData.length > 0 && sorted.length > 0 && (
+                <p className="text-xs text-faint mt-2">
+                    {withoutData.length <= 6
+                        ? `No ${basis} data for: ${withoutData.map(r => r.name).join(', ')}`
+                        : `${withoutData.length} other selected vehicles have no ${basis} data.`}
+                </p>
+            )}
+
+            {!presentationMode && <ChartInfoBubble chartKey="perfcompare" />}
+        </div>
+    );
+}

--- a/src/components/PerformanceCurveView.jsx
+++ b/src/components/PerformanceCurveView.jsx
@@ -16,6 +16,7 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { useTheme } from '../hooks/useTheme';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
+import AxisScaleControls from './AxisScaleControls';
 
 /** Okabe-Ito, matching the palette the other charts use for run colours. */
 const PALETTE = ['#0072B2', '#D55E00', '#009E73', '#CC79A7', '#E69F00', '#56B4E9', '#F0E442'];
@@ -27,9 +28,11 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
 
     const [sessionsByVehicle, setSessionsByVehicle] = useState(null);
     const [loading, setLoading] = useState(true);
-    const [showAllRuns, setShowAllRuns] = useState(false);
-    const [xMax, setXMax] = useState('');   // '' = auto-scale
-    const [yMax, setYMax] = useState('');
+    // 'mode'   — quickest run in each drive mode (default: the mode comparison)
+    // 'vehicle' — one line per vehicle, its single quickest run
+    // 'all'     — every run, for run-to-run consistency
+    const [grouping, setGrouping] = useState('mode');
+    const [scale, setScale] = useState({ xMin: null, xMax: null, yMin: null, yMax: null });
 
     const selected = useMemo(
         () => selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean),
@@ -56,26 +59,34 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
      */
     const series = useMemo(() => {
         if (!sessionsByVehicle) return [];
+        const quickest = (a, b) => (a?.zero_to_60_sec ?? Infinity) <= (b?.zero_to_60_sec ?? Infinity) ? a : b;
         const out = [];
         for (const v of selected) {
             const name = vehicleLabel(v);
-            for (const session of sessionsByVehicle[v.id] || []) {
-                if (session.test_type !== 'accel') continue;
 
-                const runs = (session.performance_runs || []).filter(
+            // Runs across every accel session this vehicle has, since a vehicle's
+            // quickest run isn't necessarily in its most recent session.
+            const allRuns = (sessionsByVehicle[v.id] || [])
+                .filter(s => s.test_type === 'accel')
+                .flatMap(s => (s.performance_runs || []).filter(
                     r => (r.performance_run_points || []).length >= 2,
-                );
-                // Best (quickest) run per drive mode unless showing everything.
-                const chosen = showAllRuns ? runs : Object.values(
-                    runs.reduce((acc, r) => {
-                        const key = r.drive_mode || 'Unspecified';
-                        const cur = acc[key];
-                        const t = r.zero_to_60_sec ?? Infinity;
-                        if (!cur || t < (cur.zero_to_60_sec ?? Infinity)) acc[key] = r;
-                        return acc;
-                    }, {}),
-                );
+                ));
+            if (allRuns.length === 0) continue;
 
+            let chosen;
+            if (grouping === 'all') {
+                chosen = allRuns;
+            } else if (grouping === 'vehicle') {
+                chosen = [allRuns.reduce(quickest)];
+            } else {
+                chosen = Object.values(allRuns.reduce((acc, r) => {
+                    const key = r.drive_mode || 'Unspecified';
+                    acc[key] = acc[key] ? quickest(acc[key], r) : r;
+                    return acc;
+                }, {}));
+            }
+
+            {
                 for (const run of chosen) {
                     // Drop the 1ft-rollout split: it's the same 60 mph point on a
                     // different clock, and mixing it with the zero-start splits
@@ -101,7 +112,10 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
                     out.push({
                         // Year and trim are dropped: with one line per drive mode the
                         // legend is already long, and the mode is what distinguishes them.
-                        label: `${v.name} · ${run.drive_mode || 'Run'}${showAllRuns ? ` #${(run.sequence ?? 0) + 1}` : ''}`,
+                        // Best-per-vehicle needs no mode in the label — there's one line.
+                        label: grouping === 'vehicle'
+                            ? v.name
+                            : `${v.name} · ${run.drive_mode || 'Run'}${grouping === 'all' ? ` #${(run.sequence ?? 0) + 1}` : ''}`,
                         fullLabel: `${name} · ${run.drive_mode || 'Run'}`,
                         points,
                         zeroTo60: run.zero_to_60_sec,
@@ -110,7 +124,7 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
             }
         }
         return out;
-    }, [sessionsByVehicle, selected, showAllRuns]);
+    }, [sessionsByVehicle, selected, grouping]);
 
     useEffect(() => {
         if (!canvasRef.current || series.length === 0) {
@@ -172,15 +186,17 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
                 scales: {
                     x: {
                         type: 'linear',
-                        beginAtZero: true,
-                        ...(Number(xMax) > 0 ? { max: Number(xMax) } : {}),
+                        beginAtZero: scale.xMin == null,
+                        ...(scale.xMin != null ? { min: scale.xMin } : {}),
+                        ...(scale.xMax != null ? { max: scale.xMax } : {}),
                         grid: { color: grid },
                         ticks: { color: tick },
                         title: { display: true, text: 'Elapsed time (s)', color: tick },
                     },
                     y: {
-                        beginAtZero: true,
-                        ...(Number(yMax) > 0 ? { max: Number(yMax) } : {}),
+                        beginAtZero: scale.yMin == null,
+                        ...(scale.yMin != null ? { min: scale.yMin } : {}),
+                        ...(scale.yMax != null ? { max: scale.yMax } : {}),
                         grid: { color: grid },
                         ticks: { color: tick },
                         title: { display: true, text: 'Speed (mph)', color: tick },
@@ -190,68 +206,31 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
         });
 
         return () => { chartRef.current?.destroy(); chartRef.current = null; };
-    }, [series, isDark, presentationMode, xMax, yMax]);
+    }, [series, isDark, presentationMode, scale]);
 
     if (loading) return <LoadingSpinner />;
 
     return (
         <>
             {!presentationMode && <div className="card mb-6">
-                <div className="axis-selectors">
-                    <div>
-                        <label className="block font-medium mb-2">X-Axis:</label>
-                        <select disabled value="time" className="border p-2 rounded w-full opacity-60">
-                            <option value="time">Elapsed time (s)</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label className="block font-medium mb-2">Y-Axis:</label>
-                        <select disabled value="speed" className="border p-2 rounded w-full opacity-60">
-                            <option value="speed">Speed (mph)</option>
-                        </select>
-                    </div>
+                <div className="flex flex-wrap items-end gap-6">
                     <div>
                         <label className="block font-medium mb-2">Runs shown:</label>
                         <select
-                            value={showAllRuns ? 'all' : 'best'}
-                            onChange={e => setShowAllRuns(e.target.value === 'all')}
-                            className="border p-2 rounded w-full"
+                            value={grouping}
+                            onChange={e => setGrouping(e.target.value)}
+                            className="border p-2 rounded"
                         >
-                            <option value="best">Best per drive mode</option>
+                            <option value="mode">Best per drive mode</option>
+                            <option value="vehicle">Best per vehicle</option>
                             <option value="all">Every run</option>
                         </select>
                     </div>
+                    <span className="text-xs text-faint pb-3">
+                        {series.length} line{series.length === 1 ? '' : 's'} plotted
+                    </span>
                 </div>
-
-                {/* A single slow mode stretches the time axis and squashes every
-                    other line into the left edge, so the range is clampable. */}
-                <div className="axis-selectors">
-                    <div>
-                        <label className="block font-medium mb-2">Max time (s):</label>
-                        <input
-                            type="number" step="0.5" min="0" value={xMax}
-                            onChange={e => setXMax(e.target.value)}
-                            placeholder="auto"
-                            className="border p-2 rounded w-full"
-                        />
-                    </div>
-                    <div>
-                        <label className="block font-medium mb-2">Max speed (mph):</label>
-                        <input
-                            type="number" step="5" min="0" value={yMax}
-                            onChange={e => setYMax(e.target.value)}
-                            placeholder="auto"
-                            className="border p-2 rounded w-full"
-                        />
-                    </div>
-                    <div className="flex items-end">
-                        <span className="text-xs text-faint pb-2">
-                            {showAllRuns ? 'All runs' : 'Best run per drive mode'} · {series.length} plotted
-                        </span>
-                    </div>
-                </div>
-
-                <p className="text-xs text-muted">
+                <p className="text-xs text-muted mt-3">
                     Built from imported split times. The 1&nbsp;ft-rollout split is left out —
                     it is the same 60&nbsp;mph point on a different clock — and the 0–60 time is
                     added as the final point, since sources list splits only to 0–50.
@@ -272,6 +251,20 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
                     </div>
                 )}
             </div>
+
+            {/* Scale controls sit BELOW the chart in their own card, matching every
+                other chart view. X and Y value pickers are omitted: the split
+                series supports only time-versus-speed, and a control with one
+                option is noise. */}
+            {!presentationMode && series.length > 0 && (
+                <AxisScaleControls
+                    xMin={scale.xMin} xMax={scale.xMax}
+                    yMin={scale.yMin} yMax={scale.yMax}
+                    onChange={(key, val) => setScale(prev => ({ ...prev, [key]: val }))}
+                    xAxisLabel="X-Axis Scale (s)"
+                    yAxisLabel="Y-Axis Scale (mph)"
+                />
+            )}
 
             {!presentationMode && <ChartInfoBubble chartKey="perfcurve" />}
         </>

--- a/src/components/PerformanceCurveView.jsx
+++ b/src/components/PerformanceCurveView.jsx
@@ -1,0 +1,227 @@
+/**
+ * Acceleration Curve — speed against elapsed time, one line per run.
+ *
+ * Built from the split series (performance_run_points), so it only has anything
+ * to draw where a detail testing CSV has been imported. Reported figures carry
+ * no trace, and are deliberately not synthesised into a fake curve.
+ *
+ * Defaults to the best run per drive mode: a session is typically eight
+ * launches, and plotting all of them at once buries the comparison that
+ * actually matters — what each drive mode costs you.
+ */
+import { useState, useEffect, useMemo, useRef } from 'react';
+import Chart from 'chart.js/auto';
+import { dataService } from '../services/DataService';
+import { vehicleLabel } from '../utils/specHelpers';
+import { useTheme } from '../hooks/useTheme';
+import LoadingSpinner from './LoadingSpinner';
+import ChartInfoBubble from './ChartInfoBubble';
+
+/** Okabe-Ito, matching the palette the other charts use for run colours. */
+const PALETTE = ['#0072B2', '#D55E00', '#009E73', '#CC79A7', '#E69F00', '#56B4E9', '#F0E442'];
+
+export default function PerformanceCurveView({ vehicles, selectedVehicleIds, presentationMode }) {
+    const { isDark } = useTheme();
+    const canvasRef  = useRef(null);
+    const chartRef   = useRef(null);
+
+    const [sessionsByVehicle, setSessionsByVehicle] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [showAllRuns, setShowAllRuns] = useState(false);
+
+    const selected = useMemo(
+        () => selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean),
+        [selectedVehicleIds, vehicles],
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        (async () => {
+            const ids = selected.map(v => v.id);
+            const allSessions = await dataService.getPerformanceSessions(ids);
+            const next = {};
+            for (const id of ids) next[id] = [];
+            for (const s of allSessions) next[s.vehicle_id]?.push(s);
+            if (!cancelled) { setSessionsByVehicle(next); setLoading(false); }
+        })();
+        return () => { cancelled = true; };
+    }, [selected.map(v => v.id).join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    /**
+     * One series per run worth plotting. A run needs at least two split points
+     * to be a curve rather than a dot.
+     */
+    const series = useMemo(() => {
+        if (!sessionsByVehicle) return [];
+        const out = [];
+        for (const v of selected) {
+            const name = vehicleLabel(v);
+            for (const session of sessionsByVehicle[v.id] || []) {
+                if (session.test_type !== 'accel') continue;
+
+                const runs = (session.performance_runs || []).filter(
+                    r => (r.performance_run_points || []).length >= 2,
+                );
+                // Best (quickest) run per drive mode unless showing everything.
+                const chosen = showAllRuns ? runs : Object.values(
+                    runs.reduce((acc, r) => {
+                        const key = r.drive_mode || 'Unspecified';
+                        const cur = acc[key];
+                        const t = r.zero_to_60_sec ?? Infinity;
+                        if (!cur || t < (cur.zero_to_60_sec ?? Infinity)) acc[key] = r;
+                        return acc;
+                    }, {}),
+                );
+
+                for (const run of chosen) {
+                    // Drop the 1ft-rollout split: it's the same 60 mph point on a
+                    // different clock, and mixing it with the zero-start splits
+                    // would double back on the curve.
+                    const points = (run.performance_run_points || [])
+                        .filter(p => p.speed_mph != null && p.elapsed_s != null && !/\(1ft\)/.test(p.label || ''))
+                        .map(p => ({ x: Number(p.elapsed_s), y: Number(p.speed_mph) }))
+                        .sort((a, b) => a.x - b.x);
+                    if (points.length < 2) continue;
+
+                    // Every launch starts from rest; the export omits that point.
+                    if (points[0].x > 0 && points[0].y > 0) points.unshift({ x: 0, y: 0 });
+
+                    // Sources list splits up to 0-50 and then give 0-60 only as the
+                    // headline figure, so without this the curve stops short of the
+                    // very speed the run is named for. zero_to_60_sec is the
+                    // no-rollout time — the same clock as the splits above.
+                    const t60 = Number(run.zero_to_60_sec);
+                    if (Number.isFinite(t60) && t60 > points[points.length - 1].x) {
+                        points.push({ x: t60, y: 60 });
+                    }
+
+                    out.push({
+                        // Year and trim are dropped: with one line per drive mode the
+                        // legend is already long, and the mode is what distinguishes them.
+                        label: `${v.name} · ${run.drive_mode || 'Run'}${showAllRuns ? ` #${(run.sequence ?? 0) + 1}` : ''}`,
+                        fullLabel: `${name} · ${run.drive_mode || 'Run'}`,
+                        points,
+                        zeroTo60: run.zero_to_60_sec,
+                    });
+                }
+            }
+        }
+        return out;
+    }, [sessionsByVehicle, selected, showAllRuns]);
+
+    useEffect(() => {
+        if (!canvasRef.current || series.length === 0) {
+            chartRef.current?.destroy();
+            chartRef.current = null;
+            return;
+        }
+        chartRef.current?.destroy();
+
+        const grid = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+        const tick = isDark ? '#cbd5e1' : '#475569';
+
+        chartRef.current = new Chart(canvasRef.current, {
+            type: 'line',
+            data: {
+                datasets: series.map((s, i) => ({
+                    label: s.label,
+                    data: s.points,
+                    borderColor: PALETTE[i % PALETTE.length],
+                    backgroundColor: PALETTE[i % PALETTE.length],
+                    borderWidth: 2,
+                    pointRadius: presentationMode ? 0 : 2.5,
+                    tension: 0.25,
+                })),
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'nearest', intersect: false },
+                plugins: {
+                    legend: {
+                        // Drive-mode names run long ("Sport - No Launch Mode but 2
+                        // foot preload - Firm Damper - Stability Reduced"), so the
+                        // legend is capped and truncated rather than eating the plot.
+                        position: 'bottom',
+                        labels: {
+                            color: tick,
+                            usePointStyle: true,
+                            boxWidth: 8,
+                            padding: 8,
+                            font: { size: 10 },
+                            generateLabels: (chart) => Chart.defaults.plugins.legend.labels
+                                .generateLabels(chart)
+                                .map(l => ({
+                                    ...l,
+                                    text: l.text.length > 46 ? l.text.slice(0, 44) + '…' : l.text,
+                                })),
+                        },
+                    },
+                    tooltip: {
+                        callbacks: {
+                            title: (items) => `${items[0].parsed.x.toFixed(3)} s`,
+                            // Tooltip shows the untruncated name, so the legend can
+                            // stay short without losing which vehicle a line is.
+                            label: (c) => `${series[c.datasetIndex]?.fullLabel ?? c.dataset.label}: ${c.parsed.y.toFixed(0)} mph`,
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        type: 'linear',
+                        beginAtZero: true,
+                        grid: { color: grid },
+                        ticks: { color: tick },
+                        title: { display: true, text: 'Elapsed time (s)', color: tick },
+                    },
+                    y: {
+                        beginAtZero: true,
+                        grid: { color: grid },
+                        ticks: { color: tick },
+                        title: { display: true, text: 'Speed (mph)', color: tick },
+                    },
+                },
+            },
+        });
+
+        return () => { chartRef.current?.destroy(); chartRef.current = null; };
+    }, [series, isDark, presentationMode]);
+
+    if (loading) return <LoadingSpinner />;
+
+    return (
+        <div className="chart-card">
+            {!presentationMode && series.length > 0 && (
+                <div className="flex items-center gap-3 mb-3">
+                    <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                        <input
+                            type="checkbox"
+                            checked={showAllRuns}
+                            onChange={e => setShowAllRuns(e.target.checked)}
+                        />
+                        <span className="text-secondary">Show every run</span>
+                    </label>
+                    <span className="text-xs text-faint">
+                        {showAllRuns ? 'All runs' : 'Best run per drive mode'} · {series.length} plotted
+                    </span>
+                </div>
+            )}
+
+            <h3 className="chart-title">Speed vs Time</h3>
+
+            {series.length === 0 ? (
+                <p className="text-sm text-muted py-8 text-center">
+                    No acceleration split data for the selected vehicles. This chart is built
+                    from imported testing CSVs — reported figures alone carry no trace to plot.
+                </p>
+            ) : (
+                <div style={{ height: presentationMode ? '75vh' : 420 }}>
+                    <canvas ref={canvasRef} />
+                </div>
+            )}
+
+            {!presentationMode && <ChartInfoBubble chartKey="perfcurve" />}
+        </div>
+    );
+}

--- a/src/components/PerformanceCurveView.jsx
+++ b/src/components/PerformanceCurveView.jsx
@@ -28,6 +28,8 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
     const [sessionsByVehicle, setSessionsByVehicle] = useState(null);
     const [loading, setLoading] = useState(true);
     const [showAllRuns, setShowAllRuns] = useState(false);
+    const [xMax, setXMax] = useState('');   // '' = auto-scale
+    const [yMax, setYMax] = useState('');
 
     const selected = useMemo(
         () => selectedVehicleIds.map(id => vehicles.find(v => v.id === id)).filter(Boolean),
@@ -171,12 +173,14 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
                     x: {
                         type: 'linear',
                         beginAtZero: true,
+                        ...(Number(xMax) > 0 ? { max: Number(xMax) } : {}),
                         grid: { color: grid },
                         ticks: { color: tick },
                         title: { display: true, text: 'Elapsed time (s)', color: tick },
                     },
                     y: {
                         beginAtZero: true,
+                        ...(Number(yMax) > 0 ? { max: Number(yMax) } : {}),
                         grid: { color: grid },
                         ticks: { color: tick },
                         title: { display: true, text: 'Speed (mph)', color: tick },
@@ -186,42 +190,90 @@ export default function PerformanceCurveView({ vehicles, selectedVehicleIds, pre
         });
 
         return () => { chartRef.current?.destroy(); chartRef.current = null; };
-    }, [series, isDark, presentationMode]);
+    }, [series, isDark, presentationMode, xMax, yMax]);
 
     if (loading) return <LoadingSpinner />;
 
     return (
-        <div className="chart-card">
-            {!presentationMode && series.length > 0 && (
-                <div className="flex items-center gap-3 mb-3">
-                    <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+        <>
+            {!presentationMode && <div className="card mb-6">
+                <div className="axis-selectors">
+                    <div>
+                        <label className="block font-medium mb-2">X-Axis:</label>
+                        <select disabled value="time" className="border p-2 rounded w-full opacity-60">
+                            <option value="time">Elapsed time (s)</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label className="block font-medium mb-2">Y-Axis:</label>
+                        <select disabled value="speed" className="border p-2 rounded w-full opacity-60">
+                            <option value="speed">Speed (mph)</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label className="block font-medium mb-2">Runs shown:</label>
+                        <select
+                            value={showAllRuns ? 'all' : 'best'}
+                            onChange={e => setShowAllRuns(e.target.value === 'all')}
+                            className="border p-2 rounded w-full"
+                        >
+                            <option value="best">Best per drive mode</option>
+                            <option value="all">Every run</option>
+                        </select>
+                    </div>
+                </div>
+
+                {/* A single slow mode stretches the time axis and squashes every
+                    other line into the left edge, so the range is clampable. */}
+                <div className="axis-selectors">
+                    <div>
+                        <label className="block font-medium mb-2">Max time (s):</label>
                         <input
-                            type="checkbox"
-                            checked={showAllRuns}
-                            onChange={e => setShowAllRuns(e.target.checked)}
+                            type="number" step="0.5" min="0" value={xMax}
+                            onChange={e => setXMax(e.target.value)}
+                            placeholder="auto"
+                            className="border p-2 rounded w-full"
                         />
-                        <span className="text-secondary">Show every run</span>
-                    </label>
-                    <span className="text-xs text-faint">
-                        {showAllRuns ? 'All runs' : 'Best run per drive mode'} · {series.length} plotted
-                    </span>
+                    </div>
+                    <div>
+                        <label className="block font-medium mb-2">Max speed (mph):</label>
+                        <input
+                            type="number" step="5" min="0" value={yMax}
+                            onChange={e => setYMax(e.target.value)}
+                            placeholder="auto"
+                            className="border p-2 rounded w-full"
+                        />
+                    </div>
+                    <div className="flex items-end">
+                        <span className="text-xs text-faint pb-2">
+                            {showAllRuns ? 'All runs' : 'Best run per drive mode'} · {series.length} plotted
+                        </span>
+                    </div>
                 </div>
-            )}
 
-            <h3 className="chart-title">Speed vs Time</h3>
-
-            {series.length === 0 ? (
-                <p className="text-sm text-muted py-8 text-center">
-                    No acceleration split data for the selected vehicles. This chart is built
-                    from imported testing CSVs — reported figures alone carry no trace to plot.
+                <p className="text-xs text-muted">
+                    Built from imported split times. The 1&nbsp;ft-rollout split is left out —
+                    it is the same 60&nbsp;mph point on a different clock — and the 0–60 time is
+                    added as the final point, since sources list splits only to 0–50.
                 </p>
-            ) : (
-                <div style={{ height: presentationMode ? '75vh' : 420 }}>
-                    <canvas ref={canvasRef} />
-                </div>
-            )}
+            </div>}
+
+            <div className="card mb-4">
+                <h3 className="text-lg font-semibold mb-3">Speed vs Time</h3>
+
+                {series.length === 0 ? (
+                    <p className="text-sm text-muted py-8 text-center">
+                        No acceleration split data for the selected vehicles. This chart is built
+                        from imported testing CSVs — reported figures alone carry no trace to plot.
+                    </p>
+                ) : (
+                    <div style={{ height: presentationMode ? 'calc(100vh - 2rem)' : 460 }}>
+                        <canvas ref={canvasRef} />
+                    </div>
+                )}
+            </div>
 
             {!presentationMode && <ChartInfoBubble chartKey="perfcurve" />}
-        </div>
+        </>
     );
 }

--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -5,6 +5,8 @@ import SpecsChartView from './SpecsChartView';
 import SpecsScatterView from './SpecsScatterView';
 import SpecsView from './SpecsView';
 import EpaCurvesView from './EpaCurvesView';
+import PerformanceCompareView from './PerformanceCompareView';
+import PerformanceCurveView from './PerformanceCurveView';
 
 /**
  * Minimal fullscreen chart-only view rendered in the pop-out tab.
@@ -29,6 +31,22 @@ export default function PopoutView({
                 <SpecsChartView
                     vehicles={vehicles.filter(v => selectedVehicles.includes(v.id))}
                     selectedField={chartConfig.specsField}
+                    presentationMode
+                />
+            )}
+
+            {selectedVehicles.length > 0 && chartMode === 'perfcompare' && (
+                <PerformanceCompareView
+                    vehicles={vehicles}
+                    selectedVehicleIds={selectedVehicles}
+                    presentationMode
+                />
+            )}
+
+            {selectedVehicles.length > 0 && chartMode === 'perfcurve' && (
+                <PerformanceCurveView
+                    vehicles={vehicles}
+                    selectedVehicleIds={selectedVehicles}
                     presentationMode
                 />
             )}

--- a/src/constants/chartNav.js
+++ b/src/constants/chartNav.js
@@ -35,6 +35,14 @@
 
 export const CHART_CATEGORIES = [
     {
+        key: 'performance',
+        label: 'Performance',
+        modes: [
+            { key: 'perfcompare', label: 'Compare' },
+            { key: 'perfcurve',   label: 'Acceleration Curve' },
+        ],
+    },
+    {
         // "Charging & Efficiency", not "Range & Efficiency": the 'range' mode
         // below already carries that name, and a tab sharing a label with one of
         // its own sub-tabs made the nav ambiguous. The key stays 'efficiency' —

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1509,18 +1509,23 @@ class DataService {
   // charging run). See migration 036 for the full rationale.
 
   /**
-   * All performance sessions for a vehicle, with runs and split points nested.
-   * Single relational query, same shape as getEpaTestGroupFull().
+   * Performance sessions with runs and split points nested, for one vehicle or
+   * a list of them. Single relational query, same shape as getEpaTestGroupFull().
+   *
+   * Accepts an array so the comparison charts can load every selected vehicle in
+   * ONE round trip — fetching per vehicle meant ~50 queries on a wide selection.
    */
   async getPerformanceSessions(vehicleId) {
     if (!this.useSupabase) return [];
+    const ids = Array.isArray(vehicleId) ? vehicleId : [vehicleId];
+    if (ids.length === 0) return [];
     const { data, error } = await getSupabase()
       .from('performance_sessions')
       .select(`
         *,
         performance_runs(*, performance_run_points(*))
       `)
-      .eq('vehicle_id', vehicleId)
+      .in('vehicle_id', ids)
       .order('tested_at', { ascending: false });
     if (error) throw error;
     // PostgREST doesn't order nested rows — sort children so runs and their
@@ -1663,7 +1668,13 @@ class DataService {
     let q = getSupabase()
       .from('performance_summaries')
       .select('*, performance_intervals(*)');
-    if (vehicleId != null) q = q.eq('vehicle_id', vehicleId);
+    // Array form keeps the comparison charts to one query across the selection.
+    if (Array.isArray(vehicleId)) {
+      if (vehicleId.length === 0) return [];
+      q = q.in('vehicle_id', vehicleId);
+    } else if (vehicleId != null) {
+      q = q.eq('vehicle_id', vehicleId);
+    }
     const { data, error } = await q;
     if (error) {
       console.warn('Performance summaries unavailable (migrations 039/040 applied?):', error.message);

--- a/src/utils/chartHelpContent.js
+++ b/src/utils/chartHelpContent.js
@@ -205,6 +205,64 @@ export const CHART_HELP_DEFAULTS = {
             'charger availability, weather and traffic will vary.',
     },
 
+    perfcompare: {
+        title: 'About the Performance Compare chart',
+        data_source:
+            'Ranks the selected vehicles on one acceleration or braking metric. The ' +
+            '“Compare using” switch chooses where every bar comes from: Measured ' +
+            'derives from testing sessions imported into EVBench, Reported uses ' +
+            'published figures entered from a source. Speed windows (braking ' +
+            'distances, passing times) only exist as reported figures, so they appear ' +
+            'only on that basis.',
+        how_to_read:
+            'Every bar on the chart comes from the same kind of source — that is the ' +
+            'point of the basis switch. A vehicle with no data on the selected basis ' +
+            'is listed underneath as having none, rather than being quietly filled in ' +
+            'from the other basis, because mixing a stopwatch reading with a press ' +
+            'release would make the bars meaningless. Pills inside each bar show the ' +
+            'value, the average rate in g where it applies, and the drive mode or ' +
+            'source it came from. Warnings in the tooltip flag figures resting on a ' +
+            'single run, a run taken on a grade, or sources that disagree.',
+        key_terms:
+            'Measured — derived here from imported session data.\n' +
+            'Reported — a published figure entered from a source.\n' +
+            'No rollout vs 1 ft — two 0–60 conventions about 0.3 s apart; not interchangeable.\n' +
+            'Speed window — a from/to speed pair, e.g. 75–0 mph braking or 50–90 mph passing.\n' +
+            'Average rate (g) — the window expressed as an average acceleration.',
+        math_approach:
+            'Measured figures take the best run and report the spread across comparable ' +
+            'runs in the same drive mode; nothing is averaged across drive modes. ' +
+            'Reported figures take the best value when several sources disagree, and ' +
+            'flag the disagreement. Braking distances are converted to a common unit ' +
+            'for ranking but displayed as reported. Average rate is Δv/Δt for timed ' +
+            'windows and (v₁²−v₂²)/2d for braking.',
+    },
+
+    perfcurve: {
+        title: 'About the Acceleration Curve',
+        data_source:
+            'Plots speed against elapsed time from the split times recorded in an ' +
+            'imported testing CSV (0–10, 0–20, … 0–60). Only vehicles with imported ' +
+            'detail data appear — a reported 0–60 figure on its own carries no trace, ' +
+            'and no curve is invented for it.',
+        how_to_read:
+            'Each line is one run. By default the quickest run per drive mode is shown, ' +
+            'because a session is usually eight launches and plotting all of them buries ' +
+            'the comparison that matters — what each drive mode actually costs you. Tick ' +
+            '“Show every run” to see run-to-run consistency instead. A line that is ' +
+            'steeper early is quicker off the line; lines converging at the top mean the ' +
+            'difference was all in the launch.',
+        key_terms:
+            'Split — a recorded time to reach a given speed.\n' +
+            'Drive mode — the vehicle setting under test, e.g. a launch mode versus a comfort mode.\n' +
+            'Elapsed time — seconds from a standing start.',
+        math_approach:
+            'The recorded splits drawn as-is, with a zero point added at the origin since ' +
+            'every launch starts from rest and exports omit it. The 1 ft-rollout split is ' +
+            'excluded — it is the same 60 mph point measured a different way, and would ' +
+            'double back on the curve. No smoothing or curve-fitting beyond line tension.',
+    },
+
     specstable: {
         title: 'About Compare Specs',
         data_source:


### PR DESCRIPTION
Third of three PRs. Adds **Performance** as a top-level chart tab with two views, registered in all four places a new mode needs — `chartNav`, the `App.jsx` fall-through exclusion list, a `PopoutView` branch, and `CHART_HELP_DEFAULTS`.

## Compare

One bar per vehicle for a chosen metric, with a **basis switch**: Measured or Reported.

**Every bar comes from the same kind of source.** A vehicle with no data on the selected basis is acknowledged underneath rather than quietly filled in from the other one. This is deliberate — the chart does *not* use `resolveMetric().preferred`, whose measured → reported → claimed fallback is right for a single vehicle's panel but on a comparison would put one vehicle's stopwatch beside another's press release and draw them as the same measurement.

Speed windows (braking distances, passing times) exist only as reported figures, so they appear as metric options only on that basis.

## Acceleration Curve

Speed against elapsed time from the split series. Defaults to the **best run per drive mode** — a session is eight launches, and plotting all of them buries the comparison that matters.

Two data details worth noting:
- The 1 ft-rollout split is excluded: it's the same 60 mph point on a different clock and would double back on the curve.
- The 0-60 time is **appended as the final point**. Sources list splits only up to 0-50, so without this the curve stopped short of the very speed the run is named for.

## Performance fix

`getPerformanceSessions` / `getPerformanceSummaries` now accept an array of vehicle ids. Fetching per vehicle meant **~100 round trips** on a wide selection; it's now **two queries, 181 ms across 48 vehicles**.

## Verification

Driven against real imported data:

| Vehicle | Best 0-60 | Drive mode | Spread |
|---|---|---|---|
| Model Y (Juniper) | 3.504 s | Insane - No Launch Mode | 3.504–3.543 |
| R2 Perf. | 3.638 s | Sport + Launch, Firm Damper, Stability On | single run |

- Both charts render, sorted quickest-first, with drive-mode pills
- Curves reach 60 mph
- 46 selected vehicles without data are summarised, not listed by name
- Basis switch, metric selector, and window options all behave
- No console or server errors; `npm run build` green

Independent of #156 — chart views read `dataService` directly, matching how `ChargeCompareView` and `ChargingView` load their series, so there's no overlap with that PR's files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)