### PR TITLE
Honour pairings in Road Trip and the charging chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -809,6 +809,7 @@ export default function App() {
                             onUpdateRunColor={updateRunColor}
                             chartMode={chartMode}
                             pairings={pairings}
+                            setPairings={setPairings}
                         />
                     )}
                     {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'roadtrip' && (
@@ -818,6 +819,7 @@ export default function App() {
                             roadTripConfig={roadTripConfig}
                             setRoadTripConfig={setRoadTripConfig}
                             pairings={pairings}
+                            setPairings={setPairings}
                             onUpdateRunColor={updateRunColor}
                             autoColor={chartConfig.autoColor ?? true}
                             setChartConfig={setChartConfig}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -466,6 +466,7 @@ export default function App() {
                 compareConfig={compareConfig}
                 roadTripConfig={roadTripConfig}
                 epaConfig={epaConfig}
+                pairings={pairings}
                 onUpdateRunColor={updateRunColor}
             />
         );
@@ -807,6 +808,7 @@ export default function App() {
                             setChartConfig={setChartConfig}
                             onUpdateRunColor={updateRunColor}
                             chartMode={chartMode}
+                            pairings={pairings}
                         />
                     )}
                     {activeChartCategory && selectedVehicles.length > 0 && chartMode === 'roadtrip' && (
@@ -815,6 +817,7 @@ export default function App() {
                             selectedVehicleIds={selectedVehicles}
                             roadTripConfig={roadTripConfig}
                             setRoadTripConfig={setRoadTripConfig}
+                            pairings={pairings}
                             onUpdateRunColor={updateRunColor}
                             autoColor={chartConfig.autoColor ?? true}
                             setChartConfig={setChartConfig}

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -9,7 +9,7 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
 import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
-import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
+import { pairKey, parsePairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
@@ -409,21 +409,41 @@ export default function ChargeCompareView({
     // Selection is by pair key, so adding a second range partner to a charging
     // test brings the new series in already selected rather than requiring a
     // second click in a different part of the UI.
-    // Stale keys are also dropped. Repinning a row changes its key (`70::` becomes
-    // `70::12`), so without pruning the old key lingers forever — and returning
-    // the row to Auto would then find its key already selected, leave the array
-    // untouched, and give the chart nothing to react to.
+    // Auto-select genuinely NEW rows, never re-select ones the user turned off.
+    //
+    // Tracked per range test rather than per pair key, because repinning a row
+    // changes its key ('70::' becomes '70::12'). Keying on the pair alone made
+    // every deselected row spring back the moment any dropdown changed, and
+    // meant a repinned row could not carry its selection across.
+    const seenPrimaries = useRef(new Set());
     useEffect(() => {
         const allKeys = resolvedPairs.map(p => p.key);
         const live = new Set(allKeys);
-        setSelectedRuns(prev => {
-            const kept = prev.filter(k => live.has(k));
-            const added = allKeys.filter(k => !prev.includes(k));
-            const next = [...kept, ...added];
-            const unchanged = next.length === prev.length && next.every((k, i) => k === prev[i]);
-            return unchanged ? prev : next;
+        const prev = selectedRuns;
+
+        const kept = prev.filter(k => live.has(k));
+        const keptSet = new Set(kept);
+        const selectedPrimaries = new Set(prev.map(k => parsePairKey(k).rangeRunId));
+
+        const added = allKeys.filter(k => {
+            if (keptSet.has(k)) return false;
+            const primary = parsePairKey(k).rangeRunId;
+            // A range test the user switched off stays off. A repinned row whose
+            // range test is still selected carries its selection to the new key.
+            // Anything genuinely new comes on.
+            return !seenPrimaries.current.has(primary) || selectedPrimaries.has(primary);
         });
-    }, [resolvedPairs]);
+
+        // Marked HERE and not inside the setState updater: React invokes updaters
+        // more than once in development, and a ref mutation in there ran twice —
+        // the second pass saw every primary as already seen, added nothing, and
+        // that empty result was the one kept, leaving the chart with no series.
+        allKeys.forEach(k => seenPrimaries.current.add(parsePairKey(k).rangeRunId));
+
+        const next = [...kept, ...added];
+        const unchanged = next.length === prev.length && next.every((k, i) => k === prev[i]);
+        if (!unchanged) setSelectedRuns(next);
+    }, [resolvedPairs, selectedRuns]);
 
     const activePairs = resolvedPairs.filter(p => selectedRuns.includes(p.key));
 

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -409,11 +409,19 @@ export default function ChargeCompareView({
     // Selection is by pair key, so adding a second range partner to a charging
     // test brings the new series in already selected rather than requiring a
     // second click in a different part of the UI.
+    // Stale keys are also dropped. Repinning a row changes its key (`70::` becomes
+    // `70::12`), so without pruning the old key lingers forever — and returning
+    // the row to Auto would then find its key already selected, leave the array
+    // untouched, and give the chart nothing to react to.
     useEffect(() => {
         const allKeys = resolvedPairs.map(p => p.key);
+        const live = new Set(allKeys);
         setSelectedRuns(prev => {
-            const newKeys = allKeys.filter(k => !prev.includes(k));
-            return newKeys.length ? [...prev, ...newKeys] : prev;
+            const kept = prev.filter(k => live.has(k));
+            const added = allKeys.filter(k => !prev.includes(k));
+            const next = [...kept, ...added];
+            const unchanged = next.length === prev.length && next.every((k, i) => k === prev[i]);
+            return unchanged ? prev : next;
         });
     }, [resolvedPairs]);
 
@@ -501,7 +509,12 @@ export default function ChargeCompareView({
                 const targetTime  = Tz + xMinutes;
                 const lastTime    = byTime[byTime.length - 1].time;
                 const timeOvershoot = Math.max(0, targetTime - lastTime);
-                const SocEnd = interpolate(byTime, 'time', 'soc', targetTime, false, true);
+                const SocRaw = interpolate(byTime, 'time', 'soc', targetTime, false, true);
+                // A pack cannot exceed 100% SoC. Extrapolating forward past the end
+                // of a short run can produce SoC well above that, and the linear
+                // model has no ceiling of its own to catch it — unclamped, a run
+                // whose data spans a couple of minutes yielded 4800 mi added in 15.
+                const SocEnd = SocRaw != null ? Math.min(100, SocRaw) : null;
                 // Linear: the SoC gained over the window, priced at the paired
                 // test's miles-per-%SoC. Recorded: read the range column directly.
                 const Rend = useLinear
@@ -524,12 +537,16 @@ export default function ChargeCompareView({
                 // Linear: the miles asked for convert to a SoC target, and the
                 // charging curve is read on the SoC axis. Recorded: sort by the
                 // range column and read time off it, as before.
-                let Tend, SocEnd, rangeOvershoot;
+                let Tend, SocEnd, rangeOvershoot, unreachable = false;
                 if (useLinear) {
                     const targetSoc = startSoc + mMiles / miPerSoc;
                     const lastSoc   = bySoc[bySoc.length - 1].soc;
-                    Tend   = interpolate(bySoc, 'soc', 'time', targetSoc, false, true);
-                    SocEnd = targetSoc;
+                    // Asking for more miles than a full pack holds from this SoC is
+                    // not a long charge, it is impossible — report no data rather
+                    // than extrapolating past 100% into a fictional time.
+                    unreachable = targetSoc > 100;
+                    Tend   = unreachable ? null : interpolate(bySoc, 'soc', 'time', targetSoc, false, true);
+                    SocEnd = Math.min(100, targetSoc);
                     // Expressed in miles so it stays comparable with mMiles.
                     rangeOvershoot = Math.max(0, targetSoc - lastSoc) * miPerSoc;
                 } else {
@@ -651,7 +668,10 @@ export default function ChargeCompareView({
                 if (inst.current) { inst.current.destroy(); inst.current = null; }
             });
         };
-    }, [selectedVehicleIds, xMinutes, mMiles, startSoc, runDataCache, orientation, selectedRuns, units, isDark]);
+    // resolvedPairs, not just selectedRuns: changing a row's partner can leave the
+    // selection array identical (same row, different pairing) while every bar's
+    // value changes, and the chart would keep the previous partner's numbers.
+    }, [selectedVehicleIds, xMinutes, mMiles, startSoc, runDataCache, orientation, selectedRuns, resolvedPairs, units, isDark]);
 
     const hasRangeRuns = resolvedPairs.length > 0;
 

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -9,7 +9,8 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
 import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
-import { pairKey, parsePairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
+import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
+import { useRunSelection } from '../hooks/useRunSelection';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
@@ -288,7 +289,6 @@ export default function ChargeCompareView({
     const [loading,         setLoading]         = useState(false);
     const [copied,          setCopied]          = useState(false);
     const [orientation,     setOrientation]     = useState('horizontal');
-    const [selectedRuns,    setSelectedRuns]    = useState([]);
     const isHorizontal = orientation === 'horizontal';
 
     const chart1Ref      = useRef(null);
@@ -415,35 +415,19 @@ export default function ChargeCompareView({
     // changes its key ('70::' becomes '70::12'). Keying on the pair alone made
     // every deselected row spring back the moment any dropdown changed, and
     // meant a repinned row could not carry its selection across.
-    const seenPrimaries = useRef(new Set());
-    useEffect(() => {
-        const allKeys = resolvedPairs.map(p => p.key);
-        const live = new Set(allKeys);
-        const prev = selectedRuns;
-
-        const kept = prev.filter(k => live.has(k));
-        const keptSet = new Set(kept);
-        const selectedPrimaries = new Set(prev.map(k => parsePairKey(k).rangeRunId));
-
-        const added = allKeys.filter(k => {
-            if (keptSet.has(k)) return false;
-            const primary = parsePairKey(k).rangeRunId;
-            // A range test the user switched off stays off. A repinned row whose
-            // range test is still selected carries its selection to the new key.
-            // Anything genuinely new comes on.
-            return !seenPrimaries.current.has(primary) || selectedPrimaries.has(primary);
-        });
-
-        // Marked HERE and not inside the setState updater: React invokes updaters
-        // more than once in development, and a ref mutation in there ran twice —
-        // the second pass saw every primary as already seen, added nothing, and
-        // that empty result was the one kept, leaving the chart with no series.
-        allKeys.forEach(k => seenPrimaries.current.add(parsePairKey(k).rangeRunId));
-
-        const next = [...kept, ...added];
-        const unchanged = next.length === prev.length && next.every((k, i) => k === prev[i]);
-        if (!unchanged) setSelectedRuns(next);
-    }, [resolvedPairs, selectedRuns]);
+    // Selection lives in the shared hook (hooks/useRunSelection.js) so this chart,
+    // Road Trip and anything added later behave identically when the data shifts
+    // underneath them — pruning, repin carry-over and first-sighting bootstrap
+    // were three separate implementations that each got a different part wrong.
+    const selectionRows = useMemo(
+        () => resolvedPairs.map(p => ({
+            key: p.key,
+            vehicleId: p.rangeRun.vehicleId,
+            groupId: p.rangeRun.id,     // survives a repin, which changes the key
+        })),
+        [resolvedPairs]
+    );
+    const { selected: selectedRuns, toggle: toggleRun } = useRunSelection(selectionRows);
 
     const activePairs = resolvedPairs.filter(p => selectedRuns.includes(p.key));
 
@@ -755,9 +739,7 @@ export default function ChargeCompareView({
                     <RunSelector
                         vehicles={selectedVehicles}
                         selectedRunIds={selectedRuns}
-                        onToggleRun={runId => setSelectedRuns(prev =>
-                            prev.includes(runId) ? prev.filter(id => id !== runId) : [...prev, runId]
-                        )}
+                        onToggleRun={toggleRun}
                         onUpdateRunColor={onUpdateRunColor}
                         runFilter={(run, vehicle) =>
                             // A range test with no charging curve to pair against

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -166,7 +166,13 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         });
     }, [pairings]);
 
-    // Lazy-load data_points for newly selected runs
+    // Lazy-load data_points for newly selected runs.
+    //
+    // Keyed on what is MISSING, not on the selection: a pairing change evicts
+    // cached runs (their derived range is stale), and keying on the selection
+    // alone meant nothing refetched them — the series vanished until some
+    // unrelated toggle changed the selection and happened to trigger this.
+    const missingRunIds = chartConfig.selectedRuns.filter(id => !(id in runDataCache));
     useEffect(() => {
         const fetchMissingData = async () => {
             const missingIds = chartConfig.selectedRuns.filter(id => !(id in runDataCache));
@@ -253,7 +259,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             setLoadingData(false);
         };
         fetchMissingData();
-    }, [chartConfig.selectedRuns]);
+    }, [missingRunIds.join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const dl = distanceLabel(units);
     const axisOptions = [

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -13,14 +13,14 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
-import { rangePartnersOfCharging } from '../utils/pairings';
-import { resolveRangeSource, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
+import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
 import ChartInfoBubble from './ChartInfoBubble';
 
-export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, pairings = {}, presentationMode = false }) {
+export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, pairings = {}, setPairings = () => {}, presentationMode = false }) {
     const { units } = useAppContext();
     const { isDark } = useTheme();
     const chartRef = useRef(null);
@@ -723,6 +723,20 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     runFilter={isChargingRun}
                     colorMap={colorMap}
                     emptyMessage="No charging test records"
+                    pairMode
+                    singlePartner
+                    pairings={pairings}
+                    primaryLabel="Charging:"
+                    partnerLabel="Range:"
+                    partnerRunsFor={vehicle => {
+                        const epa = epaRangeOption(vehicle);
+                        return epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
+                    }}
+                    partnerIdFor={run => rangePartnersOfCharging(pairings, run.id)[0] ?? null}
+                    resolvePartner={(chargingRun, vehicle) =>
+                        resolveRangeSource(chargingRun, { vehicle })}
+                    onSetPartner={(chargingId, _old, newRangeId) =>
+                        setPairings(prev => setChargingPartner(prev, chargingId, newRangeId))}
                     renderRunMeta={run => {
                         const exclusionReason = getRaceExclusionReason(run.id);
                         const offset = getRaceOffset(run.id);

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -14,6 +14,7 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
 import { rangePartnersOfCharging } from '../utils/pairings';
+import { resolveRangeSource, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
@@ -185,37 +186,54 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             runData = await dataService.getRunData(runId);
                         }
 
-                        // Derive range from a range test via SoC interpolation when
-                        // this charging run has none of its own — or whenever the
-                        // user has explicitly paired one, in which case their choice
-                        // overrides the recorded range column.
+                        // Range axis, resolved on the same ranking as every other
+                        // chart (utils/rangeSource.js):
                         //
-                        // Only an EXPLICIT pairing overrides. Letting the automatic
-                        // pick outrank the recorded column too would restate every
-                        // existing chart's range axis without anyone asking.
-                        const pairedRangeIds = rangePartnersOfCharging(pairings, runId);
-                        const hasOwnRange = runData.some(p => p.range != null);
-                        if (runData.length > 0 && (pairedRangeIds.length > 0 || !hasOwnRange)) {
+                        //   pairing → default range test → recorded range column
+                        //
+                        // A range test now outranks the recorded column outright,
+                        // not just when one was explicitly paired. The recorded
+                        // values are themselves mostly estimates — usually the car's
+                        // guess-o-meter — so they carry no more authority than a
+                        // figure derived from a measured range test, and treating
+                        // them as more authoritative was the anomaly.
+                        if (runData.length > 0) {
                             const parentVehicle = vehicles.find(v =>
                                 v.runs?.some(r => String(r.id) === String(runId))
                             );
+                            const pairedRangeIds = rangePartnersOfCharging(pairings, runId);
                             const own = (parentVehicle?.runs || []).filter(r => !r._inherited && isRangeRun(r));
-                            const rangeRun =
-                                (pairedRangeIds.length
-                                    ? own.find(r => String(r.id) === pairedRangeIds[0])
-                                    : null) ??
-                                own.find(r => r.isDefault) ??
-                                own[0];
-                            if (rangeRun) {
-                                try {
-                                    const lookup = await dataService.buildRangePerSocLookup(rangeRun.id);
-                                    if (lookup) {
-                                        runData = runData.map(p => ({
-                                            ...p,
-                                            range: p.soc != null ? lookup(p.soc) : null,
-                                        }));
-                                    }
-                                } catch (_) { /* non-fatal — chart will just lack range axis */ }
+                            const pairedRange = pairedRangeIds.length
+                                ? (pairedRangeIds[0] === EPA_PARTNER_ID
+                                    ? EPA_PARTNER_ID
+                                    : own.find(r => String(r.id) === pairedRangeIds[0]) ?? null)
+                                : null;
+
+                            const src = resolveRangeSource(run ?? { id: runId }, {
+                                vehicle: parentVehicle,
+                                explicitPairing: pairedRange,
+                            });
+
+                            // 'recorded' and 'none' mean no range test won — leave
+                            // the run's own column alone.
+                            if (src.miPerSoc != null) {
+                                let lookup = null;
+                                // A range test WITH its own SoC/range time series gives
+                                // the real, non-linear shape; prefer it. Most range
+                                // tests are scalar (distance + SoC bounds), so the
+                                // linear miPerSoc model is the usual path.
+                                if (src.sourceRun?.id && src.sourceRun.id !== EPA_PARTNER_ID) {
+                                    try {
+                                        lookup = await dataService.buildRangePerSocLookup(src.sourceRun.id);
+                                    } catch (_) { /* fall through to linear */ }
+                                }
+                                const rangeAt = lookup
+                                    ? (soc) => lookup(soc)
+                                    : (soc) => Math.round(soc * src.miPerSoc * 10) / 10;
+                                runData = runData.map(p => ({
+                                    ...p,
+                                    range: p.soc != null ? rangeAt(p.soc) : null,
+                                }));
                             }
                         }
                     } else {

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -13,12 +13,13 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
+import { rangePartnersOfCharging } from '../utils/pairings';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
 import ChartInfoBubble from './ChartInfoBubble';
 
-export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, presentationMode = false }) {
+export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, pairings = {}, presentationMode = false }) {
     const { units } = useAppContext();
     const { isDark } = useTheme();
     const chartRef = useRef(null);
@@ -140,6 +141,30 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
         }
     }, [selectedVehicleIds, chartConfig.selectedRuns, chartMode]);
 
+    // A pairing change invalidates cached range values: the derived range is
+    // baked into the cached points, so without this the axis would keep showing
+    // the previous partner's numbers until the run was reselected.
+    const prevPairingsRef = useRef(pairings);
+    useEffect(() => {
+        const prev = prevPairingsRef.current;
+        prevPairingsRef.current = pairings;
+        if (prev === pairings) return;
+        // Values are charging-run ids, which are exactly this cache's keys.
+        const affected = new Set(
+            [...Object.values(prev || {}).flat(), ...Object.values(pairings || {}).flat()].map(String)
+        );
+        if (!affected.size) return;
+        setRunDataCache(cache => {
+            const next = {};
+            let evicted = false;
+            for (const [id, data] of Object.entries(cache)) {
+                if (affected.has(String(id))) { evicted = true; continue; }
+                next[id] = data;
+            }
+            return evicted ? next : cache;
+        });
+    }, [pairings]);
+
     // Lazy-load data_points for newly selected runs
     useEffect(() => {
         const fetchMissingData = async () => {
@@ -160,15 +185,27 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             runData = await dataService.getRunData(runId);
                         }
 
-                        // If this charging run has no range values at all, derive them
-                        // on the fly from the vehicle's range test via SoC interpolation.
-                        if (runData.length > 0 && !runData.some(p => p.range != null)) {
+                        // Derive range from a range test via SoC interpolation when
+                        // this charging run has none of its own — or whenever the
+                        // user has explicitly paired one, in which case their choice
+                        // overrides the recorded range column.
+                        //
+                        // Only an EXPLICIT pairing overrides. Letting the automatic
+                        // pick outrank the recorded column too would restate every
+                        // existing chart's range axis without anyone asking.
+                        const pairedRangeIds = rangePartnersOfCharging(pairings, runId);
+                        const hasOwnRange = runData.some(p => p.range != null);
+                        if (runData.length > 0 && (pairedRangeIds.length > 0 || !hasOwnRange)) {
                             const parentVehicle = vehicles.find(v =>
                                 v.runs?.some(r => String(r.id) === String(runId))
                             );
+                            const own = (parentVehicle?.runs || []).filter(r => !r._inherited && isRangeRun(r));
                             const rangeRun =
-                                parentVehicle?.runs?.find(r => !r._inherited && r.has_range && r.isDefault) ??
-                                parentVehicle?.runs?.find(r => !r._inherited && r.has_range);
+                                (pairedRangeIds.length
+                                    ? own.find(r => String(r.id) === pairedRangeIds[0])
+                                    : null) ??
+                                own.find(r => r.isDefault) ??
+                                own[0];
                             if (rangeRun) {
                                 try {
                                     const lookup = await dataService.buildRangePerSocLookup(rangeRun.id);

--- a/src/components/PopoutView.jsx
+++ b/src/components/PopoutView.jsx
@@ -71,6 +71,7 @@ export default function PopoutView({
                     vehicles={vehicles}
                     selectedVehicleIds={selectedVehicles}
                     roadTripConfig={roadTripConfig}
+                    pairings={pairings}
                     setRoadTripConfig={() => {}}
                     presentationMode
                 />
@@ -87,6 +88,7 @@ export default function PopoutView({
                     setChartConfig={setChartConfig}
                     onUpdateRunColor={onUpdateRunColor}
                     chartMode={chartMode}
+                    pairings={pairings}
                     presentationMode
                 />
             )}

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -7,8 +7,8 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun } from '../utils/runUtils';
-import { resolveRangeSource } from '../utils/rangeSource';
-import { rangePartnersOfCharging } from '../utils/pairings';
+import { resolveRangeSource, epaRangeOption } from '../utils/rangeSource';
+import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -362,6 +362,7 @@ export default function RoadTripView({
     // view consumes a pairing chosen in Charge Compare but does not set one,
     // because it is charging-primary and the pairing is keyed by range test.
     pairings = {},
+    setPairings = () => {},
     onUpdateRunColor = null,
     presentationMode = false,
     autoColor = true,
@@ -1424,6 +1425,20 @@ export default function RoadTripView({
                             colorMap={colorMap}
                             runFilter={isChargingRun}
                             emptyMessage="No charging test data"
+                            pairMode
+                            singlePartner
+                            pairings={pairings}
+                            primaryLabel="Charging:"
+                            partnerLabel="Range:"
+                            partnerRunsFor={vehicle => {
+                                const epa = epaRangeOption(vehicle);
+                                return epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
+                            }}
+                            partnerIdFor={run => rangePartnersOfCharging(pairings, run.id)[0] ?? null}
+                            resolvePartner={(chargingRun, vehicle) =>
+                                resolveRangeSource(chargingRun, { vehicle, batteryKwh: vehicle.battery })}
+                            onSetPartner={(chargingId, _old, newRangeId) =>
+                                setPairings(prev => setChargingPartner(prev, chargingId, newRangeId))}
                             renderRunMeta={run => {
                                 const info = allChargingRunsInfo[run.id];
                                 if (!info) return null;

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -6,8 +6,9 @@ import { dataService } from '../services/DataService';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, isChargingRun } from '../utils/runUtils';
+import { filterChargingRuns, filterRangeRuns, isChargingRun } from '../utils/runUtils';
 import { resolveRangeSource } from '../utils/rangeSource';
+import { rangePartnersOfCharging } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -357,6 +358,10 @@ export default function RoadTripView({
     selectedVehicleIds,
     roadTripConfig,
     setRoadTripConfig,
+    // Global chart-session pairings (utils/pairings.js). Read-only here: this
+    // view consumes a pairing chosen in Charge Compare but does not set one,
+    // because it is charging-primary and the pairing is keyed by range test.
+    pairings = {},
     onUpdateRunColor = null,
     presentationMode = false,
     autoColor = true,
@@ -430,11 +435,25 @@ export default function RoadTripView({
         let colorIdx = 0;
         for (const vehicle of selectedVehicles) {
             for (const run of filterChargingRuns(vehicle.runs)) {
+                // Honour the chart-session pairing. The map is keyed by range test
+                // because that is the axis worth enumerating, but this view is
+                // charging-primary, so the inverse lookup is what carries a pairing
+                // chosen in Charge Compare across to here. Without it the two
+                // charts disagree about which range test prices the same curve.
+                const pairedRangeIds = rangePartnersOfCharging(pairings, run.id);
+                const pairedRange = pairedRangeIds.length
+                    ? filterRangeRuns(vehicle.runs).find(r => String(r.id) === pairedRangeIds[0]) ?? null
+                    : null;
+
                 // Shared resolver (utils/rangeSource.js) — the same ranking Charge
                 // Compare uses, so the two views can no longer disagree about which
                 // range test a charging run's miles came from. It also supplies the
                 // provenance note this view used to assemble by hand.
-                const src = resolveRangeSource(run, { vehicle, batteryKwh: vehicle.battery });
+                const src = resolveRangeSource(run, {
+                    vehicle,
+                    batteryKwh: vehicle.battery,
+                    explicitPairing: pairedRange,
+                });
 
                 map[run.id] = {
                     vehicle,
@@ -444,13 +463,15 @@ export default function RoadTripView({
                     testSpeedMph:   run.speed_mph ?? src.sourceRun?.speed_mph ?? null,
                     batteryKwh:     vehicle.battery,
                     color:          colorMap[run.id] || run.color || PALETTE[colorIdx % PALETTE.length],
-                    efficiencyNote: src.note,
+                    efficiencyNote: pairedRangeIds.length > 1
+                        ? `${src.note ?? `eff. from ${src.sourceRun?.name ?? '?'}`} · +${pairedRangeIds.length - 1} more pairing(s) not shown here`
+                        : src.note,
                 };
                 colorIdx++;
             }
         }
         return map;
-    }, [selectedVehicles, colorMap]);
+    }, [selectedVehicles, colorMap, pairings]);
 
     // ── Active run entries — ordered by vehicle pill position ─────────────────
     const runEntries = useMemo(() => {

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -490,7 +490,11 @@ export default function RoadTripView({
                 }
             }
 
-            // Give any vehicle with nothing selected one row per range test.
+            // A vehicle with nothing selected gets one row per range test. That
+            // is a lot on arrival; narrowing it to a sensible default is worth
+            // doing, but the obvious rule (defaultRangeRun) selects nothing at
+            // all on this data, so the per-vehicle "all"/"none" links carry it
+            // for now.
             for (const vehicle of selectedVehicles) {
                 const hasAny = [...allPairsInfo.values()]
                     .some(e => e.vehicle.id === vehicle.id && keptSet.has(e.key));

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -6,9 +6,9 @@ import { dataService } from '../services/DataService';
 import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
-import { filterChargingRuns, filterRangeRuns, isChargingRun } from '../utils/runUtils';
-import { resolveRangeSource, epaRangeOption } from '../utils/rangeSource';
-import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
+import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
+import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { pairKey, parsePairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -376,9 +376,10 @@ export default function RoadTripView({
     const [runDataCache, setRunDataCache] = useState({});
     const [loading, setLoading] = useState(false);
     const [selectedRunIds, setSelectedRunIds] = useState(() => {
-        // Restore run IDs from URL on first render (rt_r=id1,id2,…)
+        // Restore pair keys from the URL on first render (rt_r=70::12,71::13).
+        // Strings, not numbers: a pair key is 'rangeId::chargingId'.
         const raw = new URLSearchParams(window.location.search).get('rt_r');
-        return raw ? raw.split(',').map(Number).filter(Boolean) : [];
+        return raw ? raw.split(',').filter(Boolean) : [];
     });
     const [axisScale, setAxisScale] = useState({ xMin: null, xMax: null, yMin: null, yMax: null });
     const [copiedUrl, setCopiedUrl] = useState(false);
@@ -397,91 +398,122 @@ export default function RoadTripView({
         [vehicles, selectedVehicleIds]
     );
 
-    // ── Sync selectedRunIds when vehicle selection changes ───────────────────
-    // Keep runs from still-selected vehicles; auto-add default run for new ones.
-    useEffect(() => {
-        setSelectedRunIds(prev => {
-            const allChargingRunIds = new Set(
-                selectedVehicles.flatMap(v =>
-                    filterChargingRuns(v.runs).map(r => r.id)
-                )
-            );
-            // Drop runs whose vehicle is no longer selected
-            const kept = prev.filter(id => allChargingRunIds.has(id));
-            const keptSet = new Set(kept);
-
-            // For each vehicle with no selected runs, add its default/most-recent charging run
-            for (const vehicle of selectedVehicles) {
-                const chargingRuns = filterChargingRuns(vehicle.runs);
-                if (chargingRuns.some(r => keptSet.has(r.id))) continue;
-                const def = chargingRuns.find(r => r.isDefault) ||
-                    [...chargingRuns].sort((a, b) => new Date(b.date) - new Date(a.date))[0];
-                if (def) { kept.push(def.id); keptSet.add(def.id); }
-            }
-            return kept;
-        });
-    }, [selectedVehicleIds]); // eslint-disable-line react-hooks/exhaustive-deps
-
     // ── Resolve chart colors for all charging runs ────────────────────────────
     const colorMap = useMemo(() => {
         const allRuns = selectedVehicles.flatMap(v => filterChargingRuns(v.runs));
         return resolveChartColors(allRuns, {}, autoColor ? 'auto' : 'manual');
     }, [selectedVehicles, autoColor]);
 
-    // ── Build efficiency info for every charging run in the selection ─────────
-    // Keyed by run.id. Derives mi/kWh from the run itself (if it has range data)
-    // or falls back to the vehicle's best range run.
-    const allChargingRunsInfo = useMemo(() => {
-        const map = {};
+    // ── One entry per (range test × charging test) pair ───────────────────────
+    // Range-primary, matching Charge Compare: a charging curve is a property of
+    // the car and varies little, while a range test is a property of the day —
+    // wind, temperature, HVAC, tyres, elevation, load. Each pair is its own trip
+    // simulation, so the same car under two conditions is two comparable rows.
+    //
+    // A Map, not an object: insertion order is the display order, and the keys
+    // are pair-key strings.
+    const allPairsInfo = useMemo(() => {
+        const map = new Map();
         let colorIdx = 0;
         for (const vehicle of selectedVehicles) {
-            for (const run of filterChargingRuns(vehicle.runs)) {
-                // Honour the chart-session pairing. The map is keyed by range test
-                // because that is the axis worth enumerating, but this view is
-                // charging-primary, so the inverse lookup is what carries a pairing
-                // chosen in Charge Compare across to here. Without it the two
-                // charts disagree about which range test prices the same curve.
-                const pairedRangeIds = rangePartnersOfCharging(pairings, run.id);
-                const pairedRange = pairedRangeIds.length
-                    ? filterRangeRuns(vehicle.runs).find(r => String(r.id) === pairedRangeIds[0]) ?? null
-                    : null;
+            const chargingRuns = filterChargingRuns(vehicle.runs);
+            if (!chargingRuns.length) continue;
 
-                // Shared resolver (utils/rangeSource.js) — the same ranking Charge
-                // Compare uses, so the two views can no longer disagree about which
-                // range test a charging run's miles came from. It also supplies the
-                // provenance note this view used to assemble by hand.
-                const src = resolveRangeSource(run, {
-                    vehicle,
-                    batteryKwh: vehicle.battery,
-                    explicitPairing: pairedRange,
-                });
+            const epa = epaRangeOption(vehicle);
+            const primaries = epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
 
-                map[run.id] = {
-                    vehicle,
-                    run,
-                    miPerKwh:       src.miPerKwh,
-                    // Assume 70 mph if not specified on the run or its range source
-                    testSpeedMph:   run.speed_mph ?? src.sourceRun?.speed_mph ?? null,
-                    batteryKwh:     vehicle.battery,
-                    color:          colorMap[run.id] || run.color || PALETTE[colorIdx % PALETTE.length],
-                    efficiencyNote: pairedRangeIds.length > 1
-                        ? `${src.note ?? `eff. from ${src.sourceRun?.name ?? '?'}`} · +${pairedRangeIds.length - 1} more pairing(s) not shown here`
-                        : src.note,
-                };
-                colorIdx++;
+            for (const rangeRun of primaries) {
+                const pinned = partnersFor(pairings, rangeRun.id);
+                const rows   = pinned.length ? pinned : [null];
+
+                for (const partnerId of rows) {
+                    const chargingRun = partnerId
+                        ? chargingRuns.find(r => String(r.id) === String(partnerId)) ?? pairedChargingRun(rangeRun, vehicle)
+                        : pairedChargingRun(rangeRun, vehicle);
+                    if (!chargingRun) continue;
+
+                    // The range side is explicit — it is the row — so the resolver
+                    // enters at rank 1 and its fallbacks only matter when the chosen
+                    // test carries no usable data.
+                    const src = resolveRangeSource(chargingRun, {
+                        vehicle,
+                        batteryKwh: vehicle.battery,
+                        explicitPairing: rangeRun.id === EPA_PARTNER_ID ? EPA_PARTNER_ID : rangeRun,
+                    });
+
+                    const key = pairKey(rangeRun.id, partnerId);
+                    map.set(key, {
+                        key,
+                        vehicle,
+                        rangeRun,
+                        // `run` stays the CHARGING run: it is what supplies the
+                        // data points the simulation walks.
+                        run:            chargingRun,
+                        // Only disambiguate when a range test is shown more than once.
+                        label:          rows.length > 1
+                            ? `${rangeRun.name} × ${chargingRun.name}`
+                            : rangeRun.name,
+                        miPerKwh:       src.miPerKwh,
+                        // Assume 70 mph if neither the range test nor its source says
+                        testSpeedMph:   rangeRun.speed_mph ?? src.sourceRun?.speed_mph ?? null,
+                        batteryKwh:     vehicle.battery,
+                        color:          colorMap[chargingRun.id] || rangeRun.color || chargingRun.color || PALETTE[colorIdx % PALETTE.length],
+                        efficiencyNote: src.note,
+                    });
+                    colorIdx++;
+                }
             }
         }
         return map;
     }, [selectedVehicles, colorMap, pairings]);
 
+    // ── Sync selection when vehicles or pairings change ──────────────────────
+    // Keyed by PAIR: this view enumerates range tests, because a charging curve
+    // is a property of the car while a range test is a property of the day, and
+    // each (range × charging) pair is its own trip simulation.
+    useEffect(() => {
+        setSelectedRunIds(prev => {
+            const live = new Set(allPairsInfo.keys());
+            const kept = prev.filter(k => live.has(k));
+            const keptSet = new Set(kept);
+
+            // Repinning a row changes its key ('70::' becomes '70::12'), so carry
+            // the selection across at the range-test level. Without this the old
+            // key is pruned, the new one is never added, and the row silently
+            // disappears from the simulation instead of updating.
+            const prevPrimaries = new Set(prev.map(k => parsePairKey(k).rangeRunId));
+            for (const [key, entry] of allPairsInfo) {
+                if (keptSet.has(key)) continue;
+                if (prevPrimaries.has(String(entry.rangeRun.id))) {
+                    kept.push(key);
+                    keptSet.add(key);
+                }
+            }
+
+            // Give any vehicle with nothing selected one row per range test.
+            for (const vehicle of selectedVehicles) {
+                const hasAny = [...allPairsInfo.values()]
+                    .some(e => e.vehicle.id === vehicle.id && keptSet.has(e.key));
+                if (hasAny) continue;
+                for (const entry of allPairsInfo.values()) {
+                    if (entry.vehicle.id !== vehicle.id) continue;
+                    kept.push(entry.key);
+                    keptSet.add(entry.key);
+                }
+            }
+            const unchanged = kept.length === prev.length && kept.every((k, i) => k === prev[i]);
+            return unchanged ? prev : kept;
+        });
+    }, [allPairsInfo, selectedVehicles]);
+
     // ── Active run entries — ordered by vehicle pill position ─────────────────
     const runEntries = useMemo(() => {
         const vehicleOrder = new Map(selectedVehicles.map((v, i) => [v.id, i]));
         return selectedRunIds
-            .map(id => allChargingRunsInfo[id])
+            .map(k => allPairsInfo.get(k))
             .filter(Boolean)
             .sort((a, b) => (vehicleOrder.get(a.vehicle.id) ?? 999) - (vehicleOrder.get(b.vehicle.id) ?? 999));
-    }, [selectedRunIds, allChargingRunsInfo, selectedVehicles]);
+    }, [selectedRunIds, allPairsInfo, selectedVehicles]);
 
     const validEntries  = runEntries.filter(e => e.miPerKwh && e.batteryKwh);
     const skippedEntries = runEntries.filter(e => !e.miPerKwh || !e.batteryKwh);
@@ -655,7 +687,7 @@ export default function RoadTripView({
         }
         const entryLabel = e =>
             vehicleRunCount[e.vehicle.id] > 1
-                ? `${vehicleLabel(e.vehicle)} (${e.run.name})`
+                ? `${vehicleLabel(e.vehicle)} (${e.label})`
                 : vehicleLabel(e.vehicle);
 
         // ── Speed sweep chart ────────────────────────────────────────────────
@@ -1041,7 +1073,7 @@ export default function RoadTripView({
                                     if (idx >= 0 && idx < validEntries.length) {
                                         const e = validEntries[idx];
                                         return vehicleRunCount[e.vehicle.id] > 1
-                                            ? `${vehicleLabel(e.vehicle)} · ${e.run.name}`
+                                            ? `${vehicleLabel(e.vehicle)} · ${e.label}`
                                             : vehicleLabel(e.vehicle);
                                     }
                                     if (idx === validEntries.length) return 'ICE Reference';
@@ -1401,8 +1433,8 @@ export default function RoadTripView({
                                 const sim = simResults[i];
                                 if (!sim?.warnings?.length) return null;
                                 return sim.warnings.map((w, wi) => (
-                                    <p key={`${entry.run.id}-${wi}`} className="roadtrip-warning">
-                                        ⚠ {vehicleLabel(entry.vehicle)} – {entry.run.name}: {w}
+                                    <p key={`${entry.key}-${wi}`} className="roadtrip-warning">
+                                        ⚠ {vehicleLabel(entry.vehicle)} – {entry.label}: {w}
                                     </p>
                                 ));
                             })}
@@ -1416,43 +1448,50 @@ export default function RoadTripView({
                                 filterChargingRuns(v.runs).length > 0
                             )}
                             selectedRunIds={selectedRunIds}
-                            onToggleRun={runId => setSelectedRunIds(prev =>
-                                prev.includes(runId)
-                                    ? prev.filter(x => x !== runId)
-                                    : [...prev, runId]
+                            onToggleRun={key => setSelectedRunIds(prev =>
+                                prev.includes(key)
+                                    ? prev.filter(x => x !== key)
+                                    : [...prev, key]
                             )}
                             onUpdateRunColor={onUpdateRunColor}
                             colorMap={colorMap}
-                            runFilter={isChargingRun}
-                            emptyMessage="No charging test data"
+                            runFilter={(run, vehicle) =>
+                                isRangeRun(run) && filterChargingRuns(vehicle.runs).length > 0}
+                            emptyMessage="No range test records"
                             pairMode
-                            singlePartner
                             pairings={pairings}
-                            primaryLabel="Charging:"
-                            partnerLabel="Range:"
-                            partnerRunsFor={vehicle => {
+                            primaryLabel="Range:"
+                            partnerLabel="Charging:"
+                            partnerRunsFor={vehicle => filterChargingRuns(vehicle.runs)}
+                            extraPrimaryRunsFor={vehicle => {
+                                if (!filterChargingRuns(vehicle.runs).length) return [];
                                 const epa = epaRangeOption(vehicle);
-                                return epa ? [...filterRangeRuns(vehicle.runs), epa] : filterRangeRuns(vehicle.runs);
+                                return epa ? [epa] : [];
                             }}
-                            partnerIdFor={run => rangePartnersOfCharging(pairings, run.id)[0] ?? null}
-                            resolvePartner={(chargingRun, vehicle) =>
-                                resolveRangeSource(chargingRun, { vehicle, batteryKwh: vehicle.battery })}
-                            onSetPartner={(chargingId, _old, newRangeId) =>
-                                setPairings(prev => setChargingPartner(prev, chargingId, newRangeId))}
+                            resolvePartner={(rangeRun, vehicle) => {
+                                const run = pairedChargingRun(rangeRun, vehicle);
+                                return run ? { sourceRun: run, note: null } : null;
+                            }}
+                            onSetPartner={(rangeId, oldChargingId, newChargingId) =>
+                                setPairings(prev => replacePartner(prev, rangeId, oldChargingId, newChargingId))}
+                            onAddPartner={(rangeId, chargingId) =>
+                                setPairings(prev => addPartner(prev, rangeId, chargingId))}
+                            onRemovePartner={(rangeId, chargingId) =>
+                                setPairings(prev => removePartner(prev, rangeId, chargingId))}
                             renderRunMeta={run => {
-                                const info = allChargingRunsInfo[run.id];
-                                if (!info) return null;
-                                if (!info.miPerKwh) {
+                                const entry = [...allPairsInfo.values()].find(e => e.rangeRun.id === run.id);
+                                if (!entry) return null;
+                                if (!entry.miPerKwh) {
                                     return <span className="text-xs text-red-400 ml-1">⚠ No range data</span>;
                                 }
-                                const eff = info.miPerKwh.toFixed(1);
-                                const spd = info.testSpeedMph
-                                    ? `${fmtSpeed(info.testSpeedMph, units)}`
+                                const eff = entry.miPerKwh.toFixed(1);
+                                const spd = entry.testSpeedMph
+                                    ? `${fmtSpeed(entry.testSpeedMph, units)}`
                                     : '70 mph (assumed)';
                                 return (
                                     <span className="text-xs text-faint ml-1">
                                         {eff} {units === 'metric' ? 'km/kWh' : 'mi/kWh'} @ {spd}
-                                        {info.efficiencyNote && ` · ${info.efficiencyNote}`}
+                                        {entry.efficiencyNote && ` · ${entry.efficiencyNote}`}
                                     </span>
                                 );
                             }}
@@ -1466,8 +1505,8 @@ export default function RoadTripView({
                                 <p key={v.id}>⚠ {v.name}: No charging test data</p>
                             ))}
                             {skippedEntries.map(e => (
-                                <p key={e.run.id}>
-                                    ⚠ {vehicleLabel(e.vehicle)} – {e.run.name}: {!e.miPerKwh ? 'No range data for efficiency' : 'No battery capacity'}
+                                <p key={e.key}>
+                                    ⚠ {vehicleLabel(e.vehicle)} – {e.label}: {!e.miPerKwh ? 'No range data for efficiency' : 'No battery capacity'}
                                 </p>
                             ))}
                         </div>
@@ -1617,8 +1656,8 @@ export default function RoadTripView({
                                     let av, bv;
                                     switch (sortCol) {
                                         case 'vehicle':
-                                            av = (a.entry.vehicle.name + a.entry.run.name).toLowerCase();
-                                            bv = (b.entry.vehicle.name + b.entry.run.name).toLowerCase();
+                                            av = (a.entry.vehicle.name + a.entry.label).toLowerCase();
+                                            bv = (b.entry.vehicle.name + b.entry.label).toLowerCase();
                                             return dir * av.localeCompare(bv);
                                         case 'totalTime':  av = a.sim.totalTimeMin;     bv = b.sim.totalTimeMin;     break;
                                         case 'stops':      av = a.sim.chargeStops;      bv = b.sim.chargeStops;      break;
@@ -1651,14 +1690,14 @@ export default function RoadTripView({
                                 {rows.map(({ entry, sim, avgChargeTime, speedDiff, adjPct, vsIce }) => {
 
                                     return (
-                                        <tr key={entry.run.id}>
+                                        <tr key={entry.key}>
                                             <td className="px-3 py-2">
                                                 <div className="flex items-start gap-2">
                                                     <span className="inline-block w-3 h-3 rounded-full mt-1 shrink-0"
                                                           style={{ backgroundColor: entry.color }} />
                                                     <div>
                                                         <div className="font-medium">{vehicleLabel(entry.vehicle)}</div>
-                                                        <div className="text-xs text-faint">{entry.run.name}</div>
+                                                        <div className="text-xs text-faint">{entry.label}</div>
                                                     </div>
                                                 </div>
                                             </td>

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -8,7 +8,7 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
 import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
-import { pairKey, parsePairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
+import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
 import {
@@ -16,6 +16,7 @@ import {
     segmentsToChartPointsByTest,
     formatTime, speedCorrectionFactor,
 } from '../utils/roadTripSimulation';
+import { useRunSelection } from '../hooks/useRunSelection';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
 import ChartInfoBubble from './ChartInfoBubble';
@@ -375,12 +376,12 @@ export default function RoadTripView({
 
     const [runDataCache, setRunDataCache] = useState({});
     const [loading, setLoading] = useState(false);
-    const [selectedRunIds, setSelectedRunIds] = useState(() => {
-        // Restore pair keys from the URL on first render (rt_r=70::12,71::13).
-        // Strings, not numbers: a pair key is 'rangeId::chargingId'.
-        const raw = new URLSearchParams(window.location.search).get('rt_r');
-        return raw ? raw.split(',').filter(Boolean) : [];
-    });
+    // Pair keys restored from the URL on first render (rt_r=70::12,71::13).
+    // Strings, not numbers: a pair key is 'rangeId::chargingId'.
+    const initialRunIds = useRef(
+        (new URLSearchParams(window.location.search).get('rt_r') || '')
+            .split(',').filter(Boolean)
+    ).current;
     const [axisScale, setAxisScale] = useState({ xMin: null, xMax: null, yMin: null, yMax: null });
     const [copiedUrl, setCopiedUrl] = useState(false);
     const [imageCopied, setImageCopied] = useState(false);
@@ -467,48 +468,21 @@ export default function RoadTripView({
         return map;
     }, [selectedVehicles, colorMap, pairings]);
 
-    // ── Sync selection when vehicles or pairings change ──────────────────────
-    // Keyed by PAIR: this view enumerates range tests, because a charging curve
-    // is a property of the car while a range test is a property of the day, and
-    // each (range × charging) pair is its own trip simulation.
-    useEffect(() => {
-        setSelectedRunIds(prev => {
-            const live = new Set(allPairsInfo.keys());
-            const kept = prev.filter(k => live.has(k));
-            const keptSet = new Set(kept);
-
-            // Repinning a row changes its key ('70::' becomes '70::12'), so carry
-            // the selection across at the range-test level. Without this the old
-            // key is pruned, the new one is never added, and the row silently
-            // disappears from the simulation instead of updating.
-            const prevPrimaries = new Set(prev.map(k => parsePairKey(k).rangeRunId));
-            for (const [key, entry] of allPairsInfo) {
-                if (keptSet.has(key)) continue;
-                if (prevPrimaries.has(String(entry.rangeRun.id))) {
-                    kept.push(key);
-                    keptSet.add(key);
-                }
-            }
-
-            // A vehicle with nothing selected gets one row per range test. That
-            // is a lot on arrival; narrowing it to a sensible default is worth
-            // doing, but the obvious rule (defaultRangeRun) selects nothing at
-            // all on this data, so the per-vehicle "all"/"none" links carry it
-            // for now.
-            for (const vehicle of selectedVehicles) {
-                const hasAny = [...allPairsInfo.values()]
-                    .some(e => e.vehicle.id === vehicle.id && keptSet.has(e.key));
-                if (hasAny) continue;
-                for (const entry of allPairsInfo.values()) {
-                    if (entry.vehicle.id !== vehicle.id) continue;
-                    kept.push(entry.key);
-                    keptSet.add(entry.key);
-                }
-            }
-            const unchanged = kept.length === prev.length && kept.every((k, i) => k === prev[i]);
-            return unchanged ? prev : kept;
-        });
-    }, [allPairsInfo, selectedVehicles]);
+    // Selection lives in the shared hook (hooks/useRunSelection.js), the same one
+    // Charge Compare uses. Previously this view had its own copy, whose bootstrap
+    // refilled any vehicle that happened to be empty — so clearing one vehicle
+    // and then changing another vehicle's dropdown brought the first one back.
+    const selectionRows = useMemo(
+        () => [...allPairsInfo.values()].map(e => ({
+            key: e.key,
+            vehicleId: e.vehicle.id,
+            groupId: e.rangeRun.id,     // survives a repin, which changes the key
+        })),
+        [allPairsInfo]
+    );
+    const { selected: selectedRunIds, toggle: toggleRunId } = useRunSelection(
+        selectionRows, { initial: initialRunIds }
+    );
 
     // ── Active run entries — ordered by vehicle pill position ─────────────────
     const runEntries = useMemo(() => {
@@ -1452,11 +1426,7 @@ export default function RoadTripView({
                                 filterChargingRuns(v.runs).length > 0
                             )}
                             selectedRunIds={selectedRunIds}
-                            onToggleRun={key => setSelectedRunIds(prev =>
-                                prev.includes(key)
-                                    ? prev.filter(x => x !== key)
-                                    : [...prev, key]
-                            )}
+                            onToggleRun={toggleRunId}
                             onUpdateRunColor={onUpdateRunColor}
                             colorMap={colorMap}
                             runFilter={(run, vehicle) =>

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -35,6 +35,8 @@ import { pairKey, partnersFor } from '../utils/pairings';
  *   partnerLabel    — prefix before the dropdown,      e.g. "Charging:"
  *   partnerRunsFor  — (vehicle) => runs offered as partners
  *   extraPrimaryRunsFor — (vehicle) => synthetic primary rows (e.g. EPA range)
+ *   singlePartner   — one partner per row, selection still keyed by run id
+ *   partnerIdFor    — (run) => partnerRunId | null, single-partner mode only
  *   resolvePartner  — (primaryRun, vehicle) => { sourceRun, note } for the
  *                     automatic choice shown when nothing is pinned
  *   onSetPartner    — (primaryRunId, oldPartnerId, newPartnerId) => void
@@ -55,6 +57,13 @@ export default function RunSelector({
     pairings = {},
     primaryLabel = null,
     partnerLabel = 'Paired with:',
+    // One partner per row, selection still keyed by run id. For views whose
+    // subject is the primary run (the charging chart plots one curve per run,
+    // Road Trip simulates one trip per run) — they cannot render a run twice, so
+    // they get the same row shape without the ＋ that would imply they could.
+    singlePartner = false,
+    // (run) => partnerRunId | null — single-partner mode only
+    partnerIdFor = null,
     partnerRunsFor = null,
     // Rows that are not runs — e.g. the vehicle's EPA rated range, which is a
     // legitimate range basis with no test behind it.
@@ -80,6 +89,10 @@ export default function RunSelector({
      * whether or not anyone has paired it.
      */
     const partnerRowsFor = (run) => {
+        // Single-partner views ask the parent which partner this row holds: the
+        // map is keyed by the other side, and knowing that would make this
+        // component orientation-aware again.
+        if (singlePartner) return [partnerIdFor ? (partnerIdFor(run) ?? null) : null];
         const pinned = partnersFor(pairings, run.id);
         return pinned.length ? pinned : [null];
     };
@@ -98,9 +111,11 @@ export default function RunSelector({
 
     const selectedCount = pairMode
         ? vehicles.reduce((n, v) => n + primaryRunsFor(v).reduce(
-            (m, run) => m + partnerRowsFor(run).filter(
-                partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
-            ).length, 0), 0)
+            (m, run) => m + (singlePartner
+                ? (selectedRunIds.some(id => String(id) === String(run.id)) ? 1 : 0)
+                : partnerRowsFor(run).filter(
+                    partnerId => selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId))
+                  ).length), 0), 0)
         : vehicles.reduce((n, v) =>
             n + (v.runs || []).filter(r => runFilter(r, v)).filter(isSelected).length, 0);
 
@@ -152,6 +167,7 @@ export default function RunSelector({
                                                         resolvePartner={resolvePartner}
                                                         primaryLabel={primaryLabel}
                                                         partnerLabel={partnerLabel}
+                                                        singlePartner={singlePartner}
                                                         selectedRunIds={selectedRunIds}
                                                         onToggleRun={onToggleRun}
                                                         onSetPartner={onSetPartner}
@@ -196,7 +212,7 @@ export default function RunSelector({
  */
 function PairRows({
     run, vehicle, partnerIds, partnerRuns, resolvePartner,
-    primaryLabel, partnerLabel,
+    primaryLabel, partnerLabel, singlePartner,
     selectedRunIds, onToggleRun, onSetPartner, onAddPartner, onRemovePartner,
     onUpdateRunColor, renderRunMeta, colorMap,
 }) {
@@ -216,8 +232,9 @@ function PairRows({
     if (!partnerIds.some(Boolean) && auto?.sourceRun) used.add(String(auto.sourceRun.id));
     const unused = partnerRuns.filter(r => !used.has(String(r.id)));
 
+    const rowKey = (partnerId) => singlePartner ? String(run.id) : pairKey(run.id, partnerId);
     const isSelected = (partnerId) =>
-        selectedRunIds.some(id => String(id) === pairKey(run.id, partnerId));
+        selectedRunIds.some(id => String(id) === rowKey(partnerId));
 
     return (
         <div className="pair-group">
@@ -229,7 +246,7 @@ function PairRows({
                     <input
                         type="checkbox"
                         checked={isSelected(partnerId)}
-                        onChange={() => onToggleRun(pairKey(run.id, partnerId))}
+                        onChange={() => onToggleRun(singlePartner ? run.id : rowKey(partnerId))}
                         className="w-4 h-4 shrink-0"
                     />
 
@@ -271,7 +288,7 @@ function PairRows({
                         </select>
 
                         {/* Discovery: how many other range tests could go here */}
-                        {idx === 0 && unused.length > 0 && (
+                        {!singlePartner && idx === 0 && unused.length > 0 && (
                             <span
                                 className="pair-more-badge"
                                 title={`${unused.length} more option(s): ${unused.map(r => r.name).join(', ')}`}
@@ -280,7 +297,7 @@ function PairRows({
                             </span>
                         )}
 
-                        {idx === 0 ? (
+                        {singlePartner ? null : idx === 0 ? (
                             <button
                                 type="button"
                                 onClick={() => {

--- a/src/components/RunSelector.jsx
+++ b/src/components/RunSelector.jsx
@@ -109,6 +109,21 @@ export default function RunSelector({
             : own;
     };
 
+    /**
+     * Select or clear every row for one vehicle. Emits the same toggle the rows
+     * do, so the parent's selection model — run ids or pair keys — stays the
+     * only thing that knows which is which.
+     */
+    const setVehicleSelection = (vehicle, wanted) => {
+        for (const run of primaryRunsFor(vehicle)) {
+            for (const partnerId of partnerRowsFor(run)) {
+                const key = pairMode && !singlePartner ? pairKey(run.id, partnerId) : run.id;
+                const isOn = selectedRunIds.some(id => String(id) === String(key));
+                if (isOn !== wanted) onToggleRun(key);
+            }
+        }
+    };
+
     const selectedCount = pairMode
         ? vehicles.reduce((n, v) => n + primaryRunsFor(v).reduce(
             (m, run) => m + (singlePartner
@@ -149,6 +164,23 @@ export default function RunSelector({
                                         >
                                             <span style={{ display: 'inline-block', transform: isVehicleExpanded(vehicle.id) ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }} className="text-faint group-hover:text-secondary">&#9660;</span>
                                             <h4 className="text-sm font-semibold text-secondary">{vehicle.name}</h4>
+                                        </button>
+                                        {/* Bulk helpers — a vehicle can contribute a dozen rows,
+                                            and ticking them one at a time is the common complaint. */}
+                                        <button
+                                            type="button"
+                                            onClick={() => setVehicleSelection(vehicle, true)}
+                                            className="run-bulk-link"
+                                        >
+                                            all
+                                        </button>
+                                        <span className="text-faint text-xs select-none">/</span>
+                                        <button
+                                            type="button"
+                                            onClick={() => setVehicleSelection(vehicle, false)}
+                                            className="run-bulk-link"
+                                        >
+                                            none
                                         </button>
                                     </div>
 

--- a/src/hooks/useRunSelection.js
+++ b/src/hooks/useRunSelection.js
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Which rows a chart is displaying, and how that survives the data changing
+ * underneath it.
+ *
+ * Every chart had its own copy of this, and each one got a different part of it
+ * wrong: rows springing back after being switched off, rows vanishing when
+ * repinned, a whole vehicle refilling because another vehicle's dropdown moved.
+ * They are the same problem, so this is the one implementation of it.
+ *
+ * ── The four rules ───────────────────────────────────────────────────────────
+ *
+ * 1. PRUNE      a selected row whose key no longer exists is dropped.
+ * 2. CARRY      repinning a row changes its key ('70::' becomes '70::12'), so a
+ *               new key inherits the selection of the row it replaced, matched
+ *               on `groupId` — otherwise the row silently disappears.
+ * 3. BOOTSTRAP  a vehicle seen for the first time gets its rows selected. Only
+ *               the first time: a vehicle the user has emptied stays empty, or
+ *               any unrelated change refills it.
+ * 4. QUIET      when nothing actually changes, the previous array is returned
+ *               unchanged, so dependent effects don't re-fire.
+ *
+ * ── Why a ref, and why it is written here ────────────────────────────────────
+ *
+ * "Seen" has to persist across renders without causing one, so it is a ref. It
+ * is updated in the effect body and NEVER inside the state updater: React
+ * invokes updaters more than once in development, and a mutation in there ran
+ * twice — the second pass saw everything as already seen, added nothing, and
+ * that empty result was the one kept, leaving the chart with no series at all.
+ *
+ * @param {Array}  rows            [{ key, vehicleId, groupId }] every selectable row
+ * @param {Array}  [initial]       keys to start selected (e.g. restored from a URL)
+ * @param {Function} [shouldBootstrap] (vehicleId, rowsForVehicle) => keys to auto-select;
+ *                                  defaults to all of them
+ */
+export function useRunSelection(rows, { initial = [], shouldBootstrap = null } = {}) {
+    const [selected, setSelected] = useState(initial);
+    const seenVehicles = useRef(new Set());
+    // key → groupId for every row ever seen, so a key that has since disappeared
+    // can still be traced back to its group. Repinning depends on this.
+    const knownGroups  = useRef(new Map());
+
+    useEffect(() => {
+        const live = new Set(rows.map(r => r.key));
+        const prev = selected;
+
+        // 1. PRUNE
+        const kept = prev.filter(k => live.has(k));
+        const keptSet = new Set(kept);
+
+        // 2. CARRY — a row whose group still has a selection stays selected
+        //    through a key change.
+        //
+        //    The departed key is looked up in the REMEMBERED index, not in the
+        //    current rows: repinning is precisely the case where the old key no
+        //    longer exists, so searching `rows` for it always missed and the
+        //    replacement row was never carried.
+        const prevGroups = new Set(
+            prev.map(k => knownGroups.current.get(String(k)))
+                .filter(g => g != null)
+                .map(String)
+        );
+        for (const row of rows) {
+            if (keptSet.has(row.key)) continue;
+            if (prevGroups.has(String(row.groupId))) {
+                kept.push(row.key);
+                keptSet.add(row.key);
+            }
+        }
+
+        // 3. BOOTSTRAP — first sighting of a vehicle only.
+        const byVehicle = new Map();
+        for (const row of rows) {
+            if (!byVehicle.has(row.vehicleId)) byVehicle.set(row.vehicleId, []);
+            byVehicle.get(row.vehicleId).push(row);
+        }
+        for (const [vehicleId, vehicleRows] of byVehicle) {
+            if (seenVehicles.current.has(String(vehicleId))) continue;
+            const auto = shouldBootstrap
+                ? shouldBootstrap(vehicleId, vehicleRows)
+                : vehicleRows.map(r => r.key);
+            for (const key of auto) {
+                if (keptSet.has(key)) continue;
+                kept.push(key);
+                keptSet.add(key);
+            }
+        }
+
+        // Recorded AFTER deciding, and outside the updater. See the note above.
+        for (const row of rows) {
+            seenVehicles.current.add(String(row.vehicleId));
+            knownGroups.current.set(String(row.key), row.groupId);
+        }
+
+        // 4. QUIET
+        const unchanged = kept.length === prev.length && kept.every((k, i) => k === prev[i]);
+        if (!unchanged) setSelected(kept);
+    }, [rows, selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    /** Toggle one row. */
+    const toggle = (key) => setSelected(prev =>
+        prev.some(k => String(k) === String(key))
+            ? prev.filter(k => String(k) !== String(key))
+            : [...prev, key]
+    );
+
+    /** Select or clear every row belonging to one vehicle. */
+    const setVehicle = (vehicleId, wanted) => setSelected(prev => {
+        const keys = rows.filter(r => String(r.vehicleId) === String(vehicleId)).map(r => r.key);
+        if (!keys.length) return prev;
+        if (!wanted) {
+            const drop = new Set(keys.map(String));
+            return prev.filter(k => !drop.has(String(k)));
+        }
+        const have = new Set(prev.map(String));
+        const add = keys.filter(k => !have.has(String(k)));
+        return add.length ? [...prev, ...add] : prev;
+    });
+
+    return { selected, setSelected, toggle, setVehicle };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -875,6 +875,15 @@ body {
     @apply flex-1 flex items-center gap-2 flex-wrap;
 }
 
+/* Per-vehicle "all / none" bulk selection links in the run selector */
+.run-bulk-link {
+    @apply text-xs underline transition;
+    color: var(--color-text-faint);
+}
+.run-bulk-link:hover {
+    color: var(--color-primary);
+}
+
 /* ── Pair mode (charging test × range test) ─────────────────────────────────── */
 
 /* One charging test and all of its range partners, kept visually together */

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -91,6 +91,26 @@ export function rangePartnersOfCharging(pairings, chargingRunId) {
 }
 
 /**
+ * Write from the charging side: give this charging run the given range test,
+ * or `null` to return it to automatic resolution.
+ *
+ * The map stays keyed by range test — there is exactly one map, so a pairing
+ * made in a charging-primary view is the same pairing Charge Compare shows.
+ * That means detaching the charging run from wherever it currently sits before
+ * attaching it to the new range test, or the two views would disagree about a
+ * pairing they are both meant to be reading.
+ */
+export function setChargingPartner(pairings, chargingRunId, rangeRunId) {
+    const target = key(chargingRunId);
+    const out = {};
+    for (const [primaryId, partners] of Object.entries(pairings || {})) {
+        const kept = partners.filter(id => id !== target);
+        if (kept.length) out[primaryId] = kept;
+    }
+    return rangeRunId ? addPartner(out, rangeRunId, chargingRunId) : out;
+}
+
+/**
  * Add a charging partner. Returns a new map — never mutates, so React state
  * updates and the URL/broadcast effects fire correctly.
  */

--- a/src/utils/pairings.js
+++ b/src/utils/pairings.js
@@ -70,6 +70,27 @@ export function isPaired(pairings, rangeRunId) {
 }
 
 /**
+ * The inverse lookup: range tests explicitly paired to a given charging run.
+ *
+ * The map is keyed by range test because that is the axis worth enumerating,
+ * but Road Trip and the charging chart are charging-primary — they plot a
+ * charging curve and need to know which range test prices it. Without this,
+ * a pairing chosen in Charge Compare would not reach them, and two charts on
+ * one screen would disagree about what "range" means, which is precisely what
+ * making pairings global was meant to prevent.
+ *
+ * Usually returns zero or one. Several means the user deliberately compared one
+ * charging curve against multiple conditions, which a charging-primary view
+ * cannot show in a single series — callers take the first and should say so.
+ */
+export function rangePartnersOfCharging(pairings, chargingRunId) {
+    const target = key(chargingRunId);
+    return Object.entries(pairings || {})
+        .filter(([, partners]) => partners.includes(target))
+        .map(([rangeRunId]) => rangeRunId);
+}
+
+/**
  * Add a charging partner. Returns a new map — never mutates, so React state
  * updates and the URL/broadcast effects fire correctly.
  */


### PR DESCRIPTION
**Stacked on #172** — base is `feature/curated-pairing`, retarget to `main` once that merges.

## Problem

Pairings were global in name only. Chosen in Charge Compare, ignored by the two other views that combine charging with efficiency into a metric — which is precisely the split #150 said must not happen: two charts on one screen disagreeing about which range test prices the same curve.

## The inverse lookup

The map is keyed by **range test**, because that is the axis worth enumerating (a charging curve is a property of the car; a range test is a property of the day). But Road Trip and the charging chart are **charging-primary** — they plot a curve and need to know which range test prices it.

`rangePartnersOfCharging(pairings, chargingRunId)` is what carries a pairing across. Usually returns zero or one; several means the user deliberately compared one curve against multiple conditions.

## Road Trip

The resolver call now passes the paired range test as `explicitPairing`, so a pairing set in Charge Compare changes the efficiency, the stop times and the trip totals here too.

Where a charging curve is paired against several range tests, a charging-primary view cannot show them as separate series. It uses the first, and the efficiency note says how many pairings are not shown — surfacing the ambiguity rather than hiding it. Enumerating pairs properly here (one simulation per pair, so you could compare trip time at 70 mph mild against 80 mph cold) is a genuinely useful follow-up, but a much larger refactor of the entry model.

## Charging chart

The derived range axis now prefers the paired range test.

**Only an explicit pairing overrides the recorded range column.** Letting the automatic pick outrank it as well would restate every existing chart's range axis without anyone asking — that alignment with the agreed rank order is a decision worth taking deliberately and separately.

**Cache invalidation** was the real trap: the derived range is baked into cached data points, so changing a pairing evicts the affected charging runs from `runDataCache`. Without it the axis keeps showing the previous partner's numbers until the run happens to be reselected — wrong, and silently so.

Also fixes the range-test lookup in that backfill to use `isRangeRun()` rather than reading `has_range` directly, so it sees `kind` like everything else has since #167.

## Testing

8 unit tests on the inverse lookup: several range tests naming one charging run, id-type mismatches, synthetic inherited ids, empty and null maps, and that a range **key** is never mistaken for a charging partner of the same numeric value.

`vite build` clean.

**Not verified in a browser** — the pop-out and cross-view behaviour want a signed-in session to be worth looking at.

## Still per-view

Range & Efficiency has no charging test to pair, so it stays a flat list. The pairing **selector** remains Charge-Compare-only; these two views consume pairings without offering to set them, since both are charging-primary and the pairing is keyed by range test.