### PR TITLE
Pairing UI: session state and run-selector pair mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import PerformanceCurveView from './components/PerformanceCurveView';
 import AdminView from './components/AdminView';
 import { CHART_CATEGORIES, DEFAULT_CHART_MODE, ALL_CHART_MODES, categoryForMode, categoryByKey, isChartCategory } from './constants/chartNav';
 import { encodePairings, decodePairings, prunePairings } from './utils/pairings';
+import { EPA_PARTNER_ID } from './utils/rangeSource';
 
 export default function App() {
     const {
@@ -422,6 +423,9 @@ export default function App() {
         const liveRunIds = vehicles
             .filter(v => selectedVehicles.includes(v.id))
             .flatMap(v => (v.runs || []).map(r => r.id));
+        // EPA rated range is a valid pairing side with no run behind it, so it
+        // would otherwise be pruned as an unknown id on every selection change.
+        liveRunIds.push(EPA_PARTNER_ID);
         setPairings(prev => {
             const pruned = prunePairings(prev, liveRunIds);
             // Same-value guard: returning a fresh object every time would retrigger

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -826,6 +826,8 @@ export default function App() {
                             setXMinutes={v => setCompareConfig(p => ({ ...p, xMinutes: v }))}
                             setMMiles={v => setCompareConfig(p => ({ ...p, mMiles: v }))}
                             setStartSoc={v => setCompareConfig(p => ({ ...p, startSoc: v }))}
+                            pairings={pairings}
+                            setPairings={setPairings}
                             onUpdateRunColor={updateRunColor}
                         />
                     )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import PerformanceCompareView from './components/PerformanceCompareView';
 import PerformanceCurveView from './components/PerformanceCurveView';
 import AdminView from './components/AdminView';
 import { CHART_CATEGORIES, DEFAULT_CHART_MODE, ALL_CHART_MODES, categoryForMode, categoryByKey, isChartCategory } from './constants/chartNav';
+import { encodePairings, decodePairings, prunePairings } from './utils/pairings';
 
 export default function App() {
     const {
@@ -92,6 +93,10 @@ export default function App() {
     const [dragOverIdx, setDragOverIdx] = useState(null); // pill drop-indicator position
     const [chartMode, setChartMode] = useState('charging'); // 'charging' | 'range' | 'compare' | 'epacurves' | …
     const [compareConfig, setCompareConfig] = useState({ xMinutes: 15, mMiles: 150, startSoc: 10 });
+    // Which range test supplies the miles for which charging test. Global to the
+    // chart session rather than per-view, so two charts on one screen can never
+    // disagree about what "range" means. See utils/pairings.js.
+    const [pairings, setPairings] = useState({});
     const [epaConfig, setEpaConfig] = useState({ yAxis: 'kwh100mi', xMin: null, xMax: null, yMin: null, yMax: null });
     const [roadTripConfig, setRoadTripConfig] = useState({
         mode: 'distance', startSoc: 90, minSoc: 10, destinationMinSoc: 10,
@@ -163,8 +168,8 @@ export default function App() {
     const themeTitle = theme === 'dark' ? 'Dark mode (click for system)' : theme === 'light' ? 'Light mode (click for dark)' : 'System theme (click for light)';
 
     const { isPopout, sendState } = useChartSync({
-        chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig,
-        setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig,
+        chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings,
+        setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig, setPairings,
     });
 
     // Navigate to a new top-level view and push a browser history entry so the
@@ -244,6 +249,10 @@ export default function App() {
                 ...(cmpMi   != null && { mMiles:   Number(cmpMi)   }),
             }));
         }
+
+        // Pairings — global across chart modes, so read unconditionally.
+        const pairsParam = p.get('pairs');
+        if (pairsParam) setPairings(decodePairings(pairsParam));
 
         // Road Trip config
         const n = (key) => { const v = p.get(key); return v != null ? Number(v) : null; };
@@ -362,6 +371,12 @@ export default function App() {
             p.set('cmp_mi',   compareConfig.mMiles);
         }
 
+        // Pairings apply to every chart mode, so they are written whenever any
+        // exist rather than being scoped to one tab. Omitted when empty so an
+        // untouched chart keeps a clean URL.
+        const pairsEncoded = encodePairings(pairings);
+        if (pairsEncoded) p.set('pairs', pairsEncoded);
+
         // Road Trip options
         if (chartMode === 'roadtrip') {
             const rt = roadTripConfig;
@@ -395,12 +410,30 @@ export default function App() {
         }
 
         history.replaceState({ view, chartMode }, '', '?' + p.toString());
-    }, [view, chartConfig, selectedVehicles, chartMode, vehicles, compareConfig, roadTripConfig, epaConfig]);
+    }, [view, chartConfig, selectedVehicles, chartMode, vehicles, compareConfig, roadTripConfig, epaConfig, pairings]);
+
+    // ── Drop pairings for runs that are no longer on screen ─────────────────
+    // A pairing referencing a deselected vehicle's run would otherwise ride along
+    // in the URL forever and silently resurrect if that vehicle came back.
+    // Waits for vehicles to load so the first render can't prune a URL-restored
+    // map against an empty list.
+    useEffect(() => {
+        if (!vehicles.length) return;
+        const liveRunIds = vehicles
+            .filter(v => selectedVehicles.includes(v.id))
+            .flatMap(v => (v.runs || []).map(r => r.id));
+        setPairings(prev => {
+            const pruned = prunePairings(prev, liveRunIds);
+            // Same-value guard: returning a fresh object every time would retrigger
+            // the URL and broadcast effects on every render.
+            return Object.keys(pruned).length === Object.keys(prev).length ? prev : pruned;
+        });
+    }, [selectedVehicles, vehicles]);
 
     // ── Broadcast chart state to any open pop-out windows ───────────────────
     useEffect(() => {
         sendState();
-    }, [chartMode, chartConfig, selectedVehicles, compareConfig, epaConfig, sendState]);
+    }, [chartMode, chartConfig, selectedVehicles, compareConfig, epaConfig, pairings, sendState]);
 
     // Keep activeVehicle in sync with vehicles state
     const currentActiveVehicle = activeVehicle

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -7,8 +7,8 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, filterRangeRuns, isChargingRun } from '../utils/runUtils';
-import { resolveRangeSource } from '../utils/rangeSource';
+import { filterChargingRuns, filterRangeRuns, isRangeRun, defaultChargingRun } from '../utils/runUtils';
+import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
@@ -324,28 +324,40 @@ export default function ChargeCompareView({
     const resolvedPairs = useMemo(() => {
         const result = [];
         for (const vehicle of selectedVehicles) {
-            const rangeRuns = filterRangeRuns(vehicle.runs);
+            const chargingRuns = filterChargingRuns(vehicle.runs);
+            const autoCharging = defaultChargingRun(vehicle);
+            // EPA rated range is a range basis with no test behind it, so it joins
+            // the primary list rather than the partner dropdown.
+            const epa = epaRangeOption(vehicle);
+            const primaries = epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
 
-            for (const chargingRun of filterChargingRuns(vehicle.runs)) {
-                const pinned = partnersFor(pairings, chargingRun.id);
+            for (const rangeRun of primaries) {
+                const pinned = partnersFor(pairings, rangeRun.id);
                 const rows   = pinned.length ? pinned : [null];
 
                 for (const partnerId of rows) {
-                    const explicit = partnerId
-                        ? rangeRuns.find(r => String(r.id) === String(partnerId)) ?? null
-                        : null;
+                    const chargingRun = partnerId
+                        ? chargingRuns.find(r => String(r.id) === String(partnerId)) ?? autoCharging
+                        : autoCharging;
+                    if (!chargingRun) continue;
+
+                    // The range side is always explicit here — it IS the row — so
+                    // the resolver is entered at rank 1 and its fallbacks only
+                    // matter when the chosen test carries no usable data.
                     const rangeSrc = resolveRangeSource(chargingRun, {
                         vehicle,
-                        explicitPairing: explicit,
+                        explicitPairing: rangeRun.id === EPA_PARTNER_ID ? EPA_PARTNER_ID : rangeRun,
                     });
+
                     result.push({
-                        key:         pairKey(chargingRun.id, partnerId),
-                        chargingRun: { ...chargingRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
-                        // Only disambiguate when a curve is shown more than once —
-                        // the 1:1 case keeps the charging test's own name.
-                        label:       rows.length > 1 && rangeSrc.sourceRun
-                            ? `${chargingRun.name} × ${rangeSrc.sourceRun.name}`
-                            : chargingRun.name,
+                        key:         pairKey(rangeRun.id, partnerId),
+                        rangeRun:    { ...rangeRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
+                        chargingRun,
+                        // Only disambiguate when a range test is shown more than
+                        // once — the 1:1 case keeps its own name.
+                        label:       rows.length > 1
+                            ? `${rangeRun.name} × ${chargingRun.name}`
+                            : rangeRun.name,
                         rangeSrc,
                     });
                 }
@@ -355,7 +367,7 @@ export default function ChargeCompareView({
     }, [selectedVehicles, pairings]);
 
     const neededRunIds = useMemo(
-        () => [...new Set(resolvedPairs.map(p => p.chargingRun.id).filter(Boolean))],
+        () => [...new Set(resolvedPairs.map(p => p.chargingRun?.id).filter(Boolean))],
         [resolvedPairs]
     );
 
@@ -411,20 +423,20 @@ export default function ChargeCompareView({
     const buildBars = (chartType) => {
         const flatRuns = [];
 
-        for (const { key, chargingRun, label, rangeSrc } of activePairs) {
+        for (const { key, rangeRun, chargingRun, label, rangeSrc } of activePairs) {
             const chargingRunId = chargingRun.id;
             const base = {
                 id:              key,
                 name:            label,
-                vehicleName:     chargingRun.vehicleName,
-                vehicleId:       chargingRun.vehicleId,
-                color:           chargingRun.color || '#3b82f6',
-                // Each pill describes the half it came from: speed is a property of
-                // the range test, temperature of the charging session.
-                speed_mph:       rangeSrc?.sourceRun?.speed_mph ?? chargingRun.speed_mph,
-                temperature_f:   chargingRun.temperature_f,
-                source:          chargingRun.source,
-                _trim:           chargingRun._trim ?? null,
+                vehicleName:     rangeRun.vehicleName,
+                vehicleId:       rangeRun.vehicleId,
+                color:           rangeRun.color || chargingRun.color || '#3b82f6',
+                // Each pill describes the half it came from: speed and conditions
+                // belong to the range test, which is what this row enumerates.
+                speed_mph:       rangeRun.speed_mph,
+                temperature_f:   rangeRun.temperature_f,
+                source:          rangeRun.source,
+                _trim:           rangeRun._trim ?? null,
                 _chargingRunName: chargingRun.name,
                 _yUnit:          chartType === 'range_added' ? distanceLabel(units) : 'min',
                 _rangeUnit:      distanceLabel(units),
@@ -706,26 +718,41 @@ export default function ChargeCompareView({
                             prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId]
                         )}
                         onUpdateRunColor={onUpdateRunColor}
-                        runFilter={isChargingRun}
-                        emptyMessage="No charging test records"
+                        runFilter={(run, vehicle) =>
+                            // A range test with no charging curve to pair against
+                            // cannot produce a bar, so it is not offered.
+                            isRangeRun(run) && filterChargingRuns(vehicle.runs).length > 0}
+                        emptyMessage="No range test records"
                         pairMode
                         pairings={pairings}
-                        rangeRunsFor={vehicle => filterRangeRuns(vehicle.runs)}
-                        resolvePartner={(chargingRun, vehicle) =>
-                            resolveRangeSource(chargingRun, { vehicle })}
-                        onSetPartner={(chargingId, oldRangeId, newRangeId) =>
-                            setPairings(prev => replacePartner(prev, chargingId, oldRangeId, newRangeId))}
-                        onAddPartner={(chargingId, rangeId) =>
-                            setPairings(prev => addPartner(prev, chargingId, rangeId))}
-                        onRemovePartner={(chargingId, rangeId) =>
-                            setPairings(prev => removePartner(prev, chargingId, rangeId))}
+                        primaryLabel="Range:"
+                        partnerLabel="Charging:"
+                        partnerRunsFor={vehicle => filterChargingRuns(vehicle.runs)}
+                        extraPrimaryRunsFor={vehicle => {
+                            if (!filterChargingRuns(vehicle.runs).length) return [];
+                            const epa = epaRangeOption(vehicle);
+                            return epa ? [epa] : [];
+                        }}
+                        resolvePartner={(_rangeRun, vehicle) => {
+                            const run = defaultChargingRun(vehicle);
+                            return run ? { sourceRun: run, note: null } : null;
+                        }}
+                        onSetPartner={(rangeId, oldChargingId, newChargingId) =>
+                            setPairings(prev => replacePartner(prev, rangeId, oldChargingId, newChargingId))}
+                        onAddPartner={(rangeId, chargingId) =>
+                            setPairings(prev => addPartner(prev, rangeId, chargingId))}
+                        onRemovePartner={(rangeId, chargingId) =>
+                            setPairings(prev => removePartner(prev, rangeId, chargingId))}
                         renderRunMeta={run => (
+                            // Speed and temperature stay on the left now that it
+                            // enumerates range tests: they are what distinguishes
+                            // one range test from another. Date is still omitted.
                             <>
                                 {run.speed_mph != null && (
-                                    <span className="text-xs bg-[var(--color-surface-sunken)] text-secondary px-1.5 py-0.5 rounded">{fmtSpeed(run.speed_mph, units)}</span>
+                                    <span className="text-xs bg-[var(--color-surface-sunken)] text-secondary px-1.5 py-0.5 rounded shrink-0">{fmtSpeed(run.speed_mph, units)}</span>
                                 )}
                                 {run.temperature_f != null && (
-                                    <span className="text-xs bg-orange-50 text-orange-700 px-1.5 py-0.5 rounded border border-orange-200">{fmtTemp(run.temperature_f, units)}</span>
+                                    <span className="text-xs bg-orange-50 text-orange-700 px-1.5 py-0.5 rounded border border-orange-200 shrink-0">{fmtTemp(run.temperature_f, units)}</span>
                                 )}
                             </>
                         )}

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -7,8 +7,9 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, filterRangeRuns, isRangeRun, isChargingRun } from '../utils/runUtils';
+import { filterChargingRuns, filterRangeRuns, isChargingRun } from '../utils/runUtils';
 import { resolveRangeSource } from '../utils/rangeSource';
+import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
@@ -274,6 +275,10 @@ export default function ChargeCompareView({
     xMinutes = 15, setXMinutes,
     mMiles   = 150, setMMiles,
     startSoc = 10,  setStartSoc,
+    // Global chart-session pairings (utils/pairings.js). Read-only in the
+    // pop-out, which receives them over BroadcastChannel and must not edit.
+    pairings = {},
+    setPairings = () => {},
     onUpdateRunColor = null,
     presentationMode = false,
 }) {
@@ -306,43 +311,52 @@ export default function ChargeCompareView({
         [vehicles, selectedVehicleIds]
     );
 
-    // For each range run: resolve which charging run supplies the data_points.
-    // - If the range run itself has charging data → use its own ID.
-    // - Otherwise → vehicle's is_default charging run, or most recent.
-    const resolvedRuns = useMemo(() => {
+    // Charging-primary: one series per (charging test × range test) pair.
+    //
+    // This chart used to iterate range runs and hunt for a charging run to supply
+    // the data points, which made the range test the subject and buried the
+    // pairing. Inverted, the charging curve is the subject and the range test is
+    // the basis you choose for it — which is the question the chart answers.
+    //
+    // A charging run with no explicit pairing still gets one row, whose partner
+    // the resolver picks (ranks 2-4). So an untouched chart behaves exactly as it
+    // did before anyone pairs anything.
+    const resolvedPairs = useMemo(() => {
         const result = [];
         for (const vehicle of selectedVehicles) {
-            const rangeRuns    = filterRangeRuns(vehicle.runs);
-            const chargingRuns = filterChargingRuns(vehicle.runs);
-            const defaultCharging =
-                chargingRuns.find(r => r.isDefault) ||
-                [...chargingRuns].sort((a, b) => new Date(b.date) - new Date(a.date))[0] ||
-                null;
+            const rangeRuns = filterRangeRuns(vehicle.runs);
 
-            for (const rangeRun of rangeRuns) {
-                const chargingRun = isChargingRun(rangeRun) ? rangeRun : defaultCharging;
-                // Selecting a range run for this bar IS an explicit pairing, so it
-                // takes rank 1. The resolver still falls through to the vehicle
-                // default or the recorded range column when the chosen test has no
-                // usable distance/SoC data, and reports which it landed on.
-                const rangeSrc = resolveRangeSource(chargingRun, {
-                    vehicle,
-                    explicitPairing: rangeRun,
-                });
-                result.push({
-                    rangeRun:        { ...rangeRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
-                    chargingRunId:   chargingRun?.id   ?? null,
-                    chargingRunName: chargingRun?.name ?? null,
-                    rangeSrc,
-                });
+            for (const chargingRun of filterChargingRuns(vehicle.runs)) {
+                const pinned = partnersFor(pairings, chargingRun.id);
+                const rows   = pinned.length ? pinned : [null];
+
+                for (const partnerId of rows) {
+                    const explicit = partnerId
+                        ? rangeRuns.find(r => String(r.id) === String(partnerId)) ?? null
+                        : null;
+                    const rangeSrc = resolveRangeSource(chargingRun, {
+                        vehicle,
+                        explicitPairing: explicit,
+                    });
+                    result.push({
+                        key:         pairKey(chargingRun.id, partnerId),
+                        chargingRun: { ...chargingRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
+                        // Only disambiguate when a curve is shown more than once —
+                        // the 1:1 case keeps the charging test's own name.
+                        label:       rows.length > 1 && rangeSrc.sourceRun
+                            ? `${chargingRun.name} × ${rangeSrc.sourceRun.name}`
+                            : chargingRun.name,
+                        rangeSrc,
+                    });
+                }
             }
         }
         return result;
-    }, [selectedVehicles]);
+    }, [selectedVehicles, pairings]);
 
     const neededRunIds = useMemo(
-        () => [...new Set(resolvedRuns.map(r => r.chargingRunId).filter(Boolean))],
-        [resolvedRuns]
+        () => [...new Set(resolvedPairs.map(p => p.chargingRun.id).filter(Boolean))],
+        [resolvedPairs]
     );
 
     // ── Lazy-load data_points for resolved charging runs ──────────────────────
@@ -378,34 +392,40 @@ export default function ChargeCompareView({
         fetchMissing();
     }, [neededRunIds.join(',')]);
 
-    // ── Auto-select any new range runs when vehicles change ───────────────────
+    // ── Auto-select any new pairs when vehicles or pairings change ────────────
+    // Selection is by pair key, so adding a second range partner to a charging
+    // test brings the new series in already selected rather than requiring a
+    // second click in a different part of the UI.
     useEffect(() => {
-        const allRangeRunIds = resolvedRuns.map(r => r.rangeRun.id);
+        const allKeys = resolvedPairs.map(p => p.key);
         setSelectedRuns(prev => {
-            const newIds = allRangeRunIds.filter(id => !prev.includes(id));
-            return newIds.length ? [...prev, ...newIds] : prev;
+            const newKeys = allKeys.filter(k => !prev.includes(k));
+            return newKeys.length ? [...prev, ...newKeys] : prev;
         });
-    }, [resolvedRuns]);
+    }, [resolvedPairs]);
 
-    const activeResolvedRuns = resolvedRuns.filter(r => selectedRuns.includes(r.rangeRun.id));
+    const activePairs = resolvedPairs.filter(p => selectedRuns.includes(p.key));
 
     // ── Compute bars for one chart type ──────────────────────────────────────
     // chartType: 'range_added' | 'time_to_range'
     const buildBars = (chartType) => {
         const flatRuns = [];
 
-        for (const { rangeRun, chargingRunId, chargingRunName, rangeSrc } of activeResolvedRuns) {
+        for (const { key, chargingRun, label, rangeSrc } of activePairs) {
+            const chargingRunId = chargingRun.id;
             const base = {
-                id:              rangeRun.id,
-                name:            rangeRun.name,
-                vehicleName:     rangeRun.vehicleName,
-                vehicleId:       rangeRun.vehicleId,
-                color:           rangeRun.color || '#3b82f6',
-                speed_mph:       rangeRun.speed_mph,
-                temperature_f:   rangeRun.temperature_f,
-                source:          rangeRun.source,
-                _trim:           rangeRun._trim ?? null,
-                _chargingRunName: chargingRunName,
+                id:              key,
+                name:            label,
+                vehicleName:     chargingRun.vehicleName,
+                vehicleId:       chargingRun.vehicleId,
+                color:           chargingRun.color || '#3b82f6',
+                // Each pill describes the half it came from: speed is a property of
+                // the range test, temperature of the charging session.
+                speed_mph:       rangeSrc?.sourceRun?.speed_mph ?? chargingRun.speed_mph,
+                temperature_f:   chargingRun.temperature_f,
+                source:          chargingRun.source,
+                _trim:           chargingRun._trim ?? null,
+                _chargingRunName: chargingRun.name,
                 _yUnit:          chartType === 'range_added' ? distanceLabel(units) : 'min',
                 _rangeUnit:      distanceLabel(units),
                 // Which range basis produced these miles, for the provenance label.
@@ -620,7 +640,7 @@ export default function ChargeCompareView({
         };
     }, [selectedVehicleIds, xMinutes, mMiles, startSoc, runDataCache, orientation, selectedRuns, units, isDark]);
 
-    const hasRangeRuns = resolvedRuns.length > 0;
+    const hasRangeRuns = resolvedPairs.length > 0;
 
     // ── Render ────────────────────────────────────────────────────────────────
     return (
@@ -686,8 +706,19 @@ export default function ChargeCompareView({
                             prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId]
                         )}
                         onUpdateRunColor={onUpdateRunColor}
-                        runFilter={isRangeRun}
-                        emptyMessage="No range test records"
+                        runFilter={isChargingRun}
+                        emptyMessage="No charging test records"
+                        pairMode
+                        pairings={pairings}
+                        rangeRunsFor={vehicle => filterRangeRuns(vehicle.runs)}
+                        resolvePartner={(chargingRun, vehicle) =>
+                            resolveRangeSource(chargingRun, { vehicle })}
+                        onSetPartner={(chargingId, oldRangeId, newRangeId) =>
+                            setPairings(prev => replacePartner(prev, chargingId, oldRangeId, newRangeId))}
+                        onAddPartner={(chargingId, rangeId) =>
+                            setPairings(prev => addPartner(prev, chargingId, rangeId))}
+                        onRemovePartner={(chargingId, rangeId) =>
+                            setPairings(prev => removePartner(prev, chargingId, rangeId))}
                         renderRunMeta={run => (
                             <>
                                 {run.speed_mph != null && (
@@ -714,7 +745,7 @@ export default function ChargeCompareView({
                         <h4 className="text-base font-semibold mb-3">
                             Range Added in {xMinutes} Minutes <span className="text-faint font-normal">(from ~{startSoc}% SoC, in {distanceLabel(units)})</span>
                         </h4>
-                        <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activeResolvedRuns.length * 48)}px` : '450px', position: 'relative' }}>
+                        <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activePairs.length * 48)}px` : '450px', position: 'relative' }}>
                             <canvas ref={chart1Ref} />
                         </div>
                     </div>
@@ -724,7 +755,7 @@ export default function ChargeCompareView({
                         <h4 className="text-base font-semibold mb-3">
                             Time to Add {units === 'metric' ? Math.round(mMiles * MI_TO_KM) : mMiles} {distanceLabel(units)} of Range <span className="text-faint font-normal">(from ~{startSoc}% SoC)</span>
                         </h4>
-                        <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activeResolvedRuns.length * 48)}px` : '450px', position: 'relative' }}>
+                        <div style={{ height: presentationMode ? '45vh' : isHorizontal ? `${Math.max(300, activePairs.length * 48)}px` : '450px', position: 'relative' }}>
                             <canvas ref={chart2Ref} />
                         </div>
                         <div className="mt-3 flex gap-2">

--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -15,7 +15,7 @@ import PerformanceCurveView from './PerformanceCurveView';
  */
 export default function PopoutView({
     vehicles, selectedVehicles, chartMode, chartConfig,
-    setChartConfig, compareConfig, roadTripConfig, epaConfig, onUpdateRunColor,
+    setChartConfig, compareConfig, roadTripConfig, epaConfig, pairings, onUpdateRunColor,
 }) {
     return (
         <div className="popout-root">
@@ -98,6 +98,7 @@ export default function PopoutView({
                     xMinutes={compareConfig.xMinutes}
                     mMiles={compareConfig.mMiles}
                     startSoc={compareConfig.startSoc}
+                    pairings={pairings}
                     presentationMode
                 />
             )}

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { pairKey, partnersFor } from '../utils/pairings';
 
 /**
  * Shared collapsible run selector used by ChargingView, RangeChartView,
@@ -6,12 +7,31 @@ import { useState, useRef, useEffect } from 'react';
  *
  * Props:
  *   vehicles        — array of vehicle objects with .runs, in display order
- *   selectedRunIds  — array of selected run IDs
- *   onToggleRun     — (runId) => void
+ *   selectedRunIds  — array of selected run IDs (pair keys in pair mode)
+ *   onToggleRun     — (runId | pairKey) => void
  *   onUpdateRunColor — (vehicleId, runId, color) => void, or null to hide color inputs
  *   runFilter       — (run) => boolean — which runs to show per vehicle
  *   emptyMessage    — string shown when no runs pass the filter for a vehicle
  *   renderRunMeta   — optional (run) => ReactNode — extra badges after name/date
+ *
+ * ── Pair mode (opt-in) ───────────────────────────────────────────────────────
+ *
+ * Set `pairMode` and the list becomes charging tests, each with an inline
+ * `Range: … ▾` control naming the range test that supplies its miles, and a ＋
+ * that duplicates the row with the charging test pre-filled. The 1:1 case looks
+ * almost exactly like the flat list; the UI only grows when asked.
+ *
+ * Rows are keyed by PAIR, not by run — one charging curve against three range
+ * tests is three series, so a run id can no longer identify a selection.
+ *
+ *   pairMode        — enable the above
+ *   pairings        — { [chargingRunId]: [rangeRunId, ...] } (utils/pairings.js)
+ *   rangeRunsFor    — (vehicle) => range runs available as partners
+ *   resolvePartner  — (chargingRun, vehicle) => { sourceRun, note } for the
+ *                     automatic choice shown when nothing is pinned
+ *   onSetPartner    — (chargingRunId, oldRangeRunId, newRangeRunId) => void
+ *   onAddPartner    — (chargingRunId, rangeRunId) => void
+ *   onRemovePartner — (chargingRunId, rangeRunId) => void
  */
 export default function RunSelector({
     vehicles,
@@ -22,6 +42,14 @@ export default function RunSelector({
     emptyMessage = 'No runs',
     renderRunMeta = null,
     colorMap = {},
+    // Pair mode
+    pairMode = false,
+    pairings = {},
+    rangeRunsFor = null,
+    resolvePartner = null,
+    onSetPartner = null,
+    onAddPartner = null,
+    onRemovePartner = null,
 }) {
     const [expanded, setExpanded] = useState(false);
     // Default all vehicles to expanded; track explicit collapses
@@ -32,8 +60,24 @@ export default function RunSelector({
 
     const isSelected = (run) => selectedRunIds.some(id => String(id) === String(run.id));
 
-    const selectedCount = vehicles.reduce((n, v) =>
-        n + (v.runs || []).filter(runFilter).filter(isSelected).length, 0);
+    /**
+     * The partner rows for one charging run: whatever the user pinned, or a
+     * single row for the automatic choice. `null` means "resolved automatically"
+     * and still gets a row, so every charging test is visible and selectable
+     * whether or not anyone has paired it.
+     */
+    const partnerRowsFor = (run) => {
+        const pinned = partnersFor(pairings, run.id);
+        return pinned.length ? pinned : [null];
+    };
+
+    const selectedCount = pairMode
+        ? vehicles.reduce((n, v) => n + (v.runs || []).filter(runFilter).reduce(
+            (m, run) => m + partnerRowsFor(run).filter(
+                partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
+            ).length, 0), 0)
+        : vehicles.reduce((n, v) =>
+            n + (v.runs || []).filter(runFilter).filter(isSelected).length, 0);
 
     return (
         <div>
@@ -73,7 +117,24 @@ export default function RunSelector({
                                             <p className="text-sm text-faint italic">{emptyMessage}</p>
                                         ) : (
                                             <div className="run-items">
-                                                {filteredRuns.map(run => (
+                                                {filteredRuns.map(run => pairMode ? (
+                                                    <PairRows
+                                                        key={run.id}
+                                                        run={run}
+                                                        vehicle={vehicle}
+                                                        partnerIds={partnerRowsFor(run)}
+                                                        rangeRuns={rangeRunsFor?.(vehicle) ?? []}
+                                                        resolvePartner={resolvePartner}
+                                                        selectedRunIds={selectedRunIds}
+                                                        onToggleRun={onToggleRun}
+                                                        onSetPartner={onSetPartner}
+                                                        onAddPartner={onAddPartner}
+                                                        onRemovePartner={onRemovePartner}
+                                                        onUpdateRunColor={onUpdateRunColor}
+                                                        renderRunMeta={renderRunMeta}
+                                                        colorMap={colorMap}
+                                                    />
+                                                ) : (
                                                     <RunRow
                                                         key={run.id}
                                                         run={run}
@@ -94,6 +155,122 @@ export default function RunSelector({
                     </div>
                 </div>
             )}
+        </div>
+    );
+}
+
+/**
+ * One charging test and its range partner(s) — a row per pair.
+ *
+ * The first row carries the checkbox, colour and charging-test name; additional
+ * partners are continuation rows showing only their own dropdown, so a single
+ * curve compared across three conditions reads as one block rather than three
+ * unrelated entries.
+ */
+function PairRows({
+    run, vehicle, partnerIds, rangeRuns, resolvePartner,
+    selectedRunIds, onToggleRun, onSetPartner, onAddPartner, onRemovePartner,
+    onUpdateRunColor, renderRunMeta, colorMap,
+}) {
+    // What the resolver would pick with nothing pinned — shown as the dropdown's
+    // placeholder so an unpaired row still says where its miles come from.
+    const auto = resolvePartner?.(run, vehicle) ?? null;
+    const autoLabel = auto?.sourceRun?.name
+        ?? (auto?.source === 'recorded' ? 'recorded range column' : 'no range data');
+
+    // Range tests not already used by this charging run — the discovery badge.
+    const used = new Set(partnerIds.filter(Boolean).map(String));
+    const unused = rangeRuns.filter(r => !used.has(String(r.id)));
+
+    const isSelected = (partnerId) =>
+        selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId));
+
+    return (
+        <div className="pair-group">
+            {partnerIds.map((partnerId, idx) => (
+                <label key={partnerId ?? 'auto'} className={`pair-row ${isSelected(partnerId) ? '' : 'opacity-60 hover:opacity-100'}`}>
+                    <input
+                        type="checkbox"
+                        checked={isSelected(partnerId)}
+                        onChange={() => onToggleRun(pairKey(run.id, partnerId))}
+                        className="w-4 h-4 shrink-0"
+                    />
+
+                    {/* Charging test identity — only on the first row of the group */}
+                    {idx === 0 ? (
+                        <span className="pair-charging-label">
+                            {onUpdateRunColor && (
+                                <span
+                                    className="w-3 h-5 rounded-sm shrink-0 border border-black/10"
+                                    style={{ backgroundColor: colorMap[run.id] || run.color || '#3b82f6' }}
+                                />
+                            )}
+                            <span className="truncate">{run.name}</span>
+                            <span className="text-sm text-muted shrink-0"> ({run.date})</span>
+                            {renderRunMeta?.(run)}
+                        </span>
+                    ) : (
+                        <span className="pair-charging-label text-faint">↳</span>
+                    )}
+
+                    {/* The range basis for this pair */}
+                    <span className="pair-range-control" onClick={e => e.preventDefault()}>
+                        <span className="text-label shrink-0">Range:</span>
+                        <select
+                            className="form-input text-sm py-0.5"
+                            value={partnerId ?? ''}
+                            onChange={e => {
+                                const next = e.target.value;
+                                if (!next) onRemovePartner?.(run.id, partnerId);
+                                else onSetPartner?.(run.id, partnerId, next);
+                            }}
+                        >
+                            <option value="">Auto — {autoLabel}</option>
+                            {rangeRuns.map(r => (
+                                <option key={r.id} value={r.id}>{r.name}</option>
+                            ))}
+                        </select>
+
+                        {/* Discovery: how many other range tests could go here */}
+                        {idx === 0 && unused.length > 0 && (
+                            <span
+                                className="pair-more-badge"
+                                title={`${unused.length} more range test(s): ${unused.map(r => r.name).join(', ')}`}
+                            >
+                                +{unused.length}
+                            </span>
+                        )}
+
+                        {idx === 0 ? (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    // Duplicate this row with the charging test pre-filled —
+                                    // the point of the design is never re-picking it.
+                                    const next = unused[0];
+                                    if (!next) return;
+                                    if (!partnerId && auto?.sourceRun) onAddPartner?.(run.id, auto.sourceRun.id);
+                                    onAddPartner?.(run.id, next.id);
+                                }}
+                                disabled={unused.length === 0}
+                                className="pair-add-btn"
+                                title={unused.length ? 'Compare this charging test against another range test' : 'No other range tests available'}
+                            >
+                                ＋
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => onRemovePartner?.(run.id, partnerId)}
+                                className="pair-remove-btn"
+                                title="Remove this pairing"
+                            >
+                                ×
+                            </button>
+                        )}
+                    </span>
+                </label>
+            ))}
         </div>
     );
 }

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -179,7 +179,13 @@ function PairRows({
         ?? (auto?.source === 'recorded' ? 'recorded range column' : 'no range data');
 
     // Range tests not already used by this charging run — the discovery badge.
+    //
+    // An unpinned row is still *showing* the auto-resolved partner, so that one
+    // counts as used. Without this the badge over-counts ("+2" when only one
+    // other test exists) and ＋ can pick the partner already on screen, which
+    // dedupes to a no-op and looks like a dead button.
     const used = new Set(partnerIds.filter(Boolean).map(String));
+    if (!partnerIds.some(Boolean) && auto?.sourceRun) used.add(String(auto.sourceRun.id));
     const unused = rangeRuns.filter(r => !used.has(String(r.id)));
 
     const isSelected = (partnerId) =>

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -10,28 +10,36 @@ import { pairKey, partnersFor } from '../utils/pairings';
  *   selectedRunIds  — array of selected run IDs (pair keys in pair mode)
  *   onToggleRun     — (runId | pairKey) => void
  *   onUpdateRunColor — (vehicleId, runId, color) => void, or null to hide color inputs
- *   runFilter       — (run) => boolean — which runs to show per vehicle
+ *   runFilter       — (run, vehicle) => boolean — which runs to show per vehicle
  *   emptyMessage    — string shown when no runs pass the filter for a vehicle
  *   renderRunMeta   — optional (run) => ReactNode — extra badges after name/date
  *
  * ── Pair mode (opt-in) ───────────────────────────────────────────────────────
  *
- * Set `pairMode` and the list becomes charging tests, each with an inline
- * `Range: … ▾` control naming the range test that supplies its miles, and a ＋
- * that duplicates the row with the charging test pre-filled. The 1:1 case looks
- * almost exactly like the flat list; the UI only grows when asked.
+ * Set `pairMode` and each row gains an inline `<partnerLabel> … ▾` control
+ * naming the test it is paired with, plus a ＋ that duplicates the row with the
+ * primary test pre-filled. The 1:1 case looks almost exactly like the flat list;
+ * the UI only grows when asked.
  *
- * Rows are keyed by PAIR, not by run — one charging curve against three range
- * tests is three series, so a run id can no longer identify a selection.
+ * Rows are keyed by PAIR, not by run — one test against three partners is three
+ * series, so a run id can no longer identify a selection.
+ *
+ * The component is deliberately orientation-agnostic: Charge Compare enumerates
+ * range tests and picks charging curves, because a charging curve is a property
+ * of the car while a range test is a property of the day. Another view could
+ * enumerate the other way without touching this file.
  *
  *   pairMode        — enable the above
- *   pairings        — { [chargingRunId]: [rangeRunId, ...] } (utils/pairings.js)
- *   rangeRunsFor    — (vehicle) => range runs available as partners
- *   resolvePartner  — (chargingRun, vehicle) => { sourceRun, note } for the
+ *   pairings        — { [primaryRunId]: [partnerRunId, ...] } (utils/pairings.js)
+ *   primaryLabel    — prefix before the row's own name, e.g. "Range:"
+ *   partnerLabel    — prefix before the dropdown,      e.g. "Charging:"
+ *   partnerRunsFor  — (vehicle) => runs offered as partners
+ *   extraPrimaryRunsFor — (vehicle) => synthetic primary rows (e.g. EPA range)
+ *   resolvePartner  — (primaryRun, vehicle) => { sourceRun, note } for the
  *                     automatic choice shown when nothing is pinned
- *   onSetPartner    — (chargingRunId, oldRangeRunId, newRangeRunId) => void
- *   onAddPartner    — (chargingRunId, rangeRunId) => void
- *   onRemovePartner — (chargingRunId, rangeRunId) => void
+ *   onSetPartner    — (primaryRunId, oldPartnerId, newPartnerId) => void
+ *   onAddPartner    — (primaryRunId, partnerId) => void
+ *   onRemovePartner — (primaryRunId, partnerId) => void
  */
 export default function RunSelector({
     vehicles,
@@ -45,7 +53,12 @@ export default function RunSelector({
     // Pair mode
     pairMode = false,
     pairings = {},
-    rangeRunsFor = null,
+    primaryLabel = null,
+    partnerLabel = 'Paired with:',
+    partnerRunsFor = null,
+    // Rows that are not runs — e.g. the vehicle's EPA rated range, which is a
+    // legitimate range basis with no test behind it.
+    extraPrimaryRunsFor = null,
     resolvePartner = null,
     onSetPartner = null,
     onAddPartner = null,
@@ -71,13 +84,25 @@ export default function RunSelector({
         return pinned.length ? pinned : [null];
     };
 
+    /**
+     * Every primary row for a vehicle, synthetic ones included. Used for both
+     * rendering and the header count — computing them separately is how the
+     * count silently drifted from what was on screen.
+     */
+    const primaryRunsFor = (vehicle) => {
+        const own = (vehicle.runs || []).filter(r => runFilter(r, vehicle));
+        return pairMode && extraPrimaryRunsFor
+            ? [...own, ...(extraPrimaryRunsFor(vehicle) || [])]
+            : own;
+    };
+
     const selectedCount = pairMode
-        ? vehicles.reduce((n, v) => n + (v.runs || []).filter(runFilter).reduce(
+        ? vehicles.reduce((n, v) => n + primaryRunsFor(v).reduce(
             (m, run) => m + partnerRowsFor(run).filter(
                 partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
             ).length, 0), 0)
         : vehicles.reduce((n, v) =>
-            n + (v.runs || []).filter(runFilter).filter(isSelected).length, 0);
+            n + (v.runs || []).filter(r => runFilter(r, v)).filter(isSelected).length, 0);
 
     return (
         <div>
@@ -97,7 +122,7 @@ export default function RunSelector({
                 <div className="mt-3">
                     <div className="runs-list">
                         {vehicles.map(vehicle => {
-                            const filteredRuns = (vehicle.runs || []).filter(runFilter);
+                            const filteredRuns = primaryRunsFor(vehicle);
 
                             return (
                                 <div key={vehicle.id} className="vehicle-run-group" style={{ borderColor: 'var(--color-primary)' }}>
@@ -123,8 +148,10 @@ export default function RunSelector({
                                                         run={run}
                                                         vehicle={vehicle}
                                                         partnerIds={partnerRowsFor(run)}
-                                                        rangeRuns={rangeRunsFor?.(vehicle) ?? []}
+                                                        partnerRuns={partnerRunsFor?.(vehicle) ?? []}
                                                         resolvePartner={resolvePartner}
+                                                        primaryLabel={primaryLabel}
+                                                        partnerLabel={partnerLabel}
                                                         selectedRunIds={selectedRunIds}
                                                         onToggleRun={onToggleRun}
                                                         onSetPartner={onSetPartner}
@@ -168,7 +195,8 @@ export default function RunSelector({
  * unrelated entries.
  */
 function PairRows({
-    run, vehicle, partnerIds, rangeRuns, resolvePartner,
+    run, vehicle, partnerIds, partnerRuns, resolvePartner,
+    primaryLabel, partnerLabel,
     selectedRunIds, onToggleRun, onSetPartner, onAddPartner, onRemovePartner,
     onUpdateRunColor, renderRunMeta, colorMap,
 }) {
@@ -176,9 +204,9 @@ function PairRows({
     // placeholder so an unpaired row still says where its miles come from.
     const auto = resolvePartner?.(run, vehicle) ?? null;
     const autoLabel = auto?.sourceRun?.name
-        ?? (auto?.source === 'recorded' ? 'recorded range column' : 'no range data');
+        ?? (auto?.source === 'recorded' ? 'recorded range column' : 'none available');
 
-    // Range tests not already used by this charging run — the discovery badge.
+    // Partners not already used by this row — the discovery badge.
     //
     // An unpinned row is still *showing* the auto-resolved partner, so that one
     // counts as used. Without this the badge over-counts ("+2" when only one
@@ -186,7 +214,7 @@ function PairRows({
     // dedupes to a no-op and looks like a dead button.
     const used = new Set(partnerIds.filter(Boolean).map(String));
     if (!partnerIds.some(Boolean) && auto?.sourceRun) used.add(String(auto.sourceRun.id));
-    const unused = rangeRuns.filter(r => !used.has(String(r.id)));
+    const unused = partnerRuns.filter(r => !used.has(String(r.id)));
 
     const isSelected = (partnerId) =>
         selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId));
@@ -194,7 +222,10 @@ function PairRows({
     return (
         <div className="pair-group">
             {partnerIds.map((partnerId, idx) => (
-                <label key={partnerId ?? 'auto'} className={`pair-row ${isSelected(partnerId) ? '' : 'opacity-60 hover:opacity-100'}`}>
+                <label
+                    key={partnerId ?? 'auto'}
+                    className={`pair-row ${idx > 0 ? 'pair-row-child' : ''} ${isSelected(partnerId) ? '' : 'opacity-60 hover:opacity-100'}`}
+                >
                     <input
                         type="checkbox"
                         checked={isSelected(partnerId)}
@@ -202,7 +233,9 @@ function PairRows({
                         className="w-4 h-4 shrink-0"
                     />
 
-                    {/* Charging test identity — only on the first row of the group */}
+                    {/* Charging test identity — only on the first row of the group.
+                        No date or speed here: speed belongs to the range test, and
+                        this side of the row is about the charging curve. */}
                     {idx === 0 ? (
                         <span className="pair-charging-label">
                             {onUpdateRunColor && (
@@ -211,8 +244,8 @@ function PairRows({
                                     style={{ backgroundColor: colorMap[run.id] || run.color || '#3b82f6' }}
                                 />
                             )}
+                            {primaryLabel && <span className="text-label shrink-0">{primaryLabel}</span>}
                             <span className="truncate">{run.name}</span>
-                            <span className="text-sm text-muted shrink-0"> ({run.date})</span>
                             {renderRunMeta?.(run)}
                         </span>
                     ) : (
@@ -221,7 +254,7 @@ function PairRows({
 
                     {/* The range basis for this pair */}
                     <span className="pair-range-control" onClick={e => e.preventDefault()}>
-                        <span className="text-label shrink-0">Range:</span>
+                        <span className="text-label shrink-0">{partnerLabel}</span>
                         <select
                             className="form-input text-sm py-0.5"
                             value={partnerId ?? ''}
@@ -232,7 +265,7 @@ function PairRows({
                             }}
                         >
                             <option value="">Auto — {autoLabel}</option>
-                            {rangeRuns.map(r => (
+                            {partnerRuns.map(r => (
                                 <option key={r.id} value={r.id}>{r.name}</option>
                             ))}
                         </select>
@@ -241,7 +274,7 @@ function PairRows({
                         {idx === 0 && unused.length > 0 && (
                             <span
                                 className="pair-more-badge"
-                                title={`${unused.length} more range test(s): ${unused.map(r => r.name).join(', ')}`}
+                                title={`${unused.length} more option(s): ${unused.map(r => r.name).join(', ')}`}
                             >
                                 +{unused.length}
                             </span>
@@ -260,7 +293,7 @@ function PairRows({
                                 }}
                                 disabled={unused.length === 0}
                                 className="pair-add-btn"
-                                title={unused.length ? 'Compare this charging test against another range test' : 'No other range tests available'}
+                                title={unused.length ? 'Compare this test against another pairing' : 'No other options available'}
                             >
                                 ＋
                             </button>

--- a/src/hooks/useChartSync.js
+++ b/src/hooks/useChartSync.js
@@ -10,8 +10,8 @@ const CHANNEL = 'evbench-chart-sync';
  * Pop-out tab: sends 'request-state' on mount + focus, applies received state.
  */
 export function useChartSync({
-    chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig,
-    setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig,
+    chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings,
+    setChartMode, setChartConfig, setVehicleSelection, setCompareConfig, setRoadTripConfig, setEpaConfig, setPairings,
 }) {
     const isPopout = useRef(
         new URLSearchParams(window.location.search).get('popout') === '1'
@@ -20,9 +20,9 @@ export function useChartSync({
     const channelRef = useRef(null);
 
     // Keep a ref of current state so the onmessage handler never closes over stale values
-    const stateRef = useRef({ chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig });
+    const stateRef = useRef({ chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings });
     useEffect(() => {
-        stateRef.current = { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig };
+        stateRef.current = { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings };
     });
 
     useEffect(() => {
@@ -41,6 +41,11 @@ export function useChartSync({
                 if (data.compareConfig)  setCompareConfig(data.compareConfig);
                 if (data.roadTripConfig) setRoadTripConfig(data.roadTripConfig);
                 if (data.epaConfig)      setEpaConfig(data.epaConfig);
+                // Pairings decide which range test prices the miles, so a pop-out
+                // that missed them would plot different numbers than the tab that
+                // opened it, with nothing on screen saying so. Assigned even when
+                // empty, unlike the configs above — {} is a meaningful state here.
+                if (data.pairings)       setPairings(data.pairings);
             };
             // Request current state on mount and whenever the tab regains focus
             // (covers the case where the main tab refreshed while this was in the background)
@@ -55,7 +60,7 @@ export function useChartSync({
             // Main tab: respond to state requests from pop-outs
             channel.onmessage = ({ data }) => {
                 if (data?.type !== 'request-state') return;
-                const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig } = stateRef.current;
+                const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings } = stateRef.current;
                 channel.postMessage({
                     type: 'chart-state',
                     chartMode,
@@ -64,6 +69,7 @@ export function useChartSync({
                     compareConfig,
                     roadTripConfig,
                     epaConfig,
+                    pairings,
                 });
             };
             return () => channel.close();
@@ -73,7 +79,7 @@ export function useChartSync({
     /** Called by App.jsx whenever chart state changes (main tab only). */
     const sendState = useCallback(() => {
         if (isPopout || !channelRef.current) return;
-        const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig } = stateRef.current;
+        const { chartMode, chartConfig, selectedVehicles, compareConfig, roadTripConfig, epaConfig, pairings } = stateRef.current;
         channelRef.current.postMessage({
             type: 'chart-state',
             chartMode,
@@ -82,6 +88,7 @@ export function useChartSync({
             compareConfig,
             roadTripConfig,
             epaConfig,
+            pairings,
         });
     }, [isPopout]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -887,6 +887,12 @@ body {
     @apply flex items-center gap-2 cursor-pointer;
 }
 
+/* Additional partners for the same charging test — indented so the branch
+   reads as belonging to the row above, checkbox included. */
+.pair-row-child {
+    @apply pl-8;
+}
+
 /* Charging-test identity; blank on continuation rows so partners line up */
 .pair-charging-label {
     @apply flex items-center gap-2 min-w-0;

--- a/src/index.css
+++ b/src/index.css
@@ -875,6 +875,50 @@ body {
     @apply flex-1 flex items-center gap-2 flex-wrap;
 }
 
+/* ── Pair mode (charging test × range test) ─────────────────────────────────── */
+
+/* One charging test and all of its range partners, kept visually together */
+.pair-group {
+    @apply space-y-1;
+}
+
+/* A single charging × range pair */
+.pair-row {
+    @apply flex items-center gap-2 cursor-pointer;
+}
+
+/* Charging-test identity; blank on continuation rows so partners line up */
+.pair-charging-label {
+    @apply flex items-center gap-2 min-w-0;
+    flex: 1 1 40%;
+}
+
+/* The "Range: [select] +n ＋" cluster on the right of each pair row */
+.pair-range-control {
+    @apply flex items-center gap-1.5 shrink-0;
+}
+
+/* "+3" — how many other range tests could be paired with this charging test */
+.pair-more-badge {
+    @apply text-xs font-medium px-1.5 py-0.5 rounded-full cursor-help;
+    background-color: var(--color-surface-muted);
+    color: var(--color-text-muted);
+}
+
+.pair-add-btn,
+.pair-remove-btn {
+    @apply text-sm leading-none px-1 rounded transition;
+    color: var(--color-text-faint);
+}
+.pair-add-btn:hover:not(:disabled),
+.pair-remove-btn:hover {
+    color: var(--color-primary);
+    background-color: var(--color-surface-muted);
+}
+.pair-add-btn:disabled {
+    @apply opacity-30 cursor-not-allowed;
+}
+
 /* Copy chart as PNG / Reset Zoom / action button strip below charts */
 .chart-copy-btn {
     @apply text-sm flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-colors;

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -1,0 +1,122 @@
+/**
+ * Chart-session pairings — which range test supplies the miles for which
+ * charging test, chosen by the user.
+ *
+ * A pairing is rank 1 of the resolution order in utils/rangeSource.js: it beats
+ * the vehicle default, the charging run's own range half, and the recorded
+ * range column. Everything below rank 1 still applies to any charging run the
+ * user has not paired explicitly, so an empty pairing map means "resolve
+ * everything automatically" rather than "show nothing".
+ *
+ * ── Shape ────────────────────────────────────────────────────────────────────
+ *
+ *     { [chargingRunId]: [rangeRunId, ...] }
+ *
+ * A charging run may carry several range partners — one curve against 70 mph
+ * mild AND 80 mph cold is the case the whole epic exists for — so the value is
+ * a list, and each entry becomes its own chart series.
+ *
+ * Keys are stringified because run ids arrive as numbers from the database and
+ * as strings from the URL, and inherited runs (spec_links) carry synthetic
+ * string ids. Normalising once here keeps every consumer from having to care.
+ *
+ * ── Scope ────────────────────────────────────────────────────────────────────
+ *
+ * Global to the chart session, never per-view: if Charge Compare honours a
+ * pairing while the charging chart's range axis does not, two charts on the
+ * same screen disagree about what "range" means.
+ *
+ * Persisted to the URL (shareable, and what the pop-out BroadcastChannel
+ * carries). Deliberately NOT localStorage — a per-browser preference that
+ * silently diverges from what everyone else sees is a support problem on a
+ * curated site. The curator-set default lives in the database instead, on
+ * runs.paired_range_run_id.
+ */
+
+const key = id => String(id);
+
+/** Range partners explicitly chosen for a charging run. Empty when unpaired. */
+export function partnersFor(pairings, chargingRunId) {
+    return pairings?.[key(chargingRunId)] ?? [];
+}
+
+/** True when the user has explicitly paired this charging run. */
+export function isPaired(pairings, chargingRunId) {
+    return partnersFor(pairings, chargingRunId).length > 0;
+}
+
+/**
+ * Add a range partner. Returns a new map — never mutates, so React state
+ * updates and the URL/broadcast effects fire correctly.
+ */
+export function addPartner(pairings, chargingRunId, rangeRunId) {
+    const k = key(chargingRunId);
+    const existing = pairings[k] ?? [];
+    if (existing.includes(key(rangeRunId))) return pairings;
+    return { ...pairings, [k]: [...existing, key(rangeRunId)] };
+}
+
+/** Replace one partner with another, preserving its position in the list. */
+export function replacePartner(pairings, chargingRunId, oldRangeRunId, newRangeRunId) {
+    const k = key(chargingRunId);
+    const existing = pairings[k] ?? [];
+    const idx = existing.indexOf(key(oldRangeRunId));
+    if (idx === -1) return addPartner(pairings, chargingRunId, newRangeRunId);
+    const next = [...existing];
+    next[idx] = key(newRangeRunId);
+    return { ...pairings, [k]: next };
+}
+
+/** Drop one partner; drops the charging run's entry entirely when it empties. */
+export function removePartner(pairings, chargingRunId, rangeRunId) {
+    const k = key(chargingRunId);
+    const existing = pairings[k] ?? [];
+    const next = existing.filter(id => id !== key(rangeRunId));
+    const out = { ...pairings };
+    if (next.length === 0) delete out[k];
+    else out[k] = next;
+    return out;
+}
+
+/**
+ * Drop every pairing whose charging run or range partner is no longer present.
+ *
+ * Called when the vehicle selection changes: a pairing referencing a run the
+ * user can no longer see is dead weight that would otherwise ride along in the
+ * URL forever, and would silently resurrect if that vehicle came back.
+ */
+export function prunePairings(pairings, availableRunIds) {
+    const live = new Set([...availableRunIds].map(key));
+    const out = {};
+    for (const [chargingId, partners] of Object.entries(pairings || {})) {
+        if (!live.has(chargingId)) continue;
+        const kept = partners.filter(id => live.has(id));
+        if (kept.length) out[chargingId] = kept;
+    }
+    return out;
+}
+
+// ── URL encoding ─────────────────────────────────────────────────────────────
+//
+// `12:5,7;13:9` — charging run 12 paired with range runs 5 and 7; 13 with 9.
+// Compact enough that a chart with a dozen pairs still yields a usable link.
+
+export function encodePairings(pairings) {
+    const parts = Object.entries(pairings || {})
+        .filter(([, partners]) => partners?.length)
+        .map(([chargingId, partners]) => `${chargingId}:${partners.join(',')}`);
+    return parts.join(';');
+}
+
+export function decodePairings(raw) {
+    if (!raw) return {};
+    const out = {};
+    for (const group of String(raw).split(';')) {
+        if (!group) continue;
+        const [chargingId, partnerList] = group.split(':');
+        if (!chargingId || !partnerList) continue;
+        const partners = partnerList.split(',').filter(Boolean);
+        if (partners.length) out[chargingId] = partners;
+    }
+    return out;
+}

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -35,6 +35,23 @@
 
 const key = id => String(id);
 
+// ── Pair identity ────────────────────────────────────────────────────────────
+//
+// One charging run plotted against three range tests is three series, so a run
+// id is no longer enough to identify a selection or a chart series. The pair is.
+// '::' because synthetic inherited-run ids already contain '-'.
+
+const PAIR_SEP = '::';
+
+export function pairKey(chargingRunId, rangeRunId) {
+    return `${key(chargingRunId)}${PAIR_SEP}${rangeRunId == null ? '' : key(rangeRunId)}`;
+}
+
+export function parsePairKey(k) {
+    const [chargingRunId, rangeRunId] = String(k).split(PAIR_SEP);
+    return { chargingRunId, rangeRunId: rangeRunId || null };
+}
+
 /** Range partners explicitly chosen for a charging run. Empty when unpaired. */
 export function partnersFor(pairings, chargingRunId) {
     return pairings?.[key(chargingRunId)] ?? [];

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -4,17 +4,24 @@
  *
  * A pairing is rank 1 of the resolution order in utils/rangeSource.js: it beats
  * the vehicle default, the charging run's own range half, and the recorded
- * range column. Everything below rank 1 still applies to any charging run the
- * user has not paired explicitly, so an empty pairing map means "resolve
- * everything automatically" rather than "show nothing".
+ * range column. Everything below rank 1 still applies wherever the user has not
+ * paired explicitly, so an empty pairing map means "resolve everything
+ * automatically" rather than "show nothing".
  *
  * ── Shape ────────────────────────────────────────────────────────────────────
  *
- *     { [chargingRunId]: [rangeRunId, ...] }
+ *     { [rangeRunId]: [chargingRunId, ...] }
  *
- * A charging run may carry several range partners — one curve against 70 mph
- * mild AND 80 mph cold is the case the whole epic exists for — so the value is
- * a list, and each entry becomes its own chart series.
+ * Keyed by the RANGE test, because that is the axis worth enumerating: a
+ * charging curve is a property of the car and varies little, while a range test
+ * is a property of the day — wind, temperature, HVAC, tyres, elevation,
+ * humidity and load all move it, often drastically. So the list shows the
+ * variable thing and you pick the stable one for it.
+ *
+ * The value is a list because a range test may be compared against several
+ * charging curves, and each entry becomes its own chart series. The tuple is
+ * symmetric — (range, charging) either way — so only the enumeration order
+ * changes, never the maths.
  *
  * Keys are stringified because run ids arrive as numbers from the database and
  * as strings from the URL, and inherited runs (spec_links) carry synthetic
@@ -37,58 +44,58 @@ const key = id => String(id);
 
 // ── Pair identity ────────────────────────────────────────────────────────────
 //
-// One charging run plotted against three range tests is three series, so a run
-// id is no longer enough to identify a selection or a chart series. The pair is.
+// One range test plotted against three charging curves is three series, so a
+// run id is no longer enough to identify a selection or a chart series. The pair is.
 // '::' because synthetic inherited-run ids already contain '-'.
 
 const PAIR_SEP = '::';
 
-export function pairKey(chargingRunId, rangeRunId) {
-    return `${key(chargingRunId)}${PAIR_SEP}${rangeRunId == null ? '' : key(rangeRunId)}`;
+export function pairKey(rangeRunId, chargingRunId) {
+    return `${key(rangeRunId)}${PAIR_SEP}${chargingRunId == null ? '' : key(chargingRunId)}`;
 }
 
 export function parsePairKey(k) {
-    const [chargingRunId, rangeRunId] = String(k).split(PAIR_SEP);
-    return { chargingRunId, rangeRunId: rangeRunId || null };
+    const [rangeRunId, chargingRunId] = String(k).split(PAIR_SEP);
+    return { rangeRunId, chargingRunId: chargingRunId || null };
 }
 
-/** Range partners explicitly chosen for a charging run. Empty when unpaired. */
-export function partnersFor(pairings, chargingRunId) {
-    return pairings?.[key(chargingRunId)] ?? [];
+/** Charging partners explicitly chosen for a range test. Empty when unpaired. */
+export function partnersFor(pairings, rangeRunId) {
+    return pairings?.[key(rangeRunId)] ?? [];
 }
 
-/** True when the user has explicitly paired this charging run. */
-export function isPaired(pairings, chargingRunId) {
-    return partnersFor(pairings, chargingRunId).length > 0;
+/** True when the user has explicitly paired this range test. */
+export function isPaired(pairings, rangeRunId) {
+    return partnersFor(pairings, rangeRunId).length > 0;
 }
 
 /**
- * Add a range partner. Returns a new map — never mutates, so React state
+ * Add a charging partner. Returns a new map — never mutates, so React state
  * updates and the URL/broadcast effects fire correctly.
  */
-export function addPartner(pairings, chargingRunId, rangeRunId) {
-    const k = key(chargingRunId);
+export function addPartner(pairings, rangeRunId, chargingRunId) {
+    const k = key(rangeRunId);
     const existing = pairings[k] ?? [];
-    if (existing.includes(key(rangeRunId))) return pairings;
-    return { ...pairings, [k]: [...existing, key(rangeRunId)] };
+    if (existing.includes(key(chargingRunId))) return pairings;
+    return { ...pairings, [k]: [...existing, key(chargingRunId)] };
 }
 
 /** Replace one partner with another, preserving its position in the list. */
-export function replacePartner(pairings, chargingRunId, oldRangeRunId, newRangeRunId) {
-    const k = key(chargingRunId);
+export function replacePartner(pairings, rangeRunId, oldChargingRunId, newChargingRunId) {
+    const k = key(rangeRunId);
     const existing = pairings[k] ?? [];
-    const idx = existing.indexOf(key(oldRangeRunId));
-    if (idx === -1) return addPartner(pairings, chargingRunId, newRangeRunId);
+    const idx = existing.indexOf(key(oldChargingRunId));
+    if (idx === -1) return addPartner(pairings, rangeRunId, newChargingRunId);
     const next = [...existing];
-    next[idx] = key(newRangeRunId);
+    next[idx] = key(newChargingRunId);
     return { ...pairings, [k]: next };
 }
 
-/** Drop one partner; drops the charging run's entry entirely when it empties. */
-export function removePartner(pairings, chargingRunId, rangeRunId) {
-    const k = key(chargingRunId);
+/** Drop one partner; drops the range test's entry entirely when it empties. */
+export function removePartner(pairings, rangeRunId, chargingRunId) {
+    const k = key(rangeRunId);
     const existing = pairings[k] ?? [];
-    const next = existing.filter(id => id !== key(rangeRunId));
+    const next = existing.filter(id => id !== key(chargingRunId));
     const out = { ...pairings };
     if (next.length === 0) delete out[k];
     else out[k] = next;
@@ -96,7 +103,7 @@ export function removePartner(pairings, chargingRunId, rangeRunId) {
 }
 
 /**
- * Drop every pairing whose charging run or range partner is no longer present.
+ * Drop every pairing whose range test or charging partner is no longer present.
  *
  * Called when the vehicle selection changes: a pairing referencing a run the
  * user can no longer see is dead weight that would otherwise ride along in the
@@ -105,23 +112,23 @@ export function removePartner(pairings, chargingRunId, rangeRunId) {
 export function prunePairings(pairings, availableRunIds) {
     const live = new Set([...availableRunIds].map(key));
     const out = {};
-    for (const [chargingId, partners] of Object.entries(pairings || {})) {
-        if (!live.has(chargingId)) continue;
+    for (const [primaryId, partners] of Object.entries(pairings || {})) {
+        if (!live.has(primaryId)) continue;
         const kept = partners.filter(id => live.has(id));
-        if (kept.length) out[chargingId] = kept;
+        if (kept.length) out[primaryId] = kept;
     }
     return out;
 }
 
 // ── URL encoding ─────────────────────────────────────────────────────────────
 //
-// `12:5,7;13:9` — charging run 12 paired with range runs 5 and 7; 13 with 9.
+// `12:5,7;13:9` — range test 12 paired with charging runs 5 and 7; 13 with 9.
 // Compact enough that a chart with a dozen pairs still yields a usable link.
 
 export function encodePairings(pairings) {
     const parts = Object.entries(pairings || {})
         .filter(([, partners]) => partners?.length)
-        .map(([chargingId, partners]) => `${chargingId}:${partners.join(',')}`);
+        .map(([primaryId, partners]) => `${primaryId}:${partners.join(',')}`);
     return parts.join(';');
 }
 
@@ -130,10 +137,10 @@ export function decodePairings(raw) {
     const out = {};
     for (const group of String(raw).split(';')) {
         if (!group) continue;
-        const [chargingId, partnerList] = group.split(':');
-        if (!chargingId || !partnerList) continue;
+        const [primaryId, partnerList] = group.split(':');
+        if (!primaryId || !partnerList) continue;
         const partners = partnerList.split(',').filter(Boolean);
-        if (partners.length) out[chargingId] = partners;
+        if (partners.length) out[primaryId] = partners;
     }
     return out;
 }

--- a/src/utils/rangeSource.js
+++ b/src/utils/rangeSource.js
@@ -53,6 +53,27 @@
 import { isRangeRun } from './runUtils';
 
 /**
+ * Sentinel partner id for "use the vehicle's EPA range".
+ *
+ * EPA range is a legitimate basis that is not a run: it is the manufacturer's
+ * rated full-pack figure, so it prices a %SoC without any test at all. Useful
+ * as a neutral yardstick when a vehicle's own range tests are all in unusual
+ * conditions, or when it has none.
+ *
+ * A string sentinel rather than a fake run row, so it can never be confused
+ * with a real run id, survives the URL round trip, and cannot be picked up by
+ * defaultRangeRun() — EPA is only ever an explicit choice.
+ */
+export const EPA_PARTNER_ID = 'epa';
+
+/** The EPA option for a vehicle's partner dropdown, or null when it has no rated range. */
+export function epaRangeOption(vehicle) {
+    return vehicle?.range > 0
+        ? { id: EPA_PARTNER_ID, name: 'EPA range', _synthetic: true }
+        : null;
+}
+
+/**
  * Miles per %SoC from a range test.
  *
  * Guards the degenerate cases: no distance, missing SoC bounds, and
@@ -166,6 +187,22 @@ export function resolveRangeSource(chargingRun, {
         miPerSoc: null, miPerKwh: null, energyMethod: null, note: null,
     };
     if (!chargingRun) return none;
+
+    // EPA range, when explicitly chosen. Rated range is a full-pack figure, so
+    // one percent of SoC buys one hundredth of it. Only ever reachable by
+    // explicit choice — it is never resolved automatically, because a real
+    // measured test on this vehicle is always the better default.
+    const wantsEpa = explicitPairing === EPA_PARTNER_ID || explicitPairing?.id === EPA_PARTNER_ID;
+    if (wantsEpa && vehicle?.range > 0) {
+        return {
+            source: 'epa',
+            sourceRun: epaRangeOption(vehicle),
+            miPerSoc: vehicle.range / 100,
+            miPerKwh: batteryKwh > 0 ? vehicle.range / batteryKwh : null,
+            energyMethod: 'epa-rated',
+            note: 'EPA rated range',
+        };
+    }
 
     // Ranks 1–3 all resolve to a range run; pick the first that yields data.
     const candidates = [

--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -34,6 +34,23 @@ export const isRangeRun = (r) => r.kind === 'range' || !!r.has_range;
 export const filterChargingRuns = (runs) => (runs || []).filter(isChargingRun);
 export const filterRangeRuns    = (runs) => (runs || []).filter(isRangeRun);
 
+/**
+ * The charging test to use for a vehicle when the user hasn't picked one:
+ * the explicitly-defaulted run, else the most recent.
+ *
+ * The mirror of defaultRangeRun() in utils/rangeSource.js. Charging curves vary
+ * far less than range tests — they're a property of the car, where a range test
+ * is a property of the day — so this default is usually the right answer and
+ * rarely worth overriding.
+ */
+export function defaultChargingRun(vehicle) {
+    const charging = filterChargingRuns(vehicle?.runs);
+    if (!charging.length) return null;
+    return charging.find(r => r.isDefault || r.is_default)
+        ?? [...charging].sort((a, b) => new Date(b.date) - new Date(a.date))[0]
+        ?? null;
+}
+
 // ── Populated-field detection ─────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
**Part of #153 — does not close it.** This is the state layer plus the selector UI. **Pair mode is not reachable in the app yet**: Charge Compare still runs range-primary, so nothing here is user-visible until it is inverted to charging-primary and starts consuming `pairings`. That is the next piece.

Rebased onto main after #168 merged, so it targets main directly — no stacked retarget needed.

## 1. Pairing state (`utils/pairings.js`)

```
{ [chargingRunId]: [rangeRunId, ...] }
```

A charging run takes several range partners, because one curve against 70 mph mild AND 80 mph cold is the case the epic exists for; each partner becomes its own series. Keys are stringified — run ids arrive as numbers from the database, strings from the URL, and synthetic strings for runs inherited via `spec_links`.

**An empty map means "resolve everything automatically", not "show nothing".** Ranks 2–4 of the resolver still apply to any unpaired charging run, so charts behave exactly as they do today until someone actively pairs something. This phase is additive, not a second restatement.

Wired into App as a fourth synced config beside `compareConfig` / `roadTripConfig` / `epaConfig`, inheriting the existing plumbing:

- **URL** as `?pairs=12:5,7;13:9`. Written for every chart mode rather than one tab, since pairings are global to the chart session — if Charge Compare honours a pairing while the charging chart's range axis does not, two charts on one screen disagree about what "range" means. Omitted when empty so an untouched chart keeps a clean URL.
- **BroadcastChannel.** Without it a pop-out plots different numbers than the tab that opened it with nothing on screen saying so — the highest-risk silent failure in this phase. Note `pairings` is assigned even when empty, unlike the sibling configs guarded by `if (data.x)`: for them a missing value means "no change", but here `{}` is a meaningful state that must be able to propagate, or clearing a pairing would leave the pop-out showing the old one forever.
- **Pruned on selection change**, so a pairing referencing a deselected run cannot ride along in the URL or silently resurrect when that vehicle returns.

No localStorage, deliberately: a per-browser preference that silently diverges from what everyone else sees is a support problem on a curated site. The durable curator-set default belongs in the database on `runs.paired_range_run_id`.

## 2. Selector pair mode

Opt-in `pairMode` turns the shared selector's flat list into charging tests with an inline range control. The other three views pass nothing and are untouched.

```
[x] ▌ 10→80% DC fast (2026-03-14)    Range: [Auto — Ottawa loop ▾]  +3  ＋
    ↳                                Range: [80 mph cold ▾]              ×
```

Rows are keyed by **pair**, not by run — one curve against three range tests is three series, so a run id can no longer identify a selection. `'::'` as separator because synthetic inherited-run ids already contain `'-'`.

Three decisions worth reviewing:

- **An unpaired charging test still gets a row**, reading `Auto — <resolver's pick>`. Showing only pinned pairs would hide every charging test until someone paired it, and would make the automatic choice invisible. This keeps the default on screen and attributed.
- **＋ pins the auto-resolved partner before adding the new one**, so duplicating an auto row cannot silently drop the series you were already looking at.
- **The `+n` badge counts range tests NOT already used** by that charging run — "there is more here" rather than restating the current row. Tooltip names them; once #154 lands it can count congruent ones instead, which is the more useful number.

Rejected pickers are recorded on #153: double dropdown per added pair (re-picking the charging test every time), nested multi-select (a fourth nesting level), matrix grid (best for bulk, degrades past ~5×5 — kept as a possible later power mode).

## Testing

33 unit tests across the two modules: add/replace/remove, id-type normalisation, immutability and identity-preservation on no-op writes, pruning, URL round trips including malformed input and synthetic ids, pair-key round trips with inherited ids on either side, and the ＋ duplicate flow keeping both partners.

`vite build` clean.

**No preview yet** — with Charge Compare not consuming pairings there is nothing to look at. Worth reviewing visually once the next piece lands rather than now.

## Scope

#153 is 4–5 PRs' worth. Still to come, to be filed as siblings: series identity (naming elision + pair colours) and the curator-set default pairing in Tests & Data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)