### PR TITLE
Filter vehicles by which data they hold (#163)

### DIFF
--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
+import { DATA_CATEGORIES, vehicleDataCategories, hasDataCategory, filterByDataCategories } from '../utils/vehicleDataCategories';
 import { fmtDistance } from '../utils/unitConversions';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
 import DeleteQueueBar from './DeleteQueueBar';
@@ -16,24 +17,18 @@ import ImportVehiclesModal from './ImportVehiclesModal';
  * the type names are 1pt smaller and colored. Zero-count categories omitted.
  */
 function TestCountPills({ vehicle, performanceCounts = {} }) {
-    const chargingCount = vehicle.runs?.filter(r => r.has_charging).length ?? 0;
-    const rangeCount    = vehicle.runs?.filter(r => r.has_range).length    ?? 0;
-    const epaCount      = vehicle.epa_mappings?.length                     ?? 0;
-    // Performance runs aren't on vehicle.runs — they live in their own tables
-    // and are counted by a separate query (see AppContext.performanceCounts).
-    const accelCount    = performanceCounts[vehicle.id]?.accel   ?? 0;
-    const brakingCount  = performanceCounts[vehicle.id]?.braking ?? 0;
-
-    if (!chargingCount && !rangeCount && !epaCount && !accelCount && !brakingCount) return null;
+    const counts = vehicleDataCategories(vehicle, performanceCounts);
+    const shown = DATA_CATEGORIES.filter(c => counts[c.key] > 0);
+    if (shown.length === 0) return null;
 
     return (
         <p className="flex flex-wrap items-baseline gap-x-1.5">
             <span>Tests:</span>
-            {chargingCount > 0 && <span className="text-[13px] font-medium text-green-600 dark:text-green-400">Charging ({chargingCount})</span>}
-            {rangeCount    > 0 && <span className="text-[13px] font-medium text-amber-600 dark:text-amber-400">Range ({rangeCount})</span>}
-            {epaCount      > 0 && <span className="text-[13px] font-medium text-blue-600 dark:text-blue-400">EPA ({epaCount})</span>}
-            {accelCount    > 0 && <span className="text-[13px] font-medium text-purple-600 dark:text-purple-400">Acceleration ({accelCount})</span>}
-            {brakingCount  > 0 && <span className="text-[13px] font-medium text-rose-600 dark:text-rose-400">Braking ({brakingCount})</span>}
+            {shown.map(c => (
+                <span key={c.key} className={`text-[13px] font-medium ${c.colorClass}`}>
+                    {c.label} ({counts[c.key]})
+                </span>
+            ))}
         </p>
     );
 }
@@ -77,6 +72,7 @@ export default function VehiclesView({
     const [formTags, setFormTags] = useState([]);
     const [newTagName, setNewTagName] = useState('');
     const [tagFilterStates, setTagFilterStates] = useState(savedState?.tagFilterStates ?? {}); // { [tagId]: 'or' | 'and' | 'not' }
+    const [dataFilterStates, setDataFilterStates] = useState(savedState?.dataFilterStates ?? {}); // { [categoryKey]: 'or' | 'and' | 'not' }
     const [imageUploading, setImageUploading] = useState(false);
     const [viewMode, setViewMode] = useState(savedState?.viewMode ?? 'card'); // 'card' | 'list'
     const [sortBy, setSortBy] = useState(savedState?.sortBy ?? 'default');
@@ -96,10 +92,10 @@ export default function VehiclesView({
     const persistableState = useRef({});
     useEffect(() => {
         persistableState.current = {
-            textFilter, tagFilterStates, mfgFilterStates, modelFilter,
+            textFilter, tagFilterStates, mfgFilterStates, dataFilterStates, modelFilter,
             sortBy, viewMode, vehiclePage,
         };
-    }, [textFilter, tagFilterStates, mfgFilterStates, modelFilter, sortBy, viewMode, vehiclePage]);
+    }, [textFilter, tagFilterStates, mfgFilterStates, dataFilterStates, modelFilter, sortBy, viewMode, vehiclePage]);
 
     // Save state back to App when this tab is left (unmount).
     useEffect(() => {
@@ -229,6 +225,18 @@ export default function VehiclesView({
         });
     };
 
+    // AND → NOT → clear. No OR state: the useful questions about data coverage
+    // are "has charging AND range" and "has no EPA data" — nobody asks for
+    // "charging or braking", so that state would only sit in the way.
+    const cycleDataFilter = (key) => {
+        setDataFilterStates(prev => {
+            const cur = prev[key];
+            if (!cur)          return { ...prev, [key]: 'and' };
+            if (cur === 'and') return { ...prev, [key]: 'not' };
+            const next = { ...prev }; delete next[key]; return next;
+        });
+    };
+
     // Stage 1: quad-state tag filter + committed-delete filter
     const orTags  = Object.entries(tagFilterStates).filter(([, s]) => s === 'or' ).map(([id]) => Number(id));
     const andTags = Object.entries(tagFilterStates).filter(([, s]) => s === 'and').map(([id]) => Number(id));
@@ -258,9 +266,12 @@ export default function VehiclesView({
         v.model && modelFilter.has(v.model)
     );
 
+    // Stage 2c: data-type filter — which kinds of test data the vehicle holds
+    const dataFiltered = filterByDataCategories(modelFiltered, dataFilterStates, performanceCounts);
+
     // Stage 3: text filter
     const textLower = textFilter.trim().toLowerCase();
-    const textFiltered = !textLower ? modelFiltered : modelFiltered.filter(v => {
+    const textFiltered = !textLower ? dataFiltered : dataFiltered.filter(v => {
         if ([v.name, v.make, v.model].some(f => (f || '').toLowerCase().includes(textLower))) return true;
         const year = String(v.year || '');
         if (year.toLowerCase().includes(textLower)) return true;
@@ -493,7 +504,7 @@ export default function VehiclesView({
     useEffect(() => {
         if (!didMount.current) { didMount.current = true; return; }
         setVehiclePage(1);
-    }, [textFilter, tagFilterStates, sortBy, mfgFilterStates]);
+    }, [textFilter, tagFilterStates, sortBy, mfgFilterStates, dataFilterStates]);
 
     const showReorderButtons = canEdit({}) && sortBy === 'default'
         && textFilter.trim() === '' && Object.keys(tagFilterStates).length === 0
@@ -691,6 +702,42 @@ export default function VehiclesView({
                     )}
                 </div>
             )}
+
+            {/* Data filter bar — which kinds of test data a vehicle holds.
+                Tri-state AND (blue) → NOT (red) → clear; no OR, see cycleDataFilter.
+                Counts are of the vehicles still standing after the tag/brand/model
+                filters, so a zero here means "none left", not "none in the database". */}
+            <div className="tag-filter-bar">
+                <span className="text-sm font-medium text-secondary flex-shrink-0">Data:</span>
+                {DATA_CATEGORIES.map(cat => {
+                    const state = dataFilterStates[cat.key];
+                    const stateClass = state === 'and' ? 'tag-filter-and'
+                        : state === 'not' ? 'tag-filter-not'
+                        : 'tag-filter-na';
+                    const available = modelFiltered.filter(v => hasDataCategory(v, cat.key, performanceCounts)).length;
+                    const tooltip = state === 'and' ? `AND — vehicles must have ${cat.label} data. Click for NOT.`
+                        : state === 'not' ? `NOT — vehicles with ${cat.label} data are hidden. Click to clear.`
+                        : `Click to show only vehicles with ${cat.label} data`;
+                    return (
+                        <button
+                            key={cat.key}
+                            onClick={() => cycleDataFilter(cat.key)}
+                            className={`tag-filter-btn ${stateClass}`}
+                            title={tooltip}
+                        >
+                            {cat.label} ({available})
+                        </button>
+                    );
+                })}
+                {Object.keys(dataFilterStates).length > 0 && (
+                    <button
+                        onClick={() => setDataFilterStates({})}
+                        className="text-xs text-faint hover:text-secondary underline ml-1 flex-shrink-0"
+                    >
+                        Clear
+                    </button>
+                )}
+            </div>
 
             {/* Select All / Clear All Visible */}
             {textFiltered.length > 0 && (

--- a/src/utils/vehicleDataCategories.js
+++ b/src/utils/vehicleDataCategories.js
@@ -1,0 +1,93 @@
+/**
+ * Which kinds of data a vehicle has, and how much of each.
+ *
+ * Single source of truth for the Vehicles page: the "Tests:" pills on each card
+ * and the data-type filter both read from here, so adding a category later is
+ * one edit rather than three that can drift apart.
+ *
+ * Performance counts are passed in rather than read off the vehicle, because
+ * they aren't on the vehicle record — getVehicles deliberately doesn't embed the
+ * performance tables (a nested select against a table that doesn't exist yet
+ * fails the whole query and blanks the app), so AppContext loads them separately.
+ */
+
+/**
+ * Category definitions, in display order.
+ *
+ * `count` reads a vehicle's total for that category. `colorClass` is the pill
+ * styling; keeping it here means the filter chip and the card pill can share it.
+ */
+export const DATA_CATEGORIES = [
+    {
+        key: 'charging',
+        label: 'Charging',
+        colorClass: 'text-green-600 dark:text-green-400',
+        count: (v) => v.runs?.filter(r => r.has_charging).length ?? 0,
+    },
+    {
+        key: 'range',
+        label: 'Range',
+        colorClass: 'text-amber-600 dark:text-amber-400',
+        count: (v) => v.runs?.filter(r => r.has_range).length ?? 0,
+    },
+    {
+        key: 'epa',
+        label: 'EPA',
+        colorClass: 'text-blue-600 dark:text-blue-400',
+        count: (v) => v.epa_mappings?.length ?? 0,
+    },
+    {
+        key: 'accel',
+        label: 'Acceleration',
+        colorClass: 'text-purple-600 dark:text-purple-400',
+        count: (v, perf) => perf?.[v.id]?.accel ?? 0,
+    },
+    {
+        key: 'braking',
+        label: 'Braking',
+        colorClass: 'text-rose-600 dark:text-rose-400',
+        count: (v, perf) => perf?.[v.id]?.braking ?? 0,
+    },
+];
+
+/**
+ * Counts per category for one vehicle.
+ * @returns {Record<string, number>} e.g. { charging: 3, range: 8, epa: 2, accel: 6, braking: 0 }
+ */
+export function vehicleDataCategories(vehicle, performanceCounts = {}) {
+    const out = {};
+    for (const c of DATA_CATEGORIES) out[c.key] = c.count(vehicle, performanceCounts);
+    return out;
+}
+
+/** True when the vehicle has any data of that category. */
+export const hasDataCategory = (vehicle, key, performanceCounts = {}) => {
+    const cat = DATA_CATEGORIES.find(c => c.key === key);
+    return cat ? cat.count(vehicle, performanceCounts) > 0 : false;
+};
+
+/**
+ * Apply the data filter — AND / NOT only, unlike the tag filter's OR/AND/NOT.
+ *
+ * OR is dropped deliberately: the questions worth asking of data coverage are
+ * conjunctive ("has both charging and range", which is what the pairing work
+ * needs) or exclusionary ("has no EPA data" — what still needs looking up).
+ * "Has charging or braking" isn't a question anyone asks, and offering it makes
+ * the first click on a chip mean something nobody wants.
+ *
+ * @param {Array}  vehicles
+ * @param {Object} states  { [categoryKey]: 'and'|'not' }
+ * @param {Object} performanceCounts
+ */
+export function filterByDataCategories(vehicles, states, performanceCounts = {}) {
+    const pick = (s) => Object.entries(states).filter(([, v]) => v === s).map(([k]) => k);
+    const and = pick('and'), not = pick('not');
+    if (!and.length && !not.length) return vehicles;
+
+    return vehicles.filter(v => {
+        const has = (k) => hasDataCategory(v, k, performanceCounts);
+        if (not.some(has)) return false;
+        if (and.length && !and.every(has)) return false;
+        return true;
+    });
+}


### PR DESCRIPTION
Closes #163.

## Why

The Vehicles page could filter by tag, brand and model, but not by the one thing that decides whether a vehicle is useful for a given chart: what test data it actually has. Finding "every car with both charging and range data" meant reading 49 cards.

## What changed

**New `src/utils/vehicleDataCategories.js`** — the five categories (Charging, Range, EPA, Acceleration, Braking) with their label, colour and count function in one place. The card pills and the new filter both read from it, so adding a sixth category later is one edit rather than three that can drift apart. `TestCountPills` is refactored onto it and renders identically.

**Data filter bar** on the Vehicles page, below Brand/Model.

- Chips cycle **AND (blue) → NOT (red) → clear**. There is deliberately no OR state — the questions worth asking of data coverage are conjunctive ("has charging *and* range", which is what the pairing epic needs) or exclusionary ("has *no* EPA data" — i.e. what still needs looking up). "Charging or braking" isn't a question anyone asks, and offering it would make the first click on a chip mean something nobody wants.
- Each chip counts the vehicles **still standing after the tag/brand/model filters**, so it reports what is left to narrow rather than what exists in the database. A zero means "none left", not "none exist".
- Slots in as its own stage between the model filter and the text filter; resets pagination and persists across tab switches like the other filters.

## Reviewer notes

- **Performance counts stay passed in** rather than read off the vehicle record. `getVehicles` deliberately doesn't embed the performance tables — a nested select against a table that doesn't exist yet fails the *entire* PostgREST query and blanks the app, which is exactly how the vehicle list broke during #146. `AppContext` loads them separately.
- **Braking (0)** renders even though no braking data exists anywhere yet. Kept visible so the category is discoverable, the same way a tag with no vehicles still shows. Easy to hide zero-count categories if that reads as clutter.
- **No legend** on the Data row — the tag bar's ●OR ●AND ●NOT legend sits just above and the colours match, so a second one felt like noise. Tooltips spell out each state.

## Verification

`npm run build` green. Driven in the browser against real data: 49 vehicles → Acceleration AND → 5 → plus EPA AND → 2 → EPA flipped to NOT → 3 (5−2, correct) → cleared → back to 49. Visual sign-off given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)