### PR TITLE
Pairing phase 1: additive schema (kind, sessions, paired_range_run_id)

### DIFF
--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -6,8 +6,18 @@
 //   isXxxRun(run)        — predicate, takes a single run, returns boolean.
 //                          Use as a runFilter prop: <RunSelector runFilter={isChargingRun} />
 
-export const isChargingRun = (r) => r.has_charging !== false;
-export const isRangeRun    = (r) => !!r.has_range;
+// `kind` (migration 044) is the discriminator; the has_charging / has_range
+// booleans it replaced are still written by the app and kept in sync by a DB
+// trigger until #155 drops them. Reading kind-first with a boolean fallback
+// means this works whether or not migration 044 has been applied yet, so code
+// and migration can be deployed in either order.
+//
+// Note the fallback keeps the old asymmetry deliberately: a run with neither
+// flag set counts as charging (has_charging !== false), matching how these
+// predicates have always behaved. Migration 044 backfills those rows the same
+// way, so the two paths agree.
+export const isChargingRun = (r) => r.kind ? r.kind === 'charging' : r.has_charging !== false;
+export const isRangeRun    = (r) => r.kind ? r.kind === 'range'    : !!r.has_range;
 
 export const filterChargingRuns = (runs) => (runs || []).filter(isChargingRun);
 export const filterRangeRuns    = (runs) => (runs || []).filter(isRangeRun);

--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -17,7 +17,19 @@
 // predicates have always behaved. Migration 044 backfills those rows the same
 // way, so the two paths agree.
 export const isChargingRun = (r) => r.kind ? r.kind === 'charging' : r.has_charging !== false;
-export const isRangeRun    = (r) => r.kind ? r.kind === 'range'    : !!r.has_range;
+
+// `kind` alone CANNOT decide this one until #155 runs.
+//
+// A dual-role row — one drive recorded as a single run, with both flags set —
+// is genuinely both a charging test and a range test, and a single discriminator
+// cannot say so. The backfill assigns it kind='charging' (it is split into two
+// rows in #155), so testing kind alone would drop every such row out of the
+// range views. On the current database that is 35 of 76 runs.
+//
+// So has_range stays part of this predicate through the transition. After #155
+// the column is gone, `r.has_range` is undefined, and this collapses to the
+// kind check on its own with no further edit.
+export const isRangeRun = (r) => r.kind === 'range' || !!r.has_range;
 
 export const filterChargingRuns = (runs) => (runs || []).filter(isChargingRun);
 export const filterRangeRuns    = (runs) => (runs || []).filter(isRangeRun);

--- a/src/utils/vehicleDataCategories.js
+++ b/src/utils/vehicleDataCategories.js
@@ -9,7 +9,13 @@
  * they aren't on the vehicle record — getVehicles deliberately doesn't embed the
  * performance tables (a nested select against a table that doesn't exist yet
  * fails the whole query and blanks the app), so AppContext loads them separately.
+ *
+ * Charging and range counts go through the shared runUtils predicates rather
+ * than reading the role flags directly, so the card pills, the data filter and
+ * the chart run selectors can never disagree about what counts as a charging
+ * run — and all of them pick up `kind` (migration 044) together.
  */
+import { isChargingRun, isRangeRun } from './runUtils';
 
 /**
  * Category definitions, in display order.
@@ -22,13 +28,13 @@ export const DATA_CATEGORIES = [
         key: 'charging',
         label: 'Charging',
         colorClass: 'text-green-600 dark:text-green-400',
-        count: (v) => v.runs?.filter(r => r.has_charging).length ?? 0,
+        count: (v) => (v.runs || []).filter(isChargingRun).length,
     },
     {
         key: 'range',
         label: 'Range',
         colorClass: 'text-amber-600 dark:text-amber-400',
-        count: (v) => v.runs?.filter(r => r.has_range).length ?? 0,
+        count: (v) => (v.runs || []).filter(isRangeRun).length,
     },
     {
         key: 'epa',

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -82,8 +82,11 @@ One charging or range test session per vehicle.
 | `color` | `text` | `'#3b82f6'` | Chart series color |
 | `is_default` | `boolean` | `false` | |
 | `synthetic` | `boolean` | `false` | True for estimated/simulated data |
-| `has_charging` | `boolean` | `true` | |
-| `has_range` | `boolean` | `false` | |
+| `kind` | `text` | — | `'charging'` \| `'range'`. Test role discriminator. Derived from the two booleans below by trigger `trg_runs_sync_kind`; see migration 044 |
+| `has_charging` | `boolean` | `true` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
+| `has_range` | `boolean` | `false` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
+| `session_id` | `bigint` | `NULL` | FK → `test_sessions.id` ON DELETE SET NULL. Advisory grouping; never required |
+| `paired_range_run_id` | `bigint` | `NULL` | FK → `runs.id` ON DELETE SET NULL. Curator-set default range partner for a charging run |
 | `software_version` | `text` | — | |
 | `conditions` | `text` | — | Freeform notes |
 | `source` | `text` | — | URL to source video/post |
@@ -102,6 +105,29 @@ One charging or range test session per vehicle.
 | `created_at` | `timestamptz` | `now()` | |
 
 > Runs have no `user_id`. Ownership and edit permission are inherited from the parent vehicle via RLS subquery joins.
+
+---
+
+### `test_sessions`
+
+One testing outing — the runs measured during it share weather, route and afternoon. Added by migration 044 as groundwork for charging/range pairing (#150).
+
+**No `vehicle_id` by design:** a session can span several vehicles (three cars driven side by side on one loop is a single outing, and shared conditions are the whole point of grouping them). Each run carries its own `vehicle_id`, so one session's runs may belong to different vehicles.
+
+Distinct from `performance_sessions` (migration 036), which is one vehicle's accel/braking outing and shares none of these columns.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | `bigint` | auto | PK |
+| `name` | `text` | — | Human label, e.g. "Ottawa winter loop". Doubles as the short chart label for a pair whose halves both come from this session |
+| `tested_at` | `timestamp` | — | Wall-clock at the test site; zone-less, as sources report local time with no offset |
+| `tester` | `text` | — | |
+| `location_name` | `text` | — | |
+| `temperature_f` | `numeric` | — | Session-level reading. `runs.temperature_f` stays authoritative per row; congruence checks prefer this when present |
+| `source_name` | `text` | — | |
+| `url` | `text` | — | |
+| `notes` | `text` | — | |
+| `created_at` | `timestamptz` | `now()` | |
 
 ---
 
@@ -273,6 +299,19 @@ Runs inherit ownership from their parent vehicle via subquery join.
 | INSERT | Parent vehicle is owned by user OR role is `admin`/`contributor` |
 | UPDATE | Parent vehicle is owned by user OR role is `admin`/`contributor` |
 | DELETE | Parent vehicle is owned by user OR role is `admin` |
+
+---
+
+### `test_sessions`
+
+Has no parent vehicle to inherit from (a session may span several), so it carries its own policies — the same shape as `manufacturers`.
+
+| Operation | Allowed when |
+|-----------|-------------|
+| SELECT | Always (public read) |
+| INSERT | Role is `admin`/`contributor` |
+| UPDATE | Role is `admin`/`contributor` |
+| DELETE | Role is `admin` |
 
 ---
 

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -78,7 +78,7 @@ One charging or range test session per vehicle.
 | `id` | `bigint` | auto | PK |
 | `vehicle_id` | `bigint` | — | FK → `vehicles.id` |
 | `name` | `text` | — | |
-| `date` | `text` | — | ISO date string |
+| `date` | `text` | — | ISO date string. **NOT NULL** — inserts must supply it |
 | `color` | `text` | `'#3b82f6'` | Chart series color |
 | `is_default` | `boolean` | `false` | |
 | `synthetic` | `boolean` | `false` | True for estimated/simulated data |

--- a/supabase/migrations/044_pairing_schema.sql
+++ b/supabase/migrations/044_pairing_schema.sql
@@ -198,9 +198,14 @@ COMMIT;
 --             count(*) FILTER (WHERE NOT has_charging AND NOT has_range)   AS neither
 --      FROM runs GROUP BY kind;
 --
--- 3. The trigger fires on insert — expect 'range':
+-- 3. The trigger fires on insert — expect 'range'.
 --
---      INSERT INTO runs (vehicle_id, name, has_charging, has_range)
---      VALUES ((SELECT id FROM vehicles LIMIT 1), 'trigger test', false, true)
---      RETURNING kind;
---      -- then: DELETE FROM runs WHERE name = 'trigger test';
+--    Wrapped in a transaction that is rolled back, so nothing is written and
+--    there is no cleanup step to forget. `date` is NOT NULL on runs, hence the
+--    placeholder — omitting it fails on that constraint, not on anything here.
+--
+--      BEGIN;
+--      INSERT INTO runs (vehicle_id, name, date, has_charging, has_range)
+--      VALUES ((SELECT id FROM vehicles LIMIT 1), 'trigger test', '2026-01-01', false, true)
+--      RETURNING name, kind;
+--      ROLLBACK;

--- a/supabase/migrations/044_pairing_schema.sql
+++ b/supabase/migrations/044_pairing_schema.sql
@@ -1,0 +1,206 @@
+-- ============================================================
+-- Migration 044: Charging/range pairing — Part 1 (additive, reversible)
+--
+-- Groundwork for issue #150: letting any charging test pair with any range
+-- test at graph time. This migration adds structure only — no data is moved,
+-- no column is dropped, and nothing user-visible changes.
+--
+-- Three additions:
+--   1. runs.kind            — a discriminator replacing the has_charging /
+--                             has_range boolean pair (which admits four states,
+--                             two of them meaningless).
+--   2. test_sessions        — a testing outing; the home for environmental
+--                             metadata shared by the runs measured during it.
+--   3. runs.paired_range_run_id — the curator-set default range partner for a
+--                             charging test.
+--
+-- The row split (one dual-role run becoming a charging row plus a range row)
+-- and the CHECK constraints enforcing off-role columns are NULL are
+-- deliberately NOT here — they are destructive and land in #155.
+-- ============================================================
+
+
+-- Wrapped in a transaction: this is pasted into the SQL editor by hand, and a
+-- failure partway through would otherwise leave `kind` added but unpopulated,
+-- or the trigger missing.
+BEGIN;
+
+
+-- ── 1. Test sessions ─────────────────────────────────────────────────────────
+--
+-- A session is one testing outing: same weather, same route, same afternoon.
+--
+-- Deliberately has NO vehicle_id. A session can span several vehicles — three
+-- cars driven side by side on one loop is a single outing, and the whole point
+-- of grouping them is that they share conditions. Each run carries its own
+-- vehicle_id, so a session's runs may belong to different vehicles.
+--
+-- Distinct from `performance_sessions` (migration 036), which is one vehicle's
+-- accel/braking outing and shares none of these columns.
+
+CREATE TABLE test_sessions (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+
+    -- Human label for the outing, e.g. "Ottawa winter loop". Doubles as the
+    -- short chart label for a pair whose halves both come from this session
+    -- (see #153) — a good name here saves a lot of legend width.
+    name            text,
+
+    -- Wall-clock time at the test site. Zone-less for the same reason as
+    -- performance_sessions.tested_at: sources report local time with no offset
+    -- and we cannot infer one without a tz database.
+    tested_at       timestamp,
+
+    tester          text,
+    location_name   text,
+
+    -- Environmental context shared by every run in the session. runs.temperature_f
+    -- stays authoritative for its own row; this is the session-level reading, and
+    -- the congruence tiers in #154 prefer it when present.
+    temperature_f   numeric,
+
+    -- Provenance
+    source_name     text,
+    url             text,
+    notes           text,
+
+    created_at      timestamptz DEFAULT now()
+);
+
+COMMENT ON TABLE test_sessions IS
+    'A testing outing grouping runs measured under the same conditions. May span multiple vehicles — no vehicle_id by design.';
+
+ALTER TABLE test_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read test sessions"
+    ON test_sessions FOR SELECT USING (true);
+
+CREATE POLICY "Contributors can insert test sessions"
+    ON test_sessions FOR INSERT
+    WITH CHECK (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Contributors can update test sessions"
+    ON test_sessions FOR UPDATE
+    USING (current_user_role() IN ('admin', 'contributor'));
+
+CREATE POLICY "Admins can delete test sessions"
+    ON test_sessions FOR DELETE
+    USING (current_user_role() = 'admin');
+
+
+-- ── 2. runs.kind ─────────────────────────────────────────────────────────────
+--
+-- One shared derivation used by both the backfill and the sync trigger, so the
+-- two can never disagree.
+--
+--   has_range AND NOT has_charging  → 'range'
+--   everything else                 → 'charging'
+--
+-- Note what that second line covers:
+--   • dual-role rows (both true) become 'charging' — they are split in #155
+--   • both-false rows (currently invisible to BOTH selectors, since
+--     isChargingRun is has_charging !== false and isRangeRun is !!has_range)
+--     land as 'charging' rather than being lost
+
+CREATE OR REPLACE FUNCTION runs_derive_kind(p_has_charging boolean, p_has_range boolean)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+    SELECT CASE
+        WHEN COALESCE(p_has_range, false) AND NOT COALESCE(p_has_charging, true)
+        THEN 'range'
+        ELSE 'charging'
+    END;
+$$;
+
+ALTER TABLE runs ADD COLUMN kind text;
+
+UPDATE runs SET kind = runs_derive_kind(has_charging, has_range);
+
+ALTER TABLE runs ALTER COLUMN kind SET NOT NULL;
+ALTER TABLE runs ADD CONSTRAINT runs_kind_check CHECK (kind IN ('charging', 'range'));
+
+COMMENT ON COLUMN runs.kind IS
+    'Test role discriminator. Maintained from has_charging/has_range by trigger trg_runs_sync_kind until #155 drops those columns and makes this authoritative.';
+
+-- The trigger — not the application — owns `kind` during the transition.
+--
+-- This matters for deploy ordering: if the app wrote `kind` directly, shipping
+-- the code before this migration is applied would break every run insert, and
+-- forgetting to write it would silently mislabel new range runs as charging.
+-- With the trigger, the booleans stay authoritative on write, the app only
+-- reads `kind`, and the two can be deployed in either order.
+--
+-- Consequence: an explicitly-supplied `kind` is overwritten. That is intended
+-- for now. #155 drops the trigger along with the booleans.
+
+CREATE OR REPLACE FUNCTION runs_sync_kind() RETURNS trigger AS $$
+BEGIN
+    NEW.kind := runs_derive_kind(NEW.has_charging, NEW.has_range);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_runs_sync_kind
+    BEFORE INSERT OR UPDATE OF has_charging, has_range ON runs
+    FOR EACH ROW EXECUTE FUNCTION runs_sync_kind();
+
+
+-- ── 3. Session link and curated pairing ──────────────────────────────────────
+--
+-- session_id is nullable and ADVISORY. Nothing may ever require it: most
+-- existing runs will never have one, and imported runs must not become
+-- second-class for lacking one. ON DELETE SET NULL — deleting a session
+-- ungroups its runs, it does not delete them.
+
+ALTER TABLE runs
+    ADD COLUMN session_id bigint REFERENCES test_sessions(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_runs_session ON runs(session_id);
+
+COMMENT ON COLUMN runs.session_id IS
+    'Advisory grouping: runs measured during the same outing. Never required.';
+
+-- The curator-set default range partner for a charging run, used as priority 1
+-- of the resolution order in #150. Self-referencing; SET NULL so deleting a
+-- range test cannot cascade into the charging test that referenced it.
+--
+-- That this points at a run whose kind is 'range' is enforced by the
+-- application, not the schema — a cross-row CHECK would need its own trigger,
+-- and it becomes expressible more cheaply once #155 lands.
+
+ALTER TABLE runs
+    ADD COLUMN paired_range_run_id bigint REFERENCES runs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_runs_paired_range ON runs(paired_range_run_id);
+
+COMMENT ON COLUMN runs.paired_range_run_id IS
+    'Curator-set default range test for this charging run. App-enforced to reference a kind=range run.';
+
+
+COMMIT;
+
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+--
+-- Run these after applying. Expected results noted on each.
+--
+-- 1. kind agrees with the booleans on every row — expect 0:
+--
+--      SELECT count(*) FROM runs
+--      WHERE kind IS DISTINCT FROM runs_derive_kind(has_charging, has_range);
+--
+-- 2. Population census — the dual-role count is what #155 will split, and the
+--    both-false count is worth eyeballing since those rows are currently
+--    invisible in both run selectors:
+--
+--      SELECT kind,
+--             count(*)                                                    AS rows,
+--             count(*) FILTER (WHERE has_charging AND has_range)           AS dual_role,
+--             count(*) FILTER (WHERE NOT has_charging AND NOT has_range)   AS neither
+--      FROM runs GROUP BY kind;
+--
+-- 3. The trigger fires on insert — expect 'range':
+--
+--      INSERT INTO runs (vehicle_id, name, has_charging, has_range)
+--      VALUES ((SELECT id FROM vehicles LIMIT 1), 'trigger test', false, true)
+--      RETURNING kind;
+--      -- then: DELETE FROM runs WHERE name = 'trigger test';


### PR DESCRIPTION
Closes #151. Phase 1 of #150 — **additive and reversible, nothing user-visible changes.**

## ⚠️ Apply migration 044 in the Supabase SQL editor

Not strictly required before deploying (see the trigger note below — code and migration can ship in either order), but until it is applied nothing else in the epic can start.

## What it adds

**`runs.kind`** (`'charging' | 'range'`) replaces the `has_charging` / `has_range` pair, which admits four states with two of them meaningless — both-true is the collection artifact this epic exists to remove, both-false says nothing. Backfill:

| has_charging | has_range | → kind | |
|---|---|---|---|
| `t` | `f` | `charging` | |
| `f` | `t` | `range` | |
| `t` | `t` | `charging` | dual-role; split in #155 |
| `f` | `f` | `charging` | currently invisible to **both** selectors — folded in rather than lost |

**`test_sessions`** — a testing outing, and the home for environmental metadata its runs share. **No `vehicle_id` by design:** three cars driven side by side on one loop is a single outing, and shared conditions are the whole point of grouping them. Each run keeps its own `vehicle_id`, so one session's runs may span vehicles. Distinct from `performance_sessions` (036), which is one vehicle's accel/braking outing and shares none of these columns.

**`runs.session_id`** — advisory, nullable, `ON DELETE SET NULL`. Nothing may ever require it, or imported and legacy runs become second-class.

**`runs.paired_range_run_id`** — the curator-set default range partner (priority 1 of the resolution order in #150). Self-referencing, `SET NULL`. That it points at a `kind='range'` run is app-enforced; a cross-row CHECK needs its own trigger and gets cheaper after #155.

## Why a trigger owns `kind`

The application does **not** write `kind`. If it did, deploying the code before the migration was applied would break every run insert, and forgetting to write it would silently mislabel new range runs as charging. With `trg_runs_sync_kind` the booleans stay authoritative on write, the app only reads `kind`, and the two can ship in either order. #155 drops the trigger along with the booleans.

Consequence, and it's intended for now: an explicitly-supplied `kind` is overwritten by the trigger.

## Deliberately not here

The row split and the CHECK constraints asserting off-role columns are NULL. Both are destructive and belong to #155.

## Application changes

`isChargingRun` / `isRangeRun` read `kind` with a boolean fallback, so they behave correctly before *or* after the migration. The fallback preserves the existing asymmetry (a run with neither flag counts as charging), and the backfill treats those rows the same way, so both paths agree.

`vehicleDataCategories` now routes its card-pill counts through those predicates instead of reading the raw flags — it was using truthy `r.has_charging` where the selectors use `!== false`. Same result on current data, but the card pills, the data filter and the chart run selectors can no longer drift apart, and all three pick up `kind` together.

## Testing

Run against a throwaway PostgreSQL 18 cluster with stand-ins for `vehicles`, `runs` and `current_user_role()`, then torn down:

- Migration applies cleanly in a single transaction (wrapped, since these are pasted in by hand and a partial apply would leave `kind` added but unpopulated)
- Backfill: **0 mismatches** across all four boolean combinations
- Trigger fires correctly on insert, on boolean update, and overrides an explicitly-supplied `kind`
- `CHECK` rejects an invalid kind
- Deleting a session **ungroups** its runs without deleting them
- Deleting a range test **nulls** the pairing without cascading
- Sessionless inserts work — `session_id` really is optional
- `vite build` green

Not tested against the real database — the migration is unapplied. The verification queries are in the migration's footer comments, including a census of dual-role and both-false rows worth eyeballing before #155.

## Note on SCHEMA.md

`test_sessions`, the new `runs` columns and the RLS block are documented. The **migration list at the bottom of that file stops at 006** while the directory is at 044 — long stale, left alone here rather than half-fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)