### PR TITLE
Curator-set default charging pair for range tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -466,6 +466,7 @@ export default function App() {
                 compareConfig={compareConfig}
                 roadTripConfig={roadTripConfig}
                 epaConfig={epaConfig}
+                pairings={pairings}
                 onUpdateRunColor={updateRunColor}
             />
         );
@@ -807,6 +808,8 @@ export default function App() {
                             setChartConfig={setChartConfig}
                             onUpdateRunColor={updateRunColor}
                             chartMode={chartMode}
+                            pairings={pairings}
+                            setPairings={setPairings}
                         />
                     )}
                     {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'roadtrip' && (
@@ -815,6 +818,8 @@ export default function App() {
                             selectedVehicleIds={selectedVehicles}
                             roadTripConfig={roadTripConfig}
                             setRoadTripConfig={setRoadTripConfig}
+                            pairings={pairings}
+                            setPairings={setPairings}
                             onUpdateRunColor={updateRunColor}
                             autoColor={chartConfig.autoColor ?? true}
                             setChartConfig={setChartConfig}

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -10,6 +10,7 @@ import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../uti
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
 import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
+import { useRunSelection } from '../hooks/useRunSelection';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
@@ -288,7 +289,6 @@ export default function ChargeCompareView({
     const [loading,         setLoading]         = useState(false);
     const [copied,          setCopied]          = useState(false);
     const [orientation,     setOrientation]     = useState('horizontal');
-    const [selectedRuns,    setSelectedRuns]    = useState([]);
     const isHorizontal = orientation === 'horizontal';
 
     const chart1Ref      = useRef(null);
@@ -409,13 +409,25 @@ export default function ChargeCompareView({
     // Selection is by pair key, so adding a second range partner to a charging
     // test brings the new series in already selected rather than requiring a
     // second click in a different part of the UI.
-    useEffect(() => {
-        const allKeys = resolvedPairs.map(p => p.key);
-        setSelectedRuns(prev => {
-            const newKeys = allKeys.filter(k => !prev.includes(k));
-            return newKeys.length ? [...prev, ...newKeys] : prev;
-        });
-    }, [resolvedPairs]);
+    // Auto-select genuinely NEW rows, never re-select ones the user turned off.
+    //
+    // Tracked per range test rather than per pair key, because repinning a row
+    // changes its key ('70::' becomes '70::12'). Keying on the pair alone made
+    // every deselected row spring back the moment any dropdown changed, and
+    // meant a repinned row could not carry its selection across.
+    // Selection lives in the shared hook (hooks/useRunSelection.js) so this chart,
+    // Road Trip and anything added later behave identically when the data shifts
+    // underneath them — pruning, repin carry-over and first-sighting bootstrap
+    // were three separate implementations that each got a different part wrong.
+    const selectionRows = useMemo(
+        () => resolvedPairs.map(p => ({
+            key: p.key,
+            vehicleId: p.rangeRun.vehicleId,
+            groupId: p.rangeRun.id,     // survives a repin, which changes the key
+        })),
+        [resolvedPairs]
+    );
+    const { selected: selectedRuns, toggle: toggleRun } = useRunSelection(selectionRows);
 
     const activePairs = resolvedPairs.filter(p => selectedRuns.includes(p.key));
 
@@ -501,7 +513,12 @@ export default function ChargeCompareView({
                 const targetTime  = Tz + xMinutes;
                 const lastTime    = byTime[byTime.length - 1].time;
                 const timeOvershoot = Math.max(0, targetTime - lastTime);
-                const SocEnd = interpolate(byTime, 'time', 'soc', targetTime, false, true);
+                const SocRaw = interpolate(byTime, 'time', 'soc', targetTime, false, true);
+                // A pack cannot exceed 100% SoC. Extrapolating forward past the end
+                // of a short run can produce SoC well above that, and the linear
+                // model has no ceiling of its own to catch it — unclamped, a run
+                // whose data spans a couple of minutes yielded 4800 mi added in 15.
+                const SocEnd = SocRaw != null ? Math.min(100, SocRaw) : null;
                 // Linear: the SoC gained over the window, priced at the paired
                 // test's miles-per-%SoC. Recorded: read the range column directly.
                 const Rend = useLinear
@@ -524,12 +541,16 @@ export default function ChargeCompareView({
                 // Linear: the miles asked for convert to a SoC target, and the
                 // charging curve is read on the SoC axis. Recorded: sort by the
                 // range column and read time off it, as before.
-                let Tend, SocEnd, rangeOvershoot;
+                let Tend, SocEnd, rangeOvershoot, unreachable = false;
                 if (useLinear) {
                     const targetSoc = startSoc + mMiles / miPerSoc;
                     const lastSoc   = bySoc[bySoc.length - 1].soc;
-                    Tend   = interpolate(bySoc, 'soc', 'time', targetSoc, false, true);
-                    SocEnd = targetSoc;
+                    // Asking for more miles than a full pack holds from this SoC is
+                    // not a long charge, it is impossible — report no data rather
+                    // than extrapolating past 100% into a fictional time.
+                    unreachable = targetSoc > 100;
+                    Tend   = unreachable ? null : interpolate(bySoc, 'soc', 'time', targetSoc, false, true);
+                    SocEnd = Math.min(100, targetSoc);
                     // Expressed in miles so it stays comparable with mMiles.
                     rangeOvershoot = Math.max(0, targetSoc - lastSoc) * miPerSoc;
                 } else {
@@ -651,7 +672,10 @@ export default function ChargeCompareView({
                 if (inst.current) { inst.current.destroy(); inst.current = null; }
             });
         };
-    }, [selectedVehicleIds, xMinutes, mMiles, startSoc, runDataCache, orientation, selectedRuns, units, isDark]);
+    // resolvedPairs, not just selectedRuns: changing a row's partner can leave the
+    // selection array identical (same row, different pairing) while every bar's
+    // value changes, and the chart would keep the previous partner's numbers.
+    }, [selectedVehicleIds, xMinutes, mMiles, startSoc, runDataCache, orientation, selectedRuns, resolvedPairs, units, isDark]);
 
     const hasRangeRuns = resolvedPairs.length > 0;
 
@@ -715,9 +739,7 @@ export default function ChargeCompareView({
                     <RunSelector
                         vehicles={selectedVehicles}
                         selectedRunIds={selectedRuns}
-                        onToggleRun={runId => setSelectedRuns(prev =>
-                            prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId]
-                        )}
+                        onToggleRun={toggleRun}
                         onUpdateRunColor={onUpdateRunColor}
                         runFilter={(run, vehicle) =>
                             // A range test with no charging curve to pair against

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -7,7 +7,7 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, filterRangeRuns, isRangeRun, defaultChargingRun } from '../utils/runUtils';
+import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
 import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import LoadingSpinner from './LoadingSpinner';
@@ -325,7 +325,6 @@ export default function ChargeCompareView({
         const result = [];
         for (const vehicle of selectedVehicles) {
             const chargingRuns = filterChargingRuns(vehicle.runs);
-            const autoCharging = defaultChargingRun(vehicle);
             // EPA rated range is a range basis with no test behind it, so it joins
             // the primary list rather than the partner dropdown.
             const epa = epaRangeOption(vehicle);
@@ -336,6 +335,8 @@ export default function ChargeCompareView({
                 const rows   = pinned.length ? pinned : [null];
 
                 for (const partnerId of rows) {
+                    // URL pairing → curator's stored pairing → vehicle default.
+                    const autoCharging = pairedChargingRun(rangeRun, vehicle);
                     const chargingRun = partnerId
                         ? chargingRuns.find(r => String(r.id) === String(partnerId)) ?? autoCharging
                         : autoCharging;
@@ -733,9 +734,11 @@ export default function ChargeCompareView({
                             const epa = epaRangeOption(vehicle);
                             return epa ? [epa] : [];
                         }}
-                        resolvePartner={(_rangeRun, vehicle) => {
-                            const run = defaultChargingRun(vehicle);
-                            return run ? { sourceRun: run, note: null } : null;
+                        resolvePartner={(rangeRun, vehicle) => {
+                            const run = pairedChargingRun(rangeRun, vehicle);
+                            return run
+                                ? { sourceRun: run, note: rangeRun?.paired_charging_run_id != null ? 'curated' : null }
+                                : null;
                         }}
                         onSetPartner={(rangeId, oldChargingId, newChargingId) =>
                             setPairings(prev => replacePartner(prev, rangeId, oldChargingId, newChargingId))}

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -13,12 +13,14 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
+import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
+import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
 import ChartInfoBubble from './ChartInfoBubble';
 
-export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, presentationMode = false }) {
+export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, pairings = {}, setPairings = () => {}, presentationMode = false }) {
     const { units } = useAppContext();
     const { isDark } = useTheme();
     const chartRef = useRef(null);
@@ -140,7 +142,37 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         }
     }, [selectedVehicleIds, chartConfig.selectedRuns, chartMode]);
 
-    // Lazy-load data_points for newly selected runs
+    // A pairing change invalidates cached range values: the derived range is
+    // baked into the cached points, so without this the axis would keep showing
+    // the previous partner's numbers until the run was reselected.
+    const prevPairingsRef = useRef(pairings);
+    useEffect(() => {
+        const prev = prevPairingsRef.current;
+        prevPairingsRef.current = pairings;
+        if (prev === pairings) return;
+        // Values are charging-run ids, which are exactly this cache's keys.
+        const affected = new Set(
+            [...Object.values(prev || {}).flat(), ...Object.values(pairings || {}).flat()].map(String)
+        );
+        if (!affected.size) return;
+        setRunDataCache(cache => {
+            const next = {};
+            let evicted = false;
+            for (const [id, data] of Object.entries(cache)) {
+                if (affected.has(String(id))) { evicted = true; continue; }
+                next[id] = data;
+            }
+            return evicted ? next : cache;
+        });
+    }, [pairings]);
+
+    // Lazy-load data_points for newly selected runs.
+    //
+    // Keyed on what is MISSING, not on the selection: a pairing change evicts
+    // cached runs (their derived range is stale), and keying on the selection
+    // alone meant nothing refetched them — the series vanished until some
+    // unrelated toggle changed the selection and happened to trigger this.
+    const missingRunIds = chartConfig.selectedRuns.filter(id => !(id in runDataCache));
     useEffect(() => {
         const fetchMissingData = async () => {
             const missingIds = chartConfig.selectedRuns.filter(id => !(id in runDataCache));
@@ -160,25 +192,54 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             runData = await dataService.getRunData(runId);
                         }
 
-                        // If this charging run has no range values at all, derive them
-                        // on the fly from the vehicle's range test via SoC interpolation.
-                        if (runData.length > 0 && !runData.some(p => p.range != null)) {
+                        // Range axis, resolved on the same ranking as every other
+                        // chart (utils/rangeSource.js):
+                        //
+                        //   pairing → default range test → recorded range column
+                        //
+                        // A range test now outranks the recorded column outright,
+                        // not just when one was explicitly paired. The recorded
+                        // values are themselves mostly estimates — usually the car's
+                        // guess-o-meter — so they carry no more authority than a
+                        // figure derived from a measured range test, and treating
+                        // them as more authoritative was the anomaly.
+                        if (runData.length > 0) {
                             const parentVehicle = vehicles.find(v =>
                                 v.runs?.some(r => String(r.id) === String(runId))
                             );
-                            const rangeRun =
-                                parentVehicle?.runs?.find(r => !r._inherited && r.has_range && r.isDefault) ??
-                                parentVehicle?.runs?.find(r => !r._inherited && r.has_range);
-                            if (rangeRun) {
-                                try {
-                                    const lookup = await dataService.buildRangePerSocLookup(rangeRun.id);
-                                    if (lookup) {
-                                        runData = runData.map(p => ({
-                                            ...p,
-                                            range: p.soc != null ? lookup(p.soc) : null,
-                                        }));
-                                    }
-                                } catch (_) { /* non-fatal — chart will just lack range axis */ }
+                            const pairedRangeIds = rangePartnersOfCharging(pairings, runId);
+                            const own = (parentVehicle?.runs || []).filter(r => !r._inherited && isRangeRun(r));
+                            const pairedRange = pairedRangeIds.length
+                                ? (pairedRangeIds[0] === EPA_PARTNER_ID
+                                    ? EPA_PARTNER_ID
+                                    : own.find(r => String(r.id) === pairedRangeIds[0]) ?? null)
+                                : null;
+
+                            const src = resolveRangeSource(run ?? { id: runId }, {
+                                vehicle: parentVehicle,
+                                explicitPairing: pairedRange,
+                            });
+
+                            // 'recorded' and 'none' mean no range test won — leave
+                            // the run's own column alone.
+                            if (src.miPerSoc != null) {
+                                let lookup = null;
+                                // A range test WITH its own SoC/range time series gives
+                                // the real, non-linear shape; prefer it. Most range
+                                // tests are scalar (distance + SoC bounds), so the
+                                // linear miPerSoc model is the usual path.
+                                if (src.sourceRun?.id && src.sourceRun.id !== EPA_PARTNER_ID) {
+                                    try {
+                                        lookup = await dataService.buildRangePerSocLookup(src.sourceRun.id);
+                                    } catch (_) { /* fall through to linear */ }
+                                }
+                                const rangeAt = lookup
+                                    ? (soc) => lookup(soc)
+                                    : (soc) => Math.round(soc * src.miPerSoc * 10) / 10;
+                                runData = runData.map(p => ({
+                                    ...p,
+                                    range: p.soc != null ? rangeAt(p.soc) : null,
+                                }));
                             }
                         }
                     } else {
@@ -198,7 +259,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             setLoadingData(false);
         };
         fetchMissingData();
-    }, [chartConfig.selectedRuns]);
+    }, [missingRunIds.join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const dl = distanceLabel(units);
     const axisOptions = [
@@ -668,6 +729,20 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     runFilter={isChargingRun}
                     colorMap={colorMap}
                     emptyMessage="No charging test records"
+                    pairMode
+                    singlePartner
+                    pairings={pairings}
+                    primaryLabel="Charging:"
+                    partnerLabel="Range:"
+                    partnerRunsFor={vehicle => {
+                        const epa = epaRangeOption(vehicle);
+                        return epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
+                    }}
+                    partnerIdFor={run => rangePartnersOfCharging(pairings, run.id)[0] ?? null}
+                    resolvePartner={(chargingRun, vehicle) =>
+                        resolveRangeSource(chargingRun, { vehicle })}
+                    onSetPartner={(chargingId, _old, newRangeId) =>
+                        setPairings(prev => setChargingPartner(prev, chargingId, newRangeId))}
                     renderRunMeta={run => {
                         const exclusionReason = getRaceExclusionReason(run.id);
                         const offset = getRaceOffset(run.id);

--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -71,6 +71,7 @@ export default function PopoutView({
                     vehicles={vehicles}
                     selectedVehicleIds={selectedVehicles}
                     roadTripConfig={roadTripConfig}
+                    pairings={pairings}
                     setRoadTripConfig={() => {}}
                     presentationMode
                 />
@@ -87,6 +88,7 @@ export default function PopoutView({
                     setChartConfig={setChartConfig}
                     onUpdateRunColor={onUpdateRunColor}
                     chartMode={chartMode}
+                    pairings={pairings}
                     presentationMode
                 />
             )}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -6,8 +6,9 @@ import { dataService } from '../services/DataService';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, isChargingRun } from '../utils/runUtils';
-import { resolveRangeSource } from '../utils/rangeSource';
+import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
+import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -15,6 +16,7 @@ import {
     segmentsToChartPointsByTest,
     formatTime, speedCorrectionFactor,
 } from '../utils/roadTripSimulation';
+import { useRunSelection } from '../hooks/useRunSelection';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
 import ChartInfoBubble from './ChartInfoBubble';
@@ -357,6 +359,11 @@ export default function RoadTripView({
     selectedVehicleIds,
     roadTripConfig,
     setRoadTripConfig,
+    // Global chart-session pairings (utils/pairings.js). Read-only here: this
+    // view consumes a pairing chosen in Charge Compare but does not set one,
+    // because it is charging-primary and the pairing is keyed by range test.
+    pairings = {},
+    setPairings = () => {},
     onUpdateRunColor = null,
     presentationMode = false,
     autoColor = true,
@@ -369,11 +376,12 @@ export default function RoadTripView({
 
     const [runDataCache, setRunDataCache] = useState({});
     const [loading, setLoading] = useState(false);
-    const [selectedRunIds, setSelectedRunIds] = useState(() => {
-        // Restore run IDs from URL on first render (rt_r=id1,id2,…)
-        const raw = new URLSearchParams(window.location.search).get('rt_r');
-        return raw ? raw.split(',').map(Number).filter(Boolean) : [];
-    });
+    // Pair keys restored from the URL on first render (rt_r=70::12,71::13).
+    // Strings, not numbers: a pair key is 'rangeId::chargingId'.
+    const initialRunIds = useRef(
+        (new URLSearchParams(window.location.search).get('rt_r') || '')
+            .split(',').filter(Boolean)
+    ).current;
     const [axisScale, setAxisScale] = useState({ xMin: null, xMax: null, yMin: null, yMax: null });
     const [copiedUrl, setCopiedUrl] = useState(false);
     const [imageCopied, setImageCopied] = useState(false);
@@ -391,75 +399,99 @@ export default function RoadTripView({
         [vehicles, selectedVehicleIds]
     );
 
-    // ── Sync selectedRunIds when vehicle selection changes ───────────────────
-    // Keep runs from still-selected vehicles; auto-add default run for new ones.
-    useEffect(() => {
-        setSelectedRunIds(prev => {
-            const allChargingRunIds = new Set(
-                selectedVehicles.flatMap(v =>
-                    filterChargingRuns(v.runs).map(r => r.id)
-                )
-            );
-            // Drop runs whose vehicle is no longer selected
-            const kept = prev.filter(id => allChargingRunIds.has(id));
-            const keptSet = new Set(kept);
-
-            // For each vehicle with no selected runs, add its default/most-recent charging run
-            for (const vehicle of selectedVehicles) {
-                const chargingRuns = filterChargingRuns(vehicle.runs);
-                if (chargingRuns.some(r => keptSet.has(r.id))) continue;
-                const def = chargingRuns.find(r => r.isDefault) ||
-                    [...chargingRuns].sort((a, b) => new Date(b.date) - new Date(a.date))[0];
-                if (def) { kept.push(def.id); keptSet.add(def.id); }
-            }
-            return kept;
-        });
-    }, [selectedVehicleIds]); // eslint-disable-line react-hooks/exhaustive-deps
-
     // ── Resolve chart colors for all charging runs ────────────────────────────
     const colorMap = useMemo(() => {
         const allRuns = selectedVehicles.flatMap(v => filterChargingRuns(v.runs));
         return resolveChartColors(allRuns, {}, autoColor ? 'auto' : 'manual');
     }, [selectedVehicles, autoColor]);
 
-    // ── Build efficiency info for every charging run in the selection ─────────
-    // Keyed by run.id. Derives mi/kWh from the run itself (if it has range data)
-    // or falls back to the vehicle's best range run.
-    const allChargingRunsInfo = useMemo(() => {
-        const map = {};
+    // ── One entry per (range test × charging test) pair ───────────────────────
+    // Range-primary, matching Charge Compare: a charging curve is a property of
+    // the car and varies little, while a range test is a property of the day —
+    // wind, temperature, HVAC, tyres, elevation, load. Each pair is its own trip
+    // simulation, so the same car under two conditions is two comparable rows.
+    //
+    // A Map, not an object: insertion order is the display order, and the keys
+    // are pair-key strings.
+    const allPairsInfo = useMemo(() => {
+        const map = new Map();
         let colorIdx = 0;
         for (const vehicle of selectedVehicles) {
-            for (const run of filterChargingRuns(vehicle.runs)) {
-                // Shared resolver (utils/rangeSource.js) — the same ranking Charge
-                // Compare uses, so the two views can no longer disagree about which
-                // range test a charging run's miles came from. It also supplies the
-                // provenance note this view used to assemble by hand.
-                const src = resolveRangeSource(run, { vehicle, batteryKwh: vehicle.battery });
+            const chargingRuns = filterChargingRuns(vehicle.runs);
+            if (!chargingRuns.length) continue;
 
-                map[run.id] = {
-                    vehicle,
-                    run,
-                    miPerKwh:       src.miPerKwh,
-                    // Assume 70 mph if not specified on the run or its range source
-                    testSpeedMph:   run.speed_mph ?? src.sourceRun?.speed_mph ?? null,
-                    batteryKwh:     vehicle.battery,
-                    color:          colorMap[run.id] || run.color || PALETTE[colorIdx % PALETTE.length],
-                    efficiencyNote: src.note,
-                };
-                colorIdx++;
+            const epa = epaRangeOption(vehicle);
+            const primaries = epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
+
+            for (const rangeRun of primaries) {
+                const pinned = partnersFor(pairings, rangeRun.id);
+                const rows   = pinned.length ? pinned : [null];
+
+                for (const partnerId of rows) {
+                    const chargingRun = partnerId
+                        ? chargingRuns.find(r => String(r.id) === String(partnerId)) ?? pairedChargingRun(rangeRun, vehicle)
+                        : pairedChargingRun(rangeRun, vehicle);
+                    if (!chargingRun) continue;
+
+                    // The range side is explicit — it is the row — so the resolver
+                    // enters at rank 1 and its fallbacks only matter when the chosen
+                    // test carries no usable data.
+                    const src = resolveRangeSource(chargingRun, {
+                        vehicle,
+                        batteryKwh: vehicle.battery,
+                        explicitPairing: rangeRun.id === EPA_PARTNER_ID ? EPA_PARTNER_ID : rangeRun,
+                    });
+
+                    const key = pairKey(rangeRun.id, partnerId);
+                    map.set(key, {
+                        key,
+                        vehicle,
+                        rangeRun,
+                        // `run` stays the CHARGING run: it is what supplies the
+                        // data points the simulation walks.
+                        run:            chargingRun,
+                        // Only disambiguate when a range test is shown more than once.
+                        label:          rows.length > 1
+                            ? `${rangeRun.name} × ${chargingRun.name}`
+                            : rangeRun.name,
+                        miPerKwh:       src.miPerKwh,
+                        // Assume 70 mph if neither the range test nor its source says
+                        testSpeedMph:   rangeRun.speed_mph ?? src.sourceRun?.speed_mph ?? null,
+                        batteryKwh:     vehicle.battery,
+                        color:          colorMap[chargingRun.id] || rangeRun.color || chargingRun.color || PALETTE[colorIdx % PALETTE.length],
+                        efficiencyNote: src.note,
+                    });
+                    colorIdx++;
+                }
             }
         }
         return map;
-    }, [selectedVehicles, colorMap]);
+    }, [selectedVehicles, colorMap, pairings]);
+
+    // Selection lives in the shared hook (hooks/useRunSelection.js), the same one
+    // Charge Compare uses. Previously this view had its own copy, whose bootstrap
+    // refilled any vehicle that happened to be empty — so clearing one vehicle
+    // and then changing another vehicle's dropdown brought the first one back.
+    const selectionRows = useMemo(
+        () => [...allPairsInfo.values()].map(e => ({
+            key: e.key,
+            vehicleId: e.vehicle.id,
+            groupId: e.rangeRun.id,     // survives a repin, which changes the key
+        })),
+        [allPairsInfo]
+    );
+    const { selected: selectedRunIds, toggle: toggleRunId } = useRunSelection(
+        selectionRows, { initial: initialRunIds }
+    );
 
     // ── Active run entries — ordered by vehicle pill position ─────────────────
     const runEntries = useMemo(() => {
         const vehicleOrder = new Map(selectedVehicles.map((v, i) => [v.id, i]));
         return selectedRunIds
-            .map(id => allChargingRunsInfo[id])
+            .map(k => allPairsInfo.get(k))
             .filter(Boolean)
             .sort((a, b) => (vehicleOrder.get(a.vehicle.id) ?? 999) - (vehicleOrder.get(b.vehicle.id) ?? 999));
-    }, [selectedRunIds, allChargingRunsInfo, selectedVehicles]);
+    }, [selectedRunIds, allPairsInfo, selectedVehicles]);
 
     const validEntries  = runEntries.filter(e => e.miPerKwh && e.batteryKwh);
     const skippedEntries = runEntries.filter(e => !e.miPerKwh || !e.batteryKwh);
@@ -633,7 +665,7 @@ export default function RoadTripView({
         }
         const entryLabel = e =>
             vehicleRunCount[e.vehicle.id] > 1
-                ? `${vehicleLabel(e.vehicle)} (${e.run.name})`
+                ? `${vehicleLabel(e.vehicle)} (${e.label})`
                 : vehicleLabel(e.vehicle);
 
         // ── Speed sweep chart ────────────────────────────────────────────────
@@ -1019,7 +1051,7 @@ export default function RoadTripView({
                                     if (idx >= 0 && idx < validEntries.length) {
                                         const e = validEntries[idx];
                                         return vehicleRunCount[e.vehicle.id] > 1
-                                            ? `${vehicleLabel(e.vehicle)} · ${e.run.name}`
+                                            ? `${vehicleLabel(e.vehicle)} · ${e.label}`
                                             : vehicleLabel(e.vehicle);
                                     }
                                     if (idx === validEntries.length) return 'ICE Reference';
@@ -1379,8 +1411,8 @@ export default function RoadTripView({
                                 const sim = simResults[i];
                                 if (!sim?.warnings?.length) return null;
                                 return sim.warnings.map((w, wi) => (
-                                    <p key={`${entry.run.id}-${wi}`} className="roadtrip-warning">
-                                        ⚠ {vehicleLabel(entry.vehicle)} – {entry.run.name}: {w}
+                                    <p key={`${entry.key}-${wi}`} className="roadtrip-warning">
+                                        ⚠ {vehicleLabel(entry.vehicle)} – {entry.label}: {w}
                                     </p>
                                 ));
                             })}
@@ -1394,29 +1426,46 @@ export default function RoadTripView({
                                 filterChargingRuns(v.runs).length > 0
                             )}
                             selectedRunIds={selectedRunIds}
-                            onToggleRun={runId => setSelectedRunIds(prev =>
-                                prev.includes(runId)
-                                    ? prev.filter(x => x !== runId)
-                                    : [...prev, runId]
-                            )}
+                            onToggleRun={toggleRunId}
                             onUpdateRunColor={onUpdateRunColor}
                             colorMap={colorMap}
-                            runFilter={isChargingRun}
-                            emptyMessage="No charging test data"
+                            runFilter={(run, vehicle) =>
+                                isRangeRun(run) && filterChargingRuns(vehicle.runs).length > 0}
+                            emptyMessage="No range test records"
+                            pairMode
+                            pairings={pairings}
+                            primaryLabel="Range:"
+                            partnerLabel="Charging:"
+                            partnerRunsFor={vehicle => filterChargingRuns(vehicle.runs)}
+                            extraPrimaryRunsFor={vehicle => {
+                                if (!filterChargingRuns(vehicle.runs).length) return [];
+                                const epa = epaRangeOption(vehicle);
+                                return epa ? [epa] : [];
+                            }}
+                            resolvePartner={(rangeRun, vehicle) => {
+                                const run = pairedChargingRun(rangeRun, vehicle);
+                                return run ? { sourceRun: run, note: null } : null;
+                            }}
+                            onSetPartner={(rangeId, oldChargingId, newChargingId) =>
+                                setPairings(prev => replacePartner(prev, rangeId, oldChargingId, newChargingId))}
+                            onAddPartner={(rangeId, chargingId) =>
+                                setPairings(prev => addPartner(prev, rangeId, chargingId))}
+                            onRemovePartner={(rangeId, chargingId) =>
+                                setPairings(prev => removePartner(prev, rangeId, chargingId))}
                             renderRunMeta={run => {
-                                const info = allChargingRunsInfo[run.id];
-                                if (!info) return null;
-                                if (!info.miPerKwh) {
+                                const entry = [...allPairsInfo.values()].find(e => e.rangeRun.id === run.id);
+                                if (!entry) return null;
+                                if (!entry.miPerKwh) {
                                     return <span className="text-xs text-red-400 ml-1">⚠ No range data</span>;
                                 }
-                                const eff = info.miPerKwh.toFixed(1);
-                                const spd = info.testSpeedMph
-                                    ? `${fmtSpeed(info.testSpeedMph, units)}`
+                                const eff = entry.miPerKwh.toFixed(1);
+                                const spd = entry.testSpeedMph
+                                    ? `${fmtSpeed(entry.testSpeedMph, units)}`
                                     : '70 mph (assumed)';
                                 return (
                                     <span className="text-xs text-faint ml-1">
                                         {eff} {units === 'metric' ? 'km/kWh' : 'mi/kWh'} @ {spd}
-                                        {info.efficiencyNote && ` · ${info.efficiencyNote}`}
+                                        {entry.efficiencyNote && ` · ${entry.efficiencyNote}`}
                                     </span>
                                 );
                             }}
@@ -1430,8 +1479,8 @@ export default function RoadTripView({
                                 <p key={v.id}>⚠ {v.name}: No charging test data</p>
                             ))}
                             {skippedEntries.map(e => (
-                                <p key={e.run.id}>
-                                    ⚠ {vehicleLabel(e.vehicle)} – {e.run.name}: {!e.miPerKwh ? 'No range data for efficiency' : 'No battery capacity'}
+                                <p key={e.key}>
+                                    ⚠ {vehicleLabel(e.vehicle)} – {e.label}: {!e.miPerKwh ? 'No range data for efficiency' : 'No battery capacity'}
                                 </p>
                             ))}
                         </div>
@@ -1581,8 +1630,8 @@ export default function RoadTripView({
                                     let av, bv;
                                     switch (sortCol) {
                                         case 'vehicle':
-                                            av = (a.entry.vehicle.name + a.entry.run.name).toLowerCase();
-                                            bv = (b.entry.vehicle.name + b.entry.run.name).toLowerCase();
+                                            av = (a.entry.vehicle.name + a.entry.label).toLowerCase();
+                                            bv = (b.entry.vehicle.name + b.entry.label).toLowerCase();
                                             return dir * av.localeCompare(bv);
                                         case 'totalTime':  av = a.sim.totalTimeMin;     bv = b.sim.totalTimeMin;     break;
                                         case 'stops':      av = a.sim.chargeStops;      bv = b.sim.chargeStops;      break;
@@ -1615,14 +1664,14 @@ export default function RoadTripView({
                                 {rows.map(({ entry, sim, avgChargeTime, speedDiff, adjPct, vsIce }) => {
 
                                     return (
-                                        <tr key={entry.run.id}>
+                                        <tr key={entry.key}>
                                             <td className="px-3 py-2">
                                                 <div className="flex items-start gap-2">
                                                     <span className="inline-block w-3 h-3 rounded-full mt-1 shrink-0"
                                                           style={{ backgroundColor: entry.color }} />
                                                     <div>
                                                         <div className="font-medium">{vehicleLabel(entry.vehicle)}</div>
-                                                        <div className="text-xs text-faint">{entry.run.name}</div>
+                                                        <div className="text-xs text-faint">{entry.label}</div>
                                                     </div>
                                                 </div>
                                             </td>

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -35,6 +35,8 @@ import { pairKey, partnersFor } from '../utils/pairings';
  *   partnerLabel    — prefix before the dropdown,      e.g. "Charging:"
  *   partnerRunsFor  — (vehicle) => runs offered as partners
  *   extraPrimaryRunsFor — (vehicle) => synthetic primary rows (e.g. EPA range)
+ *   singlePartner   — one partner per row, selection still keyed by run id
+ *   partnerIdFor    — (run) => partnerRunId | null, single-partner mode only
  *   resolvePartner  — (primaryRun, vehicle) => { sourceRun, note } for the
  *                     automatic choice shown when nothing is pinned
  *   onSetPartner    — (primaryRunId, oldPartnerId, newPartnerId) => void
@@ -55,6 +57,13 @@ export default function RunSelector({
     pairings = {},
     primaryLabel = null,
     partnerLabel = 'Paired with:',
+    // One partner per row, selection still keyed by run id. For views whose
+    // subject is the primary run (the charging chart plots one curve per run,
+    // Road Trip simulates one trip per run) — they cannot render a run twice, so
+    // they get the same row shape without the ＋ that would imply they could.
+    singlePartner = false,
+    // (run) => partnerRunId | null — single-partner mode only
+    partnerIdFor = null,
     partnerRunsFor = null,
     // Rows that are not runs — e.g. the vehicle's EPA rated range, which is a
     // legitimate range basis with no test behind it.
@@ -80,6 +89,10 @@ export default function RunSelector({
      * whether or not anyone has paired it.
      */
     const partnerRowsFor = (run) => {
+        // Single-partner views ask the parent which partner this row holds: the
+        // map is keyed by the other side, and knowing that would make this
+        // component orientation-aware again.
+        if (singlePartner) return [partnerIdFor ? (partnerIdFor(run) ?? null) : null];
         const pinned = partnersFor(pairings, run.id);
         return pinned.length ? pinned : [null];
     };
@@ -96,11 +109,28 @@ export default function RunSelector({
             : own;
     };
 
+    /**
+     * Select or clear every row for one vehicle. Emits the same toggle the rows
+     * do, so the parent's selection model — run ids or pair keys — stays the
+     * only thing that knows which is which.
+     */
+    const setVehicleSelection = (vehicle, wanted) => {
+        for (const run of primaryRunsFor(vehicle)) {
+            for (const partnerId of partnerRowsFor(run)) {
+                const key = pairMode && !singlePartner ? pairKey(run.id, partnerId) : run.id;
+                const isOn = selectedRunIds.some(id => String(id) === String(key));
+                if (isOn !== wanted) onToggleRun(key);
+            }
+        }
+    };
+
     const selectedCount = pairMode
         ? vehicles.reduce((n, v) => n + primaryRunsFor(v).reduce(
-            (m, run) => m + partnerRowsFor(run).filter(
-                partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
-            ).length, 0), 0)
+            (m, run) => m + (singlePartner
+                ? (selectedRunIds.some(id => String(id) === String(run.id)) ? 1 : 0)
+                : partnerRowsFor(run).filter(
+                    partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
+                  ).length), 0), 0)
         : vehicles.reduce((n, v) =>
             n + (v.runs || []).filter(r => runFilter(r, v)).filter(isSelected).length, 0);
 
@@ -135,6 +165,23 @@ export default function RunSelector({
                                             <span style={{ display: 'inline-block', transform: isVehicleExpanded(vehicle.id) ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }} className="text-faint group-hover:text-secondary">&#9660;</span>
                                             <h4 className="text-sm font-semibold text-secondary">{vehicle.name}</h4>
                                         </button>
+                                        {/* Bulk helpers — a vehicle can contribute a dozen rows,
+                                            and ticking them one at a time is the common complaint. */}
+                                        <button
+                                            type="button"
+                                            onClick={() => setVehicleSelection(vehicle, true)}
+                                            className="run-bulk-link"
+                                        >
+                                            all
+                                        </button>
+                                        <span className="text-faint text-xs select-none">/</span>
+                                        <button
+                                            type="button"
+                                            onClick={() => setVehicleSelection(vehicle, false)}
+                                            className="run-bulk-link"
+                                        >
+                                            none
+                                        </button>
                                     </div>
 
                                     {isVehicleExpanded(vehicle.id) && (
@@ -152,6 +199,7 @@ export default function RunSelector({
                                                         resolvePartner={resolvePartner}
                                                         primaryLabel={primaryLabel}
                                                         partnerLabel={partnerLabel}
+                                                        singlePartner={singlePartner}
                                                         selectedRunIds={selectedRunIds}
                                                         onToggleRun={onToggleRun}
                                                         onSetPartner={onSetPartner}
@@ -196,7 +244,7 @@ export default function RunSelector({
  */
 function PairRows({
     run, vehicle, partnerIds, partnerRuns, resolvePartner,
-    primaryLabel, partnerLabel,
+    primaryLabel, partnerLabel, singlePartner,
     selectedRunIds, onToggleRun, onSetPartner, onAddPartner, onRemovePartner,
     onUpdateRunColor, renderRunMeta, colorMap,
 }) {
@@ -216,8 +264,9 @@ function PairRows({
     if (!partnerIds.some(Boolean) && auto?.sourceRun) used.add(String(auto.sourceRun.id));
     const unused = partnerRuns.filter(r => !used.has(String(r.id)));
 
+    const rowKey = (partnerId) => singlePartner ? String(run.id) : pairKey(run.id, partnerId);
     const isSelected = (partnerId) =>
-        selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId));
+        selectedRunIds.some(id => String(id) === rowKey(partnerId));
 
     return (
         <div className="pair-group">
@@ -229,7 +278,7 @@ function PairRows({
                     <input
                         type="checkbox"
                         checked={isSelected(partnerId)}
-                        onChange={() => onToggleRun(pairKey(run.id, partnerId))}
+                        onChange={() => onToggleRun(singlePartner ? run.id : rowKey(partnerId))}
                         className="w-4 h-4 shrink-0"
                     />
 
@@ -271,7 +320,7 @@ function PairRows({
                         </select>
 
                         {/* Discovery: how many other range tests could go here */}
-                        {idx === 0 && unused.length > 0 && (
+                        {!singlePartner && idx === 0 && unused.length > 0 && (
                             <span
                                 className="pair-more-badge"
                                 title={`${unused.length} more option(s): ${unused.map(r => r.name).join(', ')}`}
@@ -280,7 +329,7 @@ function PairRows({
                             </span>
                         )}
 
-                        {idx === 0 ? (
+                        {singlePartner ? null : idx === 0 ? (
                             <button
                                 type="button"
                                 onClick={() => {

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -13,6 +13,7 @@ import { RunVoteButtons } from './VoteButtons';
 import EpaVehicleSection from './EpaVehicleSection';
 import PerformanceVehicleSection from './PerformanceVehicleSection';
 import { deriveChargingAxis } from '../utils/deriveChargingAxis';
+import { filterChargingRuns, defaultChargingRun } from '../utils/runUtils';
 import { isTimestampValue, timestampToMs } from '../utils/parseElapsedTime';
 
 // ── Data-type flag definitions ────────────────────────────────────────────────
@@ -47,6 +48,44 @@ const FIELD_META = [
  * Renders the 📏 Range pill followed by speed, distance, energy, efficiency,
  * temperature, SoC window, and source link.
  */
+/**
+ * Curator's default charging test for a range test (migration 045).
+ *
+ * A chart-session pairing lives only in the URL, so it is reproducible only by
+ * whoever holds the link. This is the published answer: what a visitor arriving
+ * without one sees. Leaving it on Auto keeps the vehicle-wide default, which is
+ * the right choice for most range tests — this exists for the range test that
+ * needs a different curve than its siblings.
+ */
+function PairedChargingControl({ run, vehicle, onSet }) {
+    const chargingRuns = filterChargingRuns(vehicle.runs);
+    if (chargingRuns.length === 0) return null;
+
+    const auto = defaultChargingRun(vehicle);
+    const isCurated = run.paired_charging_run_id != null;
+
+    return (
+        <div className="flex items-center gap-2 text-sm mt-1">
+            <span className="text-label shrink-0">Charging pair:</span>
+            <select
+                value={run.paired_charging_run_id ?? ''}
+                onChange={e => onSet(e.target.value || null)}
+                className="form-input text-sm py-0.5"
+            >
+                <option value="">Auto{auto ? ` — ${auto.name}` : ''}</option>
+                {chargingRuns.map(r => (
+                    <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+            </select>
+            {isCurated && (
+                <span className="text-xs text-indigo-500" title="Published pairing — everyone sees this, not just someone with a shared link">
+                    curated
+                </span>
+            )}
+        </div>
+    );
+}
+
 function RunRangeMetaLine({ run, units }) {
     const rangeFlag = DATA_FLAGS.find(f => f.key === 'range');
     const dot = <span className="mx-1.5 text-faint select-none">·</span>;
@@ -415,7 +454,7 @@ const DeriveAxisPanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2303,6 +2342,13 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         )}
                                         {inferRunFlags(run).includes('charging') && (
                                             <RunChargingMetaLine run={run} calcKwhByRun={calcKwhByRun} onCheckKwh={handleCheckKwh} />
+                                        )}
+                                        {(inferRunFlags(run).includes('range') || run.distance_miles != null) && canEdit(vehicle) && (
+                                            <PairedChargingControl
+                                                run={run}
+                                                vehicle={vehicle}
+                                                onSet={chargingId => setPairedChargingRun(vehicle.id, run.id, chargingId)}
+                                            />
                                         )}
                                     </div>
                                 </div>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -314,6 +314,28 @@ export function AppProvider({ children }) {
         }
     };
 
+    /**
+     * Set the curator's default charging test for a range test, or clear it with
+     * null. This is the durable pairing — a chart-session pairing lives only in
+     * the URL, so this is what a visitor arriving without one sees.
+     */
+    const setPairedChargingRun = async (vehicleId, rangeRunId, chargingRunId) => {
+        try {
+            await dataService.setPairedChargingRun(rangeRunId, chargingRunId);
+            setVehicles(prev => prev.map(v =>
+                v.id !== vehicleId ? v : {
+                    ...v,
+                    runs: v.runs.map(r => r.id === rangeRunId
+                        ? { ...r, paired_charging_run_id: chargingRunId ? Number(chargingRunId) : null }
+                        : r),
+                }
+            ));
+        } catch (error) {
+            logIfUnauthorized('set_paired_charging_run', 'run', rangeRunId, error);
+            showError('Error saving pairing: ' + error.message);
+        }
+    };
+
     const updateRunColor = async (vehicleId, runId, color) => {
         try {
             if (typeof runId === 'string' && runId.startsWith('inherited_')) {
@@ -1326,6 +1348,7 @@ export function AppProvider({ children }) {
         updateRun,
         setDefaultRun,
         updateRunColor,
+        setPairedChargingRun,
         deleteRun,
         tags,
         createTag,

--- a/src/hooks/useRunSelection.js
+++ b/src/hooks/useRunSelection.js
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Which rows a chart is displaying, and how that survives the data changing
+ * underneath it.
+ *
+ * Every chart had its own copy of this, and each one got a different part of it
+ * wrong: rows springing back after being switched off, rows vanishing when
+ * repinned, a whole vehicle refilling because another vehicle's dropdown moved.
+ * They are the same problem, so this is the one implementation of it.
+ *
+ * ── The four rules ───────────────────────────────────────────────────────────
+ *
+ * 1. PRUNE      a selected row whose key no longer exists is dropped.
+ * 2. CARRY      repinning a row changes its key ('70::' becomes '70::12'), so a
+ *               new key inherits the selection of the row it replaced, matched
+ *               on `groupId` — otherwise the row silently disappears.
+ * 3. BOOTSTRAP  a vehicle seen for the first time gets its rows selected. Only
+ *               the first time: a vehicle the user has emptied stays empty, or
+ *               any unrelated change refills it.
+ * 4. QUIET      when nothing actually changes, the previous array is returned
+ *               unchanged, so dependent effects don't re-fire.
+ *
+ * ── Why a ref, and why it is written here ────────────────────────────────────
+ *
+ * "Seen" has to persist across renders without causing one, so it is a ref. It
+ * is updated in the effect body and NEVER inside the state updater: React
+ * invokes updaters more than once in development, and a mutation in there ran
+ * twice — the second pass saw everything as already seen, added nothing, and
+ * that empty result was the one kept, leaving the chart with no series at all.
+ *
+ * @param {Array}  rows            [{ key, vehicleId, groupId }] every selectable row
+ * @param {Array}  [initial]       keys to start selected (e.g. restored from a URL)
+ * @param {Function} [shouldBootstrap] (vehicleId, rowsForVehicle) => keys to auto-select;
+ *                                  defaults to all of them
+ */
+export function useRunSelection(rows, { initial = [], shouldBootstrap = null } = {}) {
+    const [selected, setSelected] = useState(initial);
+    const seenVehicles = useRef(new Set());
+    // key → groupId for every row ever seen, so a key that has since disappeared
+    // can still be traced back to its group. Repinning depends on this.
+    const knownGroups  = useRef(new Map());
+
+    useEffect(() => {
+        const live = new Set(rows.map(r => r.key));
+        const prev = selected;
+
+        // 1. PRUNE
+        const kept = prev.filter(k => live.has(k));
+        const keptSet = new Set(kept);
+
+        // 2. CARRY — a row whose group still has a selection stays selected
+        //    through a key change.
+        //
+        //    The departed key is looked up in the REMEMBERED index, not in the
+        //    current rows: repinning is precisely the case where the old key no
+        //    longer exists, so searching `rows` for it always missed and the
+        //    replacement row was never carried.
+        const prevGroups = new Set(
+            prev.map(k => knownGroups.current.get(String(k)))
+                .filter(g => g != null)
+                .map(String)
+        );
+        for (const row of rows) {
+            if (keptSet.has(row.key)) continue;
+            if (prevGroups.has(String(row.groupId))) {
+                kept.push(row.key);
+                keptSet.add(row.key);
+            }
+        }
+
+        // 3. BOOTSTRAP — first sighting of a vehicle only.
+        const byVehicle = new Map();
+        for (const row of rows) {
+            if (!byVehicle.has(row.vehicleId)) byVehicle.set(row.vehicleId, []);
+            byVehicle.get(row.vehicleId).push(row);
+        }
+        for (const [vehicleId, vehicleRows] of byVehicle) {
+            if (seenVehicles.current.has(String(vehicleId))) continue;
+            const auto = shouldBootstrap
+                ? shouldBootstrap(vehicleId, vehicleRows)
+                : vehicleRows.map(r => r.key);
+            for (const key of auto) {
+                if (keptSet.has(key)) continue;
+                kept.push(key);
+                keptSet.add(key);
+            }
+        }
+
+        // Recorded AFTER deciding, and outside the updater. See the note above.
+        for (const row of rows) {
+            seenVehicles.current.add(String(row.vehicleId));
+            knownGroups.current.set(String(row.key), row.groupId);
+        }
+
+        // 4. QUIET
+        const unchanged = kept.length === prev.length && kept.every((k, i) => k === prev[i]);
+        if (!unchanged) setSelected(kept);
+    }, [rows, selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    /** Toggle one row. */
+    const toggle = (key) => setSelected(prev =>
+        prev.some(k => String(k) === String(key))
+            ? prev.filter(k => String(k) !== String(key))
+            : [...prev, key]
+    );
+
+    /** Select or clear every row belonging to one vehicle. */
+    const setVehicle = (vehicleId, wanted) => setSelected(prev => {
+        const keys = rows.filter(r => String(r.vehicleId) === String(vehicleId)).map(r => r.key);
+        if (!keys.length) return prev;
+        if (!wanted) {
+            const drop = new Set(keys.map(String));
+            return prev.filter(k => !drop.has(String(k)));
+        }
+        const have = new Set(prev.map(String));
+        const add = keys.filter(k => !have.has(String(k)));
+        return add.length ? [...prev, ...add] : prev;
+    });
+
+    return { selected, setSelected, toggle, setVehicle };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -875,6 +875,15 @@ body {
     @apply flex-1 flex items-center gap-2 flex-wrap;
 }
 
+/* Per-vehicle "all / none" bulk selection links in the run selector */
+.run-bulk-link {
+    @apply text-xs underline transition;
+    color: var(--color-text-faint);
+}
+.run-bulk-link:hover {
+    color: var(--color-primary);
+}
+
 /* ── Pair mode (charging test × range test) ─────────────────────────────────── */
 
 /* One charging test and all of its range partners, kept visually together */

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -615,6 +615,30 @@ class DataService {
     if (error) throw error;
   }
 
+  /**
+   * Set (or clear, with null) the curator's default charging test for a range
+   * test. Unlike a chart-session pairing, which lives only in the URL, this is
+   * what a visitor arriving without one sees. See migration 045.
+   */
+  async setPairedChargingRun(rangeRunId, chargingRunId) {
+    if (!this.useSupabase || !this.user) {
+      const saved = localStorage.getItem('evData');
+      const data = saved ? JSON.parse(saved) : { vehicles: [], selectedVehicles: [] };
+      data.vehicles = (data.vehicles || []).map(v => ({
+        ...v,
+        runs: (v.runs || []).map(r =>
+          r.id === rangeRunId ? { ...r, paired_charging_run_id: chargingRunId ?? null } : r),
+      }));
+      localStorage.setItem('evData', JSON.stringify(data));
+      return;
+    }
+    const { error } = await getSupabase()
+      .from('runs')
+      .update({ paired_charging_run_id: chargingRunId ? Number(chargingRunId) : null })
+      .eq('id', rangeRunId);
+    if (error) throw error;
+  }
+
   async updateRunColor(vehicleId, runId, color) {
     if (!this.useSupabase || !this.user) {
       const saved = localStorage.getItem('evData');

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -70,6 +70,47 @@ export function isPaired(pairings, rangeRunId) {
 }
 
 /**
+ * The inverse lookup: range tests explicitly paired to a given charging run.
+ *
+ * The map is keyed by range test because that is the axis worth enumerating,
+ * but Road Trip and the charging chart are charging-primary — they plot a
+ * charging curve and need to know which range test prices it. Without this,
+ * a pairing chosen in Charge Compare would not reach them, and two charts on
+ * one screen would disagree about what "range" means, which is precisely what
+ * making pairings global was meant to prevent.
+ *
+ * Usually returns zero or one. Several means the user deliberately compared one
+ * charging curve against multiple conditions, which a charging-primary view
+ * cannot show in a single series — callers take the first and should say so.
+ */
+export function rangePartnersOfCharging(pairings, chargingRunId) {
+    const target = key(chargingRunId);
+    return Object.entries(pairings || {})
+        .filter(([, partners]) => partners.includes(target))
+        .map(([rangeRunId]) => rangeRunId);
+}
+
+/**
+ * Write from the charging side: give this charging run the given range test,
+ * or `null` to return it to automatic resolution.
+ *
+ * The map stays keyed by range test — there is exactly one map, so a pairing
+ * made in a charging-primary view is the same pairing Charge Compare shows.
+ * That means detaching the charging run from wherever it currently sits before
+ * attaching it to the new range test, or the two views would disagree about a
+ * pairing they are both meant to be reading.
+ */
+export function setChargingPartner(pairings, chargingRunId, rangeRunId) {
+    const target = key(chargingRunId);
+    const out = {};
+    for (const [primaryId, partners] of Object.entries(pairings || {})) {
+        const kept = partners.filter(id => id !== target);
+        if (kept.length) out[primaryId] = kept;
+    }
+    return rangeRunId ? addPartner(out, rangeRunId, chargingRunId) : out;
+}
+
+/**
  * Add a charging partner. Returns a new map — never mutates, so React state
  * updates and the URL/broadcast effects fire correctly.
  */

--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -51,6 +51,30 @@ export function defaultChargingRun(vehicle) {
         ?? null;
 }
 
+/**
+ * The charging test for a given range test, absent an explicit chart-session
+ * pairing. Two ranks:
+ *
+ *   1. the curator's stored pairing (runs.paired_charging_run_id, migration 045)
+ *   2. the vehicle's default charging run
+ *
+ * The chart session's own pairing outranks both, but it lives only in the URL —
+ * this is what a visitor arriving without one sees, and the reason a non-default
+ * pairing can be published at all.
+ *
+ * Falls through to the default when the stored id points at a run that is gone
+ * or no longer charging, rather than silently rendering nothing.
+ */
+export function pairedChargingRun(rangeRun, vehicle) {
+    const storedId = rangeRun?.paired_charging_run_id;
+    if (storedId != null) {
+        const stored = filterChargingRuns(vehicle?.runs)
+            .find(r => String(r.id) === String(storedId));
+        if (stored) return stored;
+    }
+    return defaultChargingRun(vehicle);
+}
+
 // ── Populated-field detection ─────────────────────────────────────────────────
 
 /**

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -86,7 +86,7 @@ One charging or range test session per vehicle.
 | `has_charging` | `boolean` | `true` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
 | `has_range` | `boolean` | `false` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
 | `session_id` | `bigint` | `NULL` | FK → `test_sessions.id` ON DELETE SET NULL. Advisory grouping; never required |
-| `paired_range_run_id` | `bigint` | `NULL` | FK → `runs.id` ON DELETE SET NULL. Curator-set default range partner for a charging run |
+| `paired_charging_run_id` | `bigint` | `NULL` | FK → `runs.id` ON DELETE SET NULL. Curator-set default charging test for a **range** test (migration 045). Overrides the automatic pick; a URL pairing still overrides this |
 | `software_version` | `text` | — | |
 | `conditions` | `text` | — | Freeform notes |
 | `source` | `text` | — | URL to source video/post |

--- a/supabase/migrations/045_curated_pairing.sql
+++ b/supabase/migrations/045_curated_pairing.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- Migration 045: Curated pairing — point the durable pairing the right way
+--
+-- Migration 044 added runs.paired_range_run_id: on a CHARGING run, its default
+-- RANGE partner. The pairing UI then landed the other way round — the chart
+-- enumerates range tests and you pick a charging curve for each, because a
+-- charging curve is a property of the car and varies little, while a range test
+-- is a property of the day, moved by wind, temperature, HVAC, tyres, elevation,
+-- humidity and load.
+--
+-- So the durable pairing belongs on the RANGE run, naming its charging partner.
+-- Nothing ever wrote paired_range_run_id — it was groundwork, populated by no
+-- code path — so it is replaced rather than repurposed under a name that would
+-- describe the opposite of what it holds.
+--
+-- Directional rather than a single symmetric paired_run_id: symmetric would work
+-- from either side, but permits two rows to disagree (A names B while B names C)
+-- with no principled tiebreak.
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE runs
+    ADD COLUMN paired_charging_run_id bigint REFERENCES runs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_runs_paired_charging ON runs(paired_charging_run_id);
+
+COMMENT ON COLUMN runs.paired_charging_run_id IS
+    'Curator-set default charging test for this range test. Overrides the automatic pick (is_default, else most recent); a URL pairing still overrides this. App-enforced to reference a kind=charging run.';
+
+-- Unused groundwork from 044, pointing the wrong way. Safe to drop: no code
+-- ever read or wrote it, so there is no data to migrate.
+DROP INDEX IF EXISTS idx_runs_paired_range;
+
+ALTER TABLE runs DROP COLUMN paired_range_run_id;
+
+COMMIT;
+
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+--
+-- 1. The new column exists and the old one is gone — expect one row, 'f':
+--
+--      SELECT
+--        EXISTS (SELECT 1 FROM information_schema.columns
+--                WHERE table_name='runs' AND column_name='paired_charging_run_id') AS added,
+--        EXISTS (SELECT 1 FROM information_schema.columns
+--                WHERE table_name='runs' AND column_name='paired_range_run_id')    AS old_still_there;
+--
+-- 2. Nothing was silently dropped — expect the same count as before applying:
+--
+--      SELECT count(*) FROM runs;
+--
+-- 3. A curated pairing survives its partner being deleted (SET NULL, not
+--    cascade). Rolled back, so it writes nothing:
+--
+--      BEGIN;
+--      UPDATE runs SET paired_charging_run_id = (
+--          SELECT id FROM runs WHERE kind = 'charging' LIMIT 1
+--      ) WHERE kind = 'range' LIMIT 1;
+--      SELECT count(*) AS paired FROM runs WHERE paired_charging_run_id IS NOT NULL;
+--      DELETE FROM runs WHERE id = (SELECT id FROM runs WHERE kind = 'charging' LIMIT 1);
+--      SELECT count(*) AS still_paired FROM runs WHERE paired_charging_run_id IS NOT NULL;
+--      ROLLBACK;


### PR DESCRIPTION
Closes #171. **Unblocks retiring the duplicate hand-curated charging runs.**

## ⚠️ Apply migration 045 before deploying

This one drops a column. It is safe — nothing ever wrote it (see below) — but it is not additive like 044.

## Why

Chart-session pairings live **only in the URL**, so a pairing that is not the automatic one is reproducible solely by whoever holds the link. A fresh visitor gets the automatic resolution. This publishes a pairing so everyone sees it — which is what the duplicate charging runs were doing by brute force.

## The column pointed the wrong way

Migration 044 added `runs.paired_range_run_id`: on a *charging* run, its default *range* partner. #169 then flipped the orientation — the chart enumerates range tests and you pick a charging curve, because a charging curve is a property of the car while a range test is a property of the day, moved by wind, temperature, HVAC, tyres, elevation, humidity and load.

So the durable pairing belongs on the **range** run, naming its charging partner. Nothing ever read or wrote `paired_range_run_id` — it was groundwork — so 045 replaces it rather than repurposing it under a name that would describe the opposite of what it holds.

**Directional, not symmetric.** A single `paired_run_id` would work from either side but permits two rows to disagree (A names B while B names C) with no principled tiebreak.

## Resolution order

```
URL pairing  →  curator's stored pairing  →  vehicle default (is_default, else most recent)
```

`pairedChargingRun()` in `utils/runUtils.js`. A stored id falls through to the default when it points at a run that has been deleted or is no longer a charging test, rather than silently rendering nothing.

## Curator control

On the range run's card in Tests & Data, gated on `canEdit`:

```
Charging pair: [ Auto — Peregrine Dreams ▾ ]  curated
```

Auto is the right answer for most range tests — marking the right charging run `is_default` already steers a whole vehicle — so this exists for the range test that needs a *different* curve than its siblings. The control names what Auto resolves to rather than making the curator guess, and flags an explicit choice as `curated` so it is visible that this one is published rather than inherited.

## Testing

**Migration**, on a throwaway PostgreSQL 18 cluster with stand-ins, applied *after* 044:

- Applies cleanly in one transaction; new column present, old one gone
- No rows lost
- 044's `kind` trigger still fires correctly afterwards
- `SET NULL` confirmed: deleting the charging partner clears the pairing and leaves the range test intact — no cascade

**Resolution chain**, 8 unit tests: no stored pairing → most recent; `is_default` beating recency; stored beating the vehicle default; string ids; a dangling id falling back; an id pointing at a *range* run falling back; explicit null; and a vehicle with no charging runs.

`vite build` clean.

**Not verified:** the control in a signed-in browser. It is gated on `canEdit`, so it is invisible to the signed-out session I can reach.

## Before deleting any duplicates

`spec_links.source_run_id` is `ON DELETE CASCADE` (migration 016) — deleting a run silently deletes every spec_link inheriting it, and another vehicle loses its inherited curve with no warning:

```sql
SELECT r.id, r.name, r.vehicle_id, count(sl.id) AS inherited_by
FROM runs r JOIN spec_links sl ON sl.source_run_id = r.id
GROUP BY r.id, r.name, r.vehicle_id ORDER BY inherited_by DESC;
```

Also worth knowing: after #155 splits dual-role rows, ~35 pairs can be populated straight from `session_id` — roughly two thirds of the charging tests get a correct pairing with no curation at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)