### PR TITLE
Pairing phase 2: range-source resolver

### DIFF
--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -7,7 +7,8 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, filterRangeRuns, isRangeRun } from '../utils/runUtils';
+import { filterChargingRuns, filterRangeRuns, isRangeRun, isChargingRun } from '../utils/runUtils';
+import { resolveRangeSource } from '../utils/rangeSource';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
@@ -319,12 +320,20 @@ export default function ChargeCompareView({
                 null;
 
             for (const rangeRun of rangeRuns) {
-                const selfHasCharging = rangeRun.has_charging !== false;
-                const chargingRun     = selfHasCharging ? rangeRun : defaultCharging;
+                const chargingRun = isChargingRun(rangeRun) ? rangeRun : defaultCharging;
+                // Selecting a range run for this bar IS an explicit pairing, so it
+                // takes rank 1. The resolver still falls through to the vehicle
+                // default or the recorded range column when the chosen test has no
+                // usable distance/SoC data, and reports which it landed on.
+                const rangeSrc = resolveRangeSource(chargingRun, {
+                    vehicle,
+                    explicitPairing: rangeRun,
+                });
                 result.push({
                     rangeRun:        { ...rangeRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
                     chargingRunId:   chargingRun?.id   ?? null,
                     chargingRunName: chargingRun?.name ?? null,
+                    rangeSrc,
                 });
             }
         }
@@ -385,7 +394,7 @@ export default function ChargeCompareView({
     const buildBars = (chartType) => {
         const flatRuns = [];
 
-        for (const { rangeRun, chargingRunId, chargingRunName } of activeResolvedRuns) {
+        for (const { rangeRun, chargingRunId, chargingRunName, rangeSrc } of activeResolvedRuns) {
             const base = {
                 id:              rangeRun.id,
                 name:            rangeRun.name,
@@ -399,6 +408,10 @@ export default function ChargeCompareView({
                 _chargingRunName: chargingRunName,
                 _yUnit:          chartType === 'range_added' ? distanceLabel(units) : 'min',
                 _rangeUnit:      distanceLabel(units),
+                // Which range basis produced these miles, for the provenance label.
+                _rangeSource:    rangeSrc?.source ?? 'none',
+                _rangeSourceNote: rangeSrc?.note ?? null,
+                _rangeSourceRun:  rangeSrc?.sourceRun?.name ?? null,
             };
 
             // No charging run resolved, or data not yet loaded
@@ -407,9 +420,19 @@ export default function ChargeCompareView({
                 continue;
             }
 
-            // Filter to points that have all three fields we need
+            // Which range basis is in play (see utils/rangeSource.js).
+            //
+            // miPerSoc present → LINEAR: miles come from the paired range test's
+            //   measured miles-per-%SoC, so the charging run only has to supply
+            //   SoC against time. Runs with no recorded range column now work.
+            // miPerSoc null    → RECORDED: fall back to interpolating the run's
+            //   own range_value points, which is what this chart always did.
+            const miPerSoc  = rangeSrc?.miPerSoc ?? null;
+            const useLinear = miPerSoc != null;
+
+            // The recorded path additionally needs the range column.
             const raw = (runDataCache[chargingRunId] || []).filter(
-                p => p.soc != null && p.time != null && p.range != null
+                p => p.soc != null && p.time != null && (useLinear || p.range != null)
             );
 
             if (raw.length === 0) {
@@ -418,14 +441,20 @@ export default function ChargeCompareView({
             }
 
             // Sort by each axis for clean interpolation
-            const bySoc   = [...raw].sort((a, b) => a.soc   - b.soc);
-            const byTime  = [...raw].sort((a, b) => a.time  - b.time);
-            const byRange = [...raw].sort((a, b) => a.range - b.range);
+            const bySoc  = [...raw].sort((a, b) => a.soc  - b.soc);
+            const byTime = [...raw].sort((a, b) => a.time - b.time);
+
+            // Absolute range at a given SoC. Linear reads it off the paired test
+            // (range remaining at that SoC); recorded interpolates the run's own
+            // range column.
+            const rangeAtSoc = (soc) => useLinear
+                ? soc * miPerSoc
+                : interpolate(bySoc, 'soc', 'range', soc, true);
 
             // Z baseline: exact interpolation (or backward extrapolation) to startSoc.
             // allowExtrapolateBefore=true lets us normalize runs whose data starts above startSoc.
-            const Tz = interpolate(bySoc, 'soc', 'time',  startSoc, true);
-            const Rz = interpolate(bySoc, 'soc', 'range', startSoc, true);
+            const Tz = interpolate(bySoc, 'soc', 'time', startSoc, true);
+            const Rz = rangeAtSoc(startSoc);
 
             if (Tz == null || Rz == null) {
                 flatRuns.push({ ...base, _yValue: 0, _startSoc: startSoc, _startRange: null, _noData: true });
@@ -439,8 +468,12 @@ export default function ChargeCompareView({
                 const targetTime  = Tz + xMinutes;
                 const lastTime    = byTime[byTime.length - 1].time;
                 const timeOvershoot = Math.max(0, targetTime - lastTime);
-                const Rend   = interpolate(byTime, 'time', 'range', targetTime, false, true);
-                const SocEnd = interpolate(byTime, 'time', 'soc',   targetTime, false, true);
+                const SocEnd = interpolate(byTime, 'time', 'soc', targetTime, false, true);
+                // Linear: the SoC gained over the window, priced at the paired
+                // test's miles-per-%SoC. Recorded: read the range column directly.
+                const Rend = useLinear
+                    ? (SocEnd != null ? SocEnd * miPerSoc : null)
+                    : interpolate(byTime, 'time', 'range', targetTime, false, true);
                 const yValueMi = Rend != null ? Math.round((Rend - Rz) * 10) / 10 : null;
                 const yValue   = yValueMi != null ? convDistance(yValueMi, units) : null;
                 flatRuns.push({
@@ -455,11 +488,25 @@ export default function ChargeCompareView({
                     _noData:          yValue == null,
                 });
             } else {
-                const targetRange  = Rz + mMiles;
-                const lastRange    = byRange[byRange.length - 1].range;
-                const rangeOvershoot = Math.max(0, targetRange - lastRange);
-                const Tend   = interpolate(byRange, 'range', 'time', targetRange, false, true);
-                const SocEnd = interpolate(byRange, 'range', 'soc',  targetRange, false, true);
+                // Linear: the miles asked for convert to a SoC target, and the
+                // charging curve is read on the SoC axis. Recorded: sort by the
+                // range column and read time off it, as before.
+                let Tend, SocEnd, rangeOvershoot;
+                if (useLinear) {
+                    const targetSoc = startSoc + mMiles / miPerSoc;
+                    const lastSoc   = bySoc[bySoc.length - 1].soc;
+                    Tend   = interpolate(bySoc, 'soc', 'time', targetSoc, false, true);
+                    SocEnd = targetSoc;
+                    // Expressed in miles so it stays comparable with mMiles.
+                    rangeOvershoot = Math.max(0, targetSoc - lastSoc) * miPerSoc;
+                } else {
+                    const byRange     = [...raw].sort((a, b) => a.range - b.range);
+                    const targetRange = Rz + mMiles;
+                    const lastRange   = byRange[byRange.length - 1].range;
+                    Tend   = interpolate(byRange, 'range', 'time', targetRange, false, true);
+                    SocEnd = interpolate(byRange, 'range', 'soc',  targetRange, false, true);
+                    rangeOvershoot = Math.max(0, targetRange - lastRange);
+                }
                 const yValue = Tend != null ? Math.round((Tend - Tz) * 10) / 10 : null;
                 flatRuns.push({
                     ...base,
@@ -539,6 +586,14 @@ export default function ChargeCompareView({
                                         run._startSoc   != null ? (run._endSoc   != null ? `SoC: ${run._startSoc}% → ${run._endSoc}%`                   : `Start SoC: ${run._startSoc}%`)        : null,
                                         run._startRange != null ? (run._endRange != null ? `Range: ${run._startRange} → ${run._endRange} ${ru}` : `Start range: ${run._startRange} ${ru}`) : null,
                                         run._chargingRunName && run._chargingRunName !== run.name ? `Charging data: ${run._chargingRunName}` : null,
+                                        // Which range basis priced these miles. Named on every
+                                        // bar: a measured-efficiency figure and a guess-o-meter
+                                        // readout must never be silently interchangeable.
+                                        run._rangeSource === 'recorded'
+                                            ? 'Range: recorded range column'
+                                            : run._rangeSourceRun && run._rangeSourceRun !== run.name
+                                                ? `Range basis: ${run._rangeSourceRun}`
+                                                : null,
                                     ].filter(Boolean), units);
                                 },
                             },

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -7,6 +7,7 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, isChargingRun } from '../utils/runUtils';
+import { resolveRangeSource } from '../utils/rangeSource';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -78,37 +79,11 @@ function calcIceTotalTimeAtSpeed(speedMph, totalDistanceMi, overheadMin) {
     return t;
 }
 
-// ── Efficiency helpers ───────────────────────────────────────────────────────
-
-/**
- * Derive mi/kWh from a run record, with two fallback methods:
- *   1. Direct:    distance_miles / energy_kwh          (preferred — measured energy)
- *   2. SoC-delta: distance_miles / (ΔSoC% × battery)  (estimated — uses usable capacity)
- * Returns null when there is insufficient data.
- */
-function computeMiPerKwh(run, batteryKwh) {
-    if (!run?.distance_miles) return null;
-    if (run.energy_kwh)
-        return run.distance_miles / run.energy_kwh;
-    // Estimate via SoC delta × battery capacity
-    if (run.start_soc != null && run.end_soc != null && batteryKwh
-            && run.start_soc > run.end_soc) {
-        const energyEst = (run.start_soc - run.end_soc) / 100 * batteryKwh;
-        if (energyEst > 0) return run.distance_miles / energyEst;
-    }
-    return null;
-}
-
-/** True when computeMiPerKwh will return a non-null value. */
-function hasRangeData(run, batteryKwh) {
-    return computeMiPerKwh(run, batteryKwh) !== null;
-}
-
-/** Human-readable note describing how efficiency was derived. */
-function efficiencyMethod(run) {
-    if (!run?.distance_miles) return null;
-    return run.energy_kwh ? null : 'est. from SoC Δ';
-}
+// Efficiency derivation moved to utils/rangeSource.js, shared with Charge
+// Compare. The mi/kWh math is unchanged (measured energy preferred, SoC-delta
+// estimate as fallback); what changed is that choosing WHICH range test to
+// derive from is now one ranked, user-overridable decision instead of two
+// views each guessing separately.
 
 // ── Default vehicle colors ───────────────────────────────────────────────────
 const PALETTE = [
@@ -454,35 +429,22 @@ export default function RoadTripView({
         const map = {};
         let colorIdx = 0;
         for (const vehicle of selectedVehicles) {
-            const bestRangeRun = [...(vehicle.runs || [])]
-                .filter(r => hasRangeData(r, vehicle.battery))
-                .sort((a, b) => new Date(b.date) - new Date(a.date))[0] || null;
-
             for (const run of filterChargingRuns(vehicle.runs)) {
-                const hasOwnRange = hasRangeData(run, vehicle.battery);
-                const rangeSource  = hasOwnRange ? run : bestRangeRun;
-                const miPerKwh     = rangeSource ? computeMiPerKwh(rangeSource, vehicle.battery) : null;
-
-                // Build a human-readable note about the efficiency source / method
-                let efficiencyNote = null;
-                if (!hasOwnRange && bestRangeRun) {
-                    const method = efficiencyMethod(bestRangeRun);
-                    efficiencyNote = method
-                        ? `eff. from ${bestRangeRun.name} (${method})`
-                        : `eff. from ${bestRangeRun.name}`;
-                } else if (hasOwnRange && efficiencyMethod(run)) {
-                    efficiencyNote = efficiencyMethod(run); // "est. from SoC Δ"
-                }
+                // Shared resolver (utils/rangeSource.js) — the same ranking Charge
+                // Compare uses, so the two views can no longer disagree about which
+                // range test a charging run's miles came from. It also supplies the
+                // provenance note this view used to assemble by hand.
+                const src = resolveRangeSource(run, { vehicle, batteryKwh: vehicle.battery });
 
                 map[run.id] = {
                     vehicle,
                     run,
-                    miPerKwh,
+                    miPerKwh:       src.miPerKwh,
                     // Assume 70 mph if not specified on the run or its range source
-                    testSpeedMph:   run.speed_mph ?? bestRangeRun?.speed_mph ?? null,
+                    testSpeedMph:   run.speed_mph ?? src.sourceRun?.speed_mph ?? null,
                     batteryKwh:     vehicle.battery,
                     color:          colorMap[run.id] || run.color || PALETTE[colorIdx % PALETTE.length],
-                    efficiencyNote,
+                    efficiencyNote: src.note,
                 };
                 colorIdx++;
             }

--- a/src/utils/rangeSource.js
+++ b/src/utils/rangeSource.js
@@ -25,22 +25,26 @@
  * ── Resolution order ─────────────────────────────────────────────────────────
  *
  *   1. 'paired'        explicit pairing chosen for this chart session
- *   2. 'same-run'      the charging run's OWN measured range data
- *   3. 'default-range' the vehicle's default range test
+ *   2. 'default-range' the vehicle's default range test
+ *   3. 'same-run'      the charging run's OWN measured range data
  *   4. 'recorded'      the charging run's recorded range_value data points
  *   5. 'none'          nothing usable
  *
- * Rank 2 is a refinement of the order agreed in #150. A dual-role run — one
- * drive recorded as a single row with both a charging curve and measured range
- * — is its own same-session partner, and 35 of 76 runs on the live database are
- * exactly that. Ranking the vehicle's default range test above it would pair a
- * drive against some other day's conditions while the conditions measured on
- * that very drive sat unused. After #155 splits those rows this rank stops
- * being a special case and becomes an ordinary same-session pairing.
+ * Rank 3 extends the order agreed in #150, which did not cover dual-role runs —
+ * one drive recorded as a single row carrying both a charging curve and measured
+ * range, which is 35 of 76 runs on the live database. It sits BELOW the vehicle
+ * default deliberately: the default range test is a deliberate, curated choice,
+ * whereas a row being dual-role is an artifact of how the data happened to be
+ * collected. Provenance, not a judgement about which conditions to compare against.
  *
- * 'recorded' stays last, as agreed: range_value is usually the car's own
- * guess-o-meter readout, it may not match the range shown anywhere else, and it
- * answers a different question than a measured-efficiency computation.
+ * Note this is the run's *measured* distance and SoC bounds, which is a different
+ * thing from rank 4. 'recorded' stays last as agreed: range_value is usually the
+ * car's own guess-o-meter readout, it may not match the range shown anywhere
+ * else, and it answers a different question than measured efficiency.
+ *
+ * Rank 3 goes dormant after #155: a split charging row carries no range columns,
+ * so it can never match. The same-session partner is surfaced through rank 1
+ * instead, with paired_range_run_id populated from the session.
  *
  * Pure module — no data-point access. The 'recorded' branch is *signalled* here
  * and computed by the caller, which is the side that holds the time series.
@@ -166,14 +170,15 @@ export function resolveRangeSource(chargingRun, {
     // Ranks 1–3 all resolve to a range run; pick the first that yields data.
     const candidates = [
         ['paired',        explicitPairing],
-        ['same-run',      isRangeRun(chargingRun) ? chargingRun : null],
         ['default-range', defaultRangeRun(vehicle, batteryKwh)],
+        ['same-run',      isRangeRun(chargingRun) ? chargingRun : null],
     ];
 
     for (const [source, run] of candidates) {
         if (!run || !hasUsableRangeData(run, batteryKwh)) continue;
-        // A default that resolves back to this same run is the same-run case,
-        // already tried above — don't relabel it as inherited from elsewhere.
+        // When the vehicle default resolves back to this very run, that is the
+        // same-run case reached by another route — fall through so it gets the
+        // 'same-run' label rather than reading as inherited from elsewhere.
         if (source === 'default-range' && run.id === chargingRun.id) continue;
 
         const { miPerKwh, method } = miPerKwhFrom(run, batteryKwh);

--- a/src/utils/rangeSource.js
+++ b/src/utils/rangeSource.js
@@ -1,0 +1,202 @@
+/**
+ * Range-source resolution — which range test supplies the miles for a charging
+ * test, and how that answer was reached.
+ *
+ * Replaces two ad-hoc resolvers that solved the same problem in opposite
+ * directions: ChargeCompareView iterated range runs and hunted for a charging
+ * run, RoadTripView iterated charging runs and hunted for efficiency. Both are
+ * now this one function, and the answer becomes user-controllable in #153.
+ *
+ * ── The math ─────────────────────────────────────────────────────────────────
+ *
+ * Pairing charging test C with range test R needs one scalar:
+ *
+ *     miPerSoc = R.distance_miles / (R.start_soc − R.end_soc)
+ *
+ * The charging test supplies ΔSoC over time; the range test supplies miles per
+ * %SoC. No battery capacity, no efficiency-unit conversion:
+ *
+ *     range added over t minutes = ΔSoC(t) × miPerSoc
+ *     time to add M miles        = time for C to gain (M / miPerSoc) percent
+ *
+ * Energy-based consumers (the road-trip simulator) want mi/kWh instead, which
+ * prefers measured energy and falls back to SoC-delta against usable capacity.
+ *
+ * ── Resolution order ─────────────────────────────────────────────────────────
+ *
+ *   1. 'paired'        explicit pairing chosen for this chart session
+ *   2. 'same-run'      the charging run's OWN measured range data
+ *   3. 'default-range' the vehicle's default range test
+ *   4. 'recorded'      the charging run's recorded range_value data points
+ *   5. 'none'          nothing usable
+ *
+ * Rank 2 is a refinement of the order agreed in #150. A dual-role run — one
+ * drive recorded as a single row with both a charging curve and measured range
+ * — is its own same-session partner, and 35 of 76 runs on the live database are
+ * exactly that. Ranking the vehicle's default range test above it would pair a
+ * drive against some other day's conditions while the conditions measured on
+ * that very drive sat unused. After #155 splits those rows this rank stops
+ * being a special case and becomes an ordinary same-session pairing.
+ *
+ * 'recorded' stays last, as agreed: range_value is usually the car's own
+ * guess-o-meter readout, it may not match the range shown anywhere else, and it
+ * answers a different question than a measured-efficiency computation.
+ *
+ * Pure module — no data-point access. The 'recorded' branch is *signalled* here
+ * and computed by the caller, which is the side that holds the time series.
+ */
+
+import { isRangeRun } from './runUtils';
+
+/**
+ * Miles per %SoC from a range test.
+ *
+ * Guards the degenerate cases: no distance, missing SoC bounds, and
+ * start === end (which would divide by zero and yield Infinity miles/%).
+ */
+export function miPerSocFrom(run) {
+    if (!run?.distance_miles) return null;
+    const { start_soc: start, end_soc: end } = run;
+    if (start == null || end == null) return null;
+    const socDelta = start - end;
+    if (!(socDelta > 0)) return null;
+    return run.distance_miles / socDelta;
+}
+
+/**
+ * Miles per kWh from a range test.
+ *
+ *   1. measured energy — distance / energy_kwh                (preferred)
+ *   2. SoC-delta estimate — distance / (ΔSoC% × usable kWh)   (needs capacity)
+ *
+ * Returns { miPerKwh, method } so callers can label an estimate as one.
+ */
+export function miPerKwhFrom(run, batteryKwh) {
+    if (!run?.distance_miles) return { miPerKwh: null, method: null };
+
+    if (run.energy_kwh) {
+        return { miPerKwh: run.distance_miles / run.energy_kwh, method: 'measured-energy' };
+    }
+
+    const socDelta = (run.start_soc != null && run.end_soc != null)
+        ? run.start_soc - run.end_soc
+        : null;
+    if (socDelta > 0 && batteryKwh > 0) {
+        const energyEst = (socDelta / 100) * batteryKwh;
+        if (energyEst > 0) {
+            return { miPerKwh: run.distance_miles / energyEst, method: 'soc-delta-estimate' };
+        }
+    }
+
+    return { miPerKwh: null, method: null };
+}
+
+/** True when a run carries range data this module can actually use. */
+export function hasUsableRangeData(run, batteryKwh) {
+    if (!isRangeRun(run)) return false;
+    return miPerSocFrom(run) != null || miPerKwhFrom(run, batteryKwh).miPerKwh != null;
+}
+
+/**
+ * The vehicle's default range test: an explicitly-defaulted one first, then the
+ * most recent that carries usable data.
+ *
+ * `is_default` is currently scoped to charging runs; #155 scopes it per kind, at
+ * which point the first branch starts firing for range tests too. Until then
+ * this resolves to most-recent, which is what RoadTripView already did.
+ */
+export function defaultRangeRun(vehicle, batteryKwh = vehicle?.battery) {
+    const candidates = (vehicle?.runs || []).filter(r => hasUsableRangeData(r, batteryKwh));
+    if (candidates.length === 0) return null;
+    return candidates.find(r => r.isDefault || r.is_default)
+        ?? [...candidates].sort((a, b) => new Date(b.date) - new Date(a.date))[0]
+        ?? null;
+}
+
+/** Human-readable provenance, e.g. `eff. from Ottawa loop (est. from SoC Δ)`. */
+function buildNote(source, sourceRun, energyMethod) {
+    const estimate = energyMethod === 'soc-delta-estimate' ? 'est. from SoC Δ' : null;
+
+    switch (source) {
+        case 'paired':
+            return `paired with ${sourceRun.name}${estimate ? ` (${estimate})` : ''}`;
+        case 'same-run':
+            return estimate ?? null;   // same row — naming it would be noise
+        case 'default-range':
+            return `eff. from ${sourceRun.name}${estimate ? ` (${estimate})` : ''}`;
+        case 'recorded':
+            return 'from recorded range column';
+        default:
+            return null;
+    }
+}
+
+/**
+ * Resolve the range source for one charging run.
+ *
+ * @param {Object}  chargingRun
+ * @param {Object}  opts
+ * @param {Object}  opts.vehicle            owning vehicle (for the default range test)
+ * @param {Object}  [opts.explicitPairing]  range run chosen for this chart session
+ * @param {number}  [opts.batteryKwh]       usable capacity; defaults to vehicle.battery
+ * @param {boolean} [opts.hasRecordedRange] whether the charging run's data points
+ *                                          carry range_value — the caller knows,
+ *                                          this module deliberately does not
+ * @returns {{
+ *   source: 'paired'|'same-run'|'default-range'|'recorded'|'none',
+ *   sourceRun: Object|null,
+ *   miPerSoc: number|null,
+ *   miPerKwh: number|null,
+ *   energyMethod: 'measured-energy'|'soc-delta-estimate'|null,
+ *   note: string|null,
+ * }}
+ */
+export function resolveRangeSource(chargingRun, {
+    vehicle,
+    explicitPairing = null,
+    batteryKwh = vehicle?.battery,
+    hasRecordedRange = false,
+} = {}) {
+    const none = {
+        source: 'none', sourceRun: null,
+        miPerSoc: null, miPerKwh: null, energyMethod: null, note: null,
+    };
+    if (!chargingRun) return none;
+
+    // Ranks 1–3 all resolve to a range run; pick the first that yields data.
+    const candidates = [
+        ['paired',        explicitPairing],
+        ['same-run',      isRangeRun(chargingRun) ? chargingRun : null],
+        ['default-range', defaultRangeRun(vehicle, batteryKwh)],
+    ];
+
+    for (const [source, run] of candidates) {
+        if (!run || !hasUsableRangeData(run, batteryKwh)) continue;
+        // A default that resolves back to this same run is the same-run case,
+        // already tried above — don't relabel it as inherited from elsewhere.
+        if (source === 'default-range' && run.id === chargingRun.id) continue;
+
+        const { miPerKwh, method } = miPerKwhFrom(run, batteryKwh);
+        return {
+            source,
+            sourceRun: run,
+            miPerSoc: miPerSocFrom(run),
+            miPerKwh,
+            energyMethod: method,
+            note: buildNote(source, run, method),
+        };
+    }
+
+    // Rank 4: the charging run's own recorded range column. Signalled only —
+    // the miles come from interpolating the caller's data points, not from a
+    // scalar, so there is nothing to return but the provenance.
+    if (hasRecordedRange) {
+        return {
+            source: 'recorded', sourceRun: null,
+            miPerSoc: null, miPerKwh: null, energyMethod: null,
+            note: buildNote('recorded'),
+        };
+    }
+
+    return none;
+}


### PR DESCRIPTION
Closes #152. Phase 2 of #150. **This is the phase where existing Charge Compare numbers restate — that is the point of it, not a side effect.**

## The resolver

One function replacing two ad-hoc resolvers that solved the same problem in opposite directions: `ChargeCompareView` iterated range runs hunting for a charging run, `RoadTripView` iterated charging runs hunting for efficiency.

Pairing charging test C with range test R needs exactly one scalar:

```
miPerSoc = R.distance_miles / (R.start_soc - R.end_soc)
```

C supplies ΔSoC over time, R supplies miles per %SoC. No battery capacity, no efficiency-unit conversion. Energy-based consumers get `miPerKwh` instead, preferring measured energy and falling back to a SoC-delta estimate.

## Resolution order

| Rank | Source | |
|---|---|---|
| 1 | `paired` | explicit pairing for this chart session |
| 2 | `default-range` | the vehicle's default range test |
| 3 | `same-run` | the charging run's own measured range data |
| 4 | `recorded` | the charging run's `range_value` points |
| 5 | `none` | nothing usable |

Rank 3 extends the order in #150, which did not cover dual-role runs — 35 of 76 runs on the live database. It sits **below** the vehicle default deliberately: the default range test is a curated choice, whereas a row being dual-role is an artifact of how the data happened to be collected. Note it is the run's *measured* distance and SoC bounds, a different thing from rank 4.

`recorded` stays last as agreed: `range_value` is usually the car's guess-o-meter and answers a different question than measured efficiency. It is *signalled* by the resolver, not computed — the caller holds the time series, so the module stays pure.

Rank 3 goes dormant after #155: a split charging row carries no range columns, so it can never match, and the same-session partner arrives through rank 1 with `paired_range_run_id` populated from the session.

## What changes in the charts

**Charge Compare.** Bars were computed by interpolating each charging run's own `range_value`; they now come from the paired range test:

```
range added   = ΔSoC over the window × miPerSoc
time to add M = time to gain (M / miPerSoc) percent
```

Selecting a range run for a bar *is* an explicit pairing, so it enters at rank 1. Fallbacks still apply when the chosen test has no usable distance/SoC data, and the bar reports which basis it landed on.

Two consequences:

- **Charging runs with no recorded range column now produce bars.** The linear path needs only SoC against time, so the point filter no longer demands `p.range`. Runs that silently rendered nothing before will now appear — expect new bars, not a bug.
- `range_value` remains available at rank 4 and still drives the old interpolation path. The `byRange` sort is now built only on that branch instead of for every bar.

**Road Trip.** Same ranking, so a dual-role run that previously always used its own efficiency now defers to the vehicle's default range test. Its local `computeMiPerKwh` / `hasRangeData` / `efficiencyMethod` are deleted — the mi/kWh math is unchanged and now shared, and the `efficiencyNote` it assembled by hand is the resolver's provenance string.

**Tooltips name the range basis on every bar** (`Range basis: 70 mph mild`, or `Range: recorded range column`). A measured-efficiency figure and a guess-o-meter readout must never be silently interchangeable. The persistent on-chart label is #153.

## Testing

**Resolver — 23 unit tests.** The `miPerSoc` / `miPerKwh` math including divide-by-zero and reversed-SoC guards; every rank of the order; the case that distinguishes this ordering from the rejected one (a dual-role run with a more recent range test available); `is_default` preference; pre-044 rows carrying no `kind`; and note formatting.

**Bar algebra — 12 checks against a synthetic charging curve.** The linear and recorded paths agree *exactly* when the recorded range column is itself linear in SoC; miles scale with the paired test's mi/%SoC; and the round trip — time for M miles, then miles gained in that time — returns M.

**Live app.** Both charts render with 57 series and no console errors. That also confirms the phase-1 predicate fix end to end: all 22 range-only plus 35 dual-role runs are present, none dropped.

## Not verified

**Whether the new numbers are right for these cars.** The algebra is checked; the restatement against real vehicles needs someone who knows what a Lyriq should do in 15 minutes. Hovering a bar names the basis, which is the quickest way to see whether the resolver picks what you would expect.

Also worth knowing: `default-range` currently means "most recent usable range test", because `is_default` is still scoped to charging runs until #155. For a vehicle with several range tests the default silently tracks whichever is newest — and that now outranks same-drive data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)