### PR TITLE
Pairing phase 5: split dual-role runs and make kind authoritative

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -13,7 +13,7 @@ import { RunVoteButtons } from './VoteButtons';
 import EpaVehicleSection from './EpaVehicleSection';
 import PerformanceVehicleSection from './PerformanceVehicleSection';
 import { deriveChargingAxis } from '../utils/deriveChargingAxis';
-import { filterChargingRuns, defaultChargingRun } from '../utils/runUtils';
+import { filterChargingRuns, defaultChargingRun, isRangeRun } from '../utils/runUtils';
 import { isTimestampValue, timestampToMs } from '../utils/parseElapsedTime';
 
 // ── Data-type flag definitions ────────────────────────────────────────────────
@@ -24,13 +24,13 @@ const DATA_FLAGS = [
     { key: 'range',    label: '📏 Range',    pillStyle: 'bg-purple-100 text-purple-800 border-purple-300', desc: 'Range/efficiency test (distance, SoC, speed, efficiency)' },
 ];
 
-/** Infer the active data-type flags from a run's boolean columns. */
-const inferRunFlags = (run) => {
-    const flags = [];
-    if (run?.has_charging ?? true)  flags.push('charging');
-    if (run?.has_range    ?? false) flags.push('range');
-    return flags;
-};
+/**
+ * A run's role. Since migration 046 a run is a charging test OR a range test,
+ * never both — the dual-role rows were split, and the flag pair that expressed
+ * them is gone. Kept as a one-element array so the pill rendering below, which
+ * was written against a list, does not have to change.
+ */
+const inferRunFlags = (run) => [isRangeRun(run) ? 'range' : 'charging'];
 
 // ── Field tag metadata (ordered for display) ──────────────────────────────────
 const FIELD_META = [
@@ -725,8 +725,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         const { dataFlags, ...metaRest } = runMetadata;
         const run = {
             ...metaRest,
-            hasCharging: dataFlags.includes('charging'),
-            hasRange:    dataFlags.includes('range'),
+            kind: dataFlags.includes('range') ? 'range' : 'charging',
             data: [],
             uploadDate: new Date().toISOString()
         };
@@ -796,8 +795,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         const { dataFlags, ...metaRest } = runMetadata;
         const run = {
             ...metaRest,
-            hasCharging: dataFlags.includes('charging'),
-            hasRange:    dataFlags.includes('range'),
+            kind: dataFlags.includes('range') ? 'range' : 'charging',
             data: transformedData,
             fieldMapping,
             calculated_fields: calculatedFields,
@@ -909,8 +907,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             const { dataFlags, ...formRest } = editFormData;
             await onUpdateRun(runId, {
                 ...formRest,
-                hasCharging: dataFlags.includes('charging'),
-                hasRange:    dataFlags.includes('range'),
+                kind: dataFlags.includes('range') ? 'range' : 'charging',
                 calculated_fields: editCalculatedFields,
             });
             // Save table data only if the editor made changes
@@ -1178,10 +1175,10 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
 
     // ── Derived-column offer logic ────────────────────────────────────────────
     // Range test runs available for measured-range estimation.
-    // Requires has_range + distance_miles; start_soc/end_soc are optional —
+    // Requires a range run with distance_miles; start_soc/end_soc are optional —
     // if absent we treat the test as a full 0→100% run (a safe approximation).
     const rangeTestRuns = (vehicle?.runs ?? [])
-        .filter(r => r.has_range && r.distance_miles > 0
+        .filter(r => isRangeRun(r) && r.distance_miles > 0
             && (r.start_soc == null || r.end_soc == null || r.start_soc !== r.end_soc))
         .sort((a, b) => new Date(b.date) - new Date(a.date));
     const selectedRangeTestRun = rangeTestRuns.find(r => r.id === selectedRangeTestRunId) ?? rangeTestRuns[0] ?? null;
@@ -1412,9 +1409,9 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                 {/* Only show metadata inputs in create mode */}
                                 {uploadMode === 'create' && (
                                     <>
-                                        {/* Data-type flags — multi-select, at least one must remain active */}
+                                        {/* Role — exactly one. A run is a charging test or a range test. */}
                                         <div>
-                                            <p className="text-xs text-muted mb-1">Data types (select all that apply)</p>
+                                            <p className="text-xs text-muted mb-1">Data type</p>
                                             <div className="data-type-flags">
                                                 {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                     const active = runMetadata.dataFlags.includes(key);
@@ -1423,12 +1420,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                             key={key}
                                                             type="button"
                                                             title={desc}
-                                                            onClick={() => setRunMetadata(m => {
-                                                                const next = active
-                                                                    ? m.dataFlags.filter(f => f !== key)
-                                                                    : [...m.dataFlags, key];
-                                                                return { ...m, dataFlags: next.length ? next : m.dataFlags };
-                                                            })}
+                                                            onClick={() => setRunMetadata(m => ({ ...m, dataFlags: [key] }))}
                                                             className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-[var(--color-surface-sunken)] text-faint border-[var(--color-border)] hover:border-[var(--color-border)]'}`}
                                                         >
                                                             {label}
@@ -1852,9 +1844,9 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                             <div>
                                 <h3 className="section-title mb-4">Edit Record</h3>
                                 <div className="space-y-3">
-                                    {/* Data-type flags — multi-select, at least one must remain active */}
+                                    {/* Role — exactly one. A run is a charging test or a range test. */}
                                     <div>
-                                        <p className="text-xs text-muted mb-1">Data types (select all that apply)</p>
+                                        <p className="text-xs text-muted mb-1">Data type</p>
                                         <div className="data-type-flags">
                                             {DATA_FLAGS.map(({ key, label, pillStyle, desc }) => {
                                                 const active = (editFormData.dataFlags || ['charging']).includes(key);
@@ -1863,13 +1855,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                         key={key}
                                                         type="button"
                                                         title={desc}
-                                                        onClick={() => setEditFormData(f => {
-                                                            const cur = f.dataFlags || ['charging'];
-                                                            const next = active
-                                                                ? cur.filter(x => x !== key)
-                                                                : [...cur, key];
-                                                            return { ...f, dataFlags: next.length ? next : cur };
-                                                        })}
+                                                        onClick={() => setEditFormData(f => ({ ...f, dataFlags: [key] }))}
                                                         className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${active ? pillStyle : 'bg-[var(--color-surface-sunken)] text-faint border-[var(--color-border)] hover:border-[var(--color-border)]'}`}
                                                     >
                                                         {label}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -254,8 +254,7 @@ export function AppProvider({ children }) {
             const normalized = {};
             for (const [k, v] of Object.entries(updates)) {
                 switch (k) {
-                    case 'hasCharging':     normalized.has_charging       = v;         break;
-                    case 'hasRange':        normalized.has_range          = v;         break;
+                    case 'kind':            normalized.kind               = v;         break;
                     case 'softwareVersion': normalized.software_version   = v;         break;
                     case 'startSoc':        normalized.start_soc          = toNum(v);  break;
                     case 'endSoc':          normalized.end_soc            = toNum(v);  break;

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1,7 +1,7 @@
 import { getSupabase } from './supabase';
 import { vehicleLabel } from '../utils/specHelpers';
 import { roundTo, } from '../utils/unitConversions';
-import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId } from '../utils/runUtils';
+import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId, runKindFrom } from '../utils/runUtils';
 
 const roundField = roundTo;
 
@@ -517,8 +517,7 @@ class DataService {
       color: run.color || '#3b82f6',
       is_default: coalesce(run.isDefault,  run.is_default)  || false,
       synthetic:  coalesce(run.synthetic,  run.synthetic)   || false,
-      has_charging: coalesce(run.hasCharging, run.has_charging) ?? true,
-      has_range:    coalesce(run.hasRange,    run.has_range)    ?? false,
+      kind: runKindFrom(run),
       source: run.source || null,
       start_soc:         numField(run.startSoc,        run.start_soc),
       end_soc:           numField(run.endSoc,          run.end_soc),
@@ -571,8 +570,7 @@ class DataService {
       name: updates.name, date: updates.date,
       software_version: updates.softwareVersion, conditions: updates.conditions, color: updates.color,
       ...(updates.calculated_fields !== undefined ? { calculated_fields: updates.calculated_fields } : {}),
-      ...(updates.hasCharging !== undefined ? { has_charging: updates.hasCharging } : {}),
-      ...(updates.hasRange    !== undefined ? { has_range:    updates.hasRange    } : {}),
+      ...(updates.kind !== undefined ? { kind: updates.kind } : {}),
       ...(updates.source !== undefined ? { source: updates.source || null } : {}),
       ...(updates.startSoc !== undefined ? { start_soc: updates.startSoc !== '' ? Number(updates.startSoc) : null } : {}),
       ...(updates.endSoc !== undefined ? { end_soc: updates.endSoc !== '' ? Number(updates.endSoc) : null } : {}),
@@ -607,10 +605,21 @@ class DataService {
       localStorage.setItem('evData', JSON.stringify(data));
       return;
     }
-    // Clear all defaults for this vehicle first (runs + inherited links) so
-    // exactly one run is ever marked as default at a time.
-    await getSupabase().from('runs').update({ is_default: false }).eq('vehicle_id', vehicleId);
-    await getSupabase().from('spec_links').update({ is_default: false }).eq('target_vehicle_id', vehicleId);
+    // Defaults are scoped PER KIND since migration 046: a vehicle has both a
+    // default charging run (the fallback curve) and a default range test (rank 2
+    // of the range-source order). Clearing across both would make setting one
+    // silently unset the other.
+    const { data: target } = await getSupabase()
+      .from('runs').select('kind').eq('id', runId).single();
+    const kind = target?.kind ?? 'charging';
+
+    await getSupabase().from('runs')
+      .update({ is_default: false }).eq('vehicle_id', vehicleId).eq('kind', kind);
+    // Inherited runs are charging curves, so they only compete with that kind.
+    if (kind === 'charging') {
+      await getSupabase().from('spec_links')
+        .update({ is_default: false }).eq('target_vehicle_id', vehicleId);
+    }
     const { error } = await getSupabase().from('runs').update({ is_default: true }).eq('id', runId);
     if (error) throw error;
   }
@@ -1529,8 +1538,7 @@ class DataService {
   //
   // Deliberately separate from `runs`: a session yields ~8 launches in 90
   // seconds, and runs rows feed the charging/range selectors and vehicle-card
-  // counts (isChargingRun treats anything without has_charging=false as a
-  // charging run). See migration 036 for the full rationale.
+  // counts. See migration 036 for the full rationale.
 
   /**
    * Performance sessions with runs and split points nested, for one vehicle or

--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -6,30 +6,30 @@
 //   isXxxRun(run)        — predicate, takes a single run, returns boolean.
 //                          Use as a runFilter prop: <RunSelector runFilter={isChargingRun} />
 
-// `kind` (migration 044) is the discriminator; the has_charging / has_range
-// booleans it replaced are still written by the app and kept in sync by a DB
-// trigger until #155 drops them. Reading kind-first with a boolean fallback
-// means this works whether or not migration 044 has been applied yet, so code
-// and migration can be deployed in either order.
+// `kind` is the discriminator, NOT NULL since migration 044 and authoritative
+// since 046 split the last dual-role rows and dropped the has_charging /
+// has_range pair it replaced.
 //
-// Note the fallback keeps the old asymmetry deliberately: a run with neither
-// flag set counts as charging (has_charging !== false), matching how these
-// predicates have always behaved. Migration 044 backfills those rows the same
-// way, so the two paths agree.
-export const isChargingRun = (r) => r.kind ? r.kind === 'charging' : r.has_charging !== false;
+// Both predicates used to carry transitional clauses — a boolean fallback here,
+// and `|| !!r.has_range` there, because a dual-role row was genuinely both roles
+// and one column could not say so. Those are gone with the columns they read.
+export const isChargingRun = (r) => r.kind === 'charging';
+export const isRangeRun    = (r) => r.kind === 'range';
 
-// `kind` alone CANNOT decide this one until #155 runs.
-//
-// A dual-role row — one drive recorded as a single run, with both flags set —
-// is genuinely both a charging test and a range test, and a single discriminator
-// cannot say so. The backfill assigns it kind='charging' (it is split into two
-// rows in #155), so testing kind alone would drop every such row out of the
-// range views. On the current database that is 35 of 76 runs.
-//
-// So has_range stays part of this predicate through the transition. After #155
-// the column is gone, `r.has_range` is undefined, and this collapses to the
-// kind check on its own with no further edit.
-export const isRangeRun = (r) => r.kind === 'range' || !!r.has_range;
+/**
+ * The `kind` to persist for a run being created or edited.
+ *
+ * Accepts `kind` directly, or the legacy hasCharging/hasRange pair that callers
+ * used before migration 046 dropped those columns. A caller that still asks for
+ * BOTH gets 'charging': a row has one role now, and the range half of a combined
+ * upload has to be created separately — see the importer note on #155.
+ */
+export function runKindFrom(run) {
+    if (run?.kind === 'charging' || run?.kind === 'range') return run.kind;
+    const wantsRange    = run?.hasRange    ?? run?.has_range    ?? false;
+    const wantsCharging = run?.hasCharging ?? run?.has_charging ?? true;
+    return (wantsRange && !wantsCharging) ? 'range' : 'charging';
+}
 
 export const filterChargingRuns = (runs) => (runs || []).filter(isChargingRun);
 export const filterRangeRuns    = (runs) => (runs || []).filter(isRangeRun);

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -80,11 +80,9 @@ One charging or range test session per vehicle.
 | `name` | `text` | — | |
 | `date` | `text` | — | ISO date string. **NOT NULL** — inserts must supply it |
 | `color` | `text` | `'#3b82f6'` | Chart series color |
-| `is_default` | `boolean` | `false` | |
+| `is_default` | `boolean` | `false` | Scoped **per kind** since 046: a vehicle has one default charging run and one default range test |
 | `synthetic` | `boolean` | `false` | True for estimated/simulated data |
-| `kind` | `text` | — | `'charging'` \| `'range'`. Test role discriminator. Derived from the two booleans below by trigger `trg_runs_sync_kind`; see migration 044 |
-| `has_charging` | `boolean` | `true` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
-| `has_range` | `boolean` | `false` | **Superseded by `kind`** — still written, no longer read. Dropped in #155 |
+| `kind` | `text` | `'charging'` | `'charging'` \| `'range'`. Test role discriminator, authoritative since migration 046. CHECK constraints assert a charging row carries no range columns (`distance_miles`, `energy_kwh`, `speed_mph`, `url`, wind) and a range row carries no charging columns (`charging_url`, `charge_energy_kwh`) |
 | `session_id` | `bigint` | `NULL` | FK → `test_sessions.id` ON DELETE SET NULL. Advisory grouping; never required |
 | `paired_charging_run_id` | `bigint` | `NULL` | FK → `runs.id` ON DELETE SET NULL. Curator-set default charging test for a **range** test (migration 045). Overrides the automatic pick; a URL pairing still overrides this |
 | `software_version` | `text` | — | |

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -78,7 +78,7 @@ One charging or range test session per vehicle.
 | `id` | `bigint` | auto | PK |
 | `vehicle_id` | `bigint` | — | FK → `vehicles.id` |
 | `name` | `text` | — | |
-| `date` | `text` | — | ISO date string. **NOT NULL** — inserts must supply it |
+| `date` | `date` | — | **NOT NULL** — inserts must supply it. (Documented as `text` until 2026-08-08; it is a real `date` column, which matters for casts in SQL) |
 | `color` | `text` | `'#3b82f6'` | Chart series color |
 | `is_default` | `boolean` | `false` | Scoped **per kind** since 046: a vehicle has one default charging run and one default range test |
 | `synthetic` | `boolean` | `false` | True for estimated/simulated data |

--- a/supabase/migrations/046_split_dual_role_runs.sql
+++ b/supabase/migrations/046_split_dual_role_runs.sql
@@ -90,8 +90,9 @@ CREATE TEMP TABLE session_map (
 WITH inserted AS (
     INSERT INTO test_sessions (name, tested_at, temperature_f, notes)
     SELECT r.name,
-           -- runs.date is text; only a parseable date becomes a timestamp.
-           CASE WHEN r.date ~ '^\d{4}-\d{2}-\d{2}' THEN r.date::timestamp ELSE NULL END,
+           -- runs.date is a DATE column (SCHEMA.md said text — it is not), so it
+           -- casts straight to the session's zone-less timestamp.
+           r.date::timestamp,
            r.temperature_f,
            'Created by migration 046 from a dual-role run.'
     FROM runs r

--- a/supabase/migrations/046_split_dual_role_runs.sql
+++ b/supabase/migrations/046_split_dual_role_runs.sql
@@ -14,9 +14,16 @@
 -- and the charging curve is the time series those data points are. The range
 -- half is a new row. Nothing has to be re-pointed.
 --
--- Expected result on the live database (census taken 2026-08-05):
---     35 dual-role rows in  →  35 new range rows + 35 sessions
---     total runs 76 → 111,  range-bearing runs 57 → 57 (unchanged in meaning)
+-- The shape of the result, whatever the count: N dual-role rows in → N new
+-- range rows + N sessions out, total runs N higher.
+--
+-- Do not trust a remembered N. A census on 2026-08-05 found 35 dual-role rows;
+-- by 2026-08-08 it was 28, after duplicate charging tests were retired. Take the
+-- count immediately before running:
+--
+--     SELECT count(*) FILTER (WHERE has_charging AND has_range) AS dual_role,
+--            count(*)                                           AS total
+--     FROM runs;
 -- ============================================================
 
 BEGIN;
@@ -124,8 +131,8 @@ SELECT
     r.avg_wind_speed_mph, r.wind_direction_deg,
     r.trim_id, sm.session_id,
     -- The pairing arrives pre-made: these two halves were measured together, so
-    -- the range row names its charging partner outright. On the live database
-    -- that is ~35 correct pairings with no curation.
+    -- the range row names its charging partner outright — one correct pairing
+    -- per split, with no curation.
     r.id
 FROM runs r
 JOIN session_map sm ON sm.charging_run_id = r.id;
@@ -184,8 +191,8 @@ COMMIT;
 
 -- ── Verification ─────────────────────────────────────────────────────────────
 --
--- 1. The countable expectation — N dual rows in, 2N rows and N sessions out.
---    With the pre-split census of 35 dual of 76 total, expect 111 / 35 / 0:
+-- 1. The countable expectation, against the census taken just before running:
+--    total_runs should rise by exactly N, and sessions should equal N.
 --
 --      SELECT
 --        (SELECT count(*) FROM runs)                              AS total_runs,

--- a/supabase/migrations/046_split_dual_role_runs.sql
+++ b/supabase/migrations/046_split_dual_role_runs.sql
@@ -28,36 +28,46 @@
 
 BEGIN;
 
--- ── Guard: refuse to run against unexpected data ─────────────────────────────
+-- ── 0. Clear vestigial off-role columns ──────────────────────────────────────
 --
--- The CHECK constraints below assert that off-role columns are NULL. A row that
--- is NOT dual-role but carries a column belonging to the other role would fail
--- them, and a bare constraint violation says little. Fail early with counts
--- instead, so the cause is legible and the transaction rolls back untouched.
+-- Some rows that are NOT dual-role still carry a column belonging to the other
+-- role. On the live database these are six charging tests whose range values
+-- were duplicated across charging events and then un-flagged as range — the
+-- numbers are leftovers, reviewed and confirmed as not belonging to those runs.
+-- Their `kind` already says charging, so nothing reads them; they would simply
+-- fail the CHECK constraints added at the end.
+--
+-- Cleared explicitly and counted out loud, rather than being silently dropped by
+-- a wider UPDATE or blocking the migration behind a constraint violation that
+-- would name neither the rows nor the reason.
 DO $$
 DECLARE
-    bad_charging int;
-    bad_range    int;
+    cleared_charging int;
+    cleared_range    int;
 BEGIN
-    SELECT count(*) INTO bad_charging
-    FROM runs
-    WHERE NOT (has_charging AND has_range)          -- dual rows are handled below
-      AND kind = 'charging'
-      AND (distance_miles IS NOT NULL OR energy_kwh IS NOT NULL
-           OR speed_mph IS NOT NULL OR url IS NOT NULL
-           OR avg_wind_speed_mph IS NOT NULL OR wind_direction_deg IS NOT NULL);
+    WITH stripped AS (
+        UPDATE runs
+        SET distance_miles = NULL, energy_kwh = NULL, speed_mph = NULL,
+            url = NULL, avg_wind_speed_mph = NULL, wind_direction_deg = NULL
+        WHERE NOT (has_charging AND has_range)      -- dual rows are split below
+          AND kind = 'charging'
+          AND (distance_miles IS NOT NULL OR energy_kwh IS NOT NULL
+               OR speed_mph IS NOT NULL OR url IS NOT NULL
+               OR avg_wind_speed_mph IS NOT NULL OR wind_direction_deg IS NOT NULL)
+        RETURNING 1
+    ) SELECT count(*) INTO cleared_charging FROM stripped;
 
-    SELECT count(*) INTO bad_range
-    FROM runs
-    WHERE NOT (has_charging AND has_range)
-      AND kind = 'range'
-      AND (charging_url IS NOT NULL OR charge_energy_kwh IS NOT NULL);
+    WITH stripped AS (
+        UPDATE runs
+        SET charging_url = NULL, charge_energy_kwh = NULL
+        WHERE NOT (has_charging AND has_range)
+          AND kind = 'range'
+          AND (charging_url IS NOT NULL OR charge_energy_kwh IS NOT NULL)
+        RETURNING 1
+    ) SELECT count(*) INTO cleared_range FROM stripped;
 
-    IF bad_charging > 0 OR bad_range > 0 THEN
-        RAISE EXCEPTION
-            'Refusing to split: % charging run(s) carry range-only columns and % range run(s) carry charging-only columns. Inspect them before running this migration — the CHECK constraints would reject them.',
-            bad_charging, bad_range;
-    END IF;
+    RAISE NOTICE 'Cleared vestigial columns: % charging run(s) carrying range values, % range run(s) carrying charging values.',
+        cleared_charging, cleared_range;
 END $$;
 
 

--- a/supabase/migrations/046_split_dual_role_runs.sql
+++ b/supabase/migrations/046_split_dual_role_runs.sql
@@ -112,41 +112,61 @@ JOIN numbered_sessions ns ON ns.rn = nr.rn;
 
 -- ── 2. The range half — a new row ────────────────────────────────────────────
 --
--- start_soc / end_soc are copied to BOTH halves: the charging side needs them
--- for its curve, the range side to price miles per %SoC. Shared context
--- (temperature, elevation, trim, conditions, colour) is copied so each half
--- stands alone in the charts that show it.
+-- Built from the table's ACTUAL columns rather than a hand-written list.
 --
--- is_default is NOT copied — it currently scopes the vehicle's default CHARGING
--- run, and handing that flag to a range row would make it the default for both
--- roles at once. Range defaults resolve by recency until a curator sets one.
+-- The hand-written version failed twice against the live database — once on a
+-- column the documentation described with the wrong type, once on a column the
+-- documentation still listed after migration 018 had dropped it. A list written
+-- from SCHEMA.md tests SCHEMA.md. Reading information_schema tests the database,
+-- copies any column added since, and cannot drift again.
+--
+-- Everything is copied EXCEPT:
+--   id, created_at            — the new row gets its own
+--   has_charging, has_range   — set below; the 044 trigger derives kind from them
+--   session_id, paired_…      — set below
+--   charging_url, charge_energy_kwh
+--                             — charging-only; the CHECK constraint forbids them
+--                               on a range row
+--   is_default                — scopes the default CHARGING run; handing it over
+--                               would make one row the default for both roles
+--   populated_fields, calculated_fields
+--                             — they describe the charging time series, which
+--                               stays with the charging half
+--
+-- start_soc / end_soc are copied by virtue of not being excluded: the charging
+-- side needs them for its curve, the range side to price miles per %SoC.
+DO $$
+DECLARE
+    col_list text;
+    sel_list text;
+BEGIN
+    SELECT string_agg(quote_ident(column_name), ', ' ORDER BY ordinal_position),
+           string_agg('r.' || quote_ident(column_name), ', ' ORDER BY ordinal_position)
+      INTO col_list, sel_list
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'runs'
+      AND column_name NOT IN (
+            'id', 'created_at',
+            'has_charging', 'has_range',
+            'session_id', 'paired_charging_run_id',
+            'charging_url', 'charge_energy_kwh',
+            'is_default',
+            'populated_fields', 'calculated_fields'
+      );
 
-INSERT INTO runs (
-    vehicle_id, name, date, color, synthetic,
-    has_charging, has_range,
-    software_version, conditions, source, url,
-    start_soc, end_soc, speed_mph,
-    distance_miles, energy_kwh,
-    temperature_f, elevation_gain_ft,
-    avg_wind_speed_mph, wind_direction_deg,
-    trim_id, session_id,
-    paired_charging_run_id
-)
-SELECT
-    r.vehicle_id, r.name, r.date, r.color, r.synthetic,
-    false, true,                       -- the trigger derives kind='range' from these
-    r.software_version, r.conditions, r.source, r.url,
-    r.start_soc, r.end_soc, r.speed_mph,
-    r.distance_miles, r.energy_kwh,
-    r.temperature_f, r.elevation_gain_ft,
-    r.avg_wind_speed_mph, r.wind_direction_deg,
-    r.trim_id, sm.session_id,
-    -- The pairing arrives pre-made: these two halves were measured together, so
-    -- the range row names its charging partner outright — one correct pairing
-    -- per split, with no curation.
-    r.id
-FROM runs r
-JOIN session_map sm ON sm.charging_run_id = r.id;
+    EXECUTE format($f$
+        INSERT INTO runs (%s, has_charging, has_range, session_id, paired_charging_run_id)
+        SELECT %s, false, true, sm.session_id,
+               -- The pairing arrives pre-made: these halves were measured
+               -- together, so the range row names its charging partner outright.
+               r.id
+        FROM runs r
+        JOIN session_map sm ON sm.charging_run_id = r.id
+    $f$, col_list, sel_list);
+
+    RAISE NOTICE 'Range halves created by copying columns: %', col_list;
+END $$;
 
 
 -- ── 3. The charging half — the original row, stripped of range columns ───────

--- a/supabase/migrations/046_split_dual_role_runs.sql
+++ b/supabase/migrations/046_split_dual_role_runs.sql
@@ -1,0 +1,218 @@
+-- ============================================================
+-- Migration 046: Split dual-role runs — the destructive one
+--
+-- One drive recorded as a single row, carrying both a charging curve and a
+-- measured range test, becomes two rows joined by a session. That is what the
+-- dual role always meant: not a scientific category, just provenance — "these
+-- were measured together". A session says it explicitly, and can say it across
+-- rows, which a flag on one row never could.
+--
+-- ⚠️ TAKE A BACKUP FIRST. This cannot be un-run. See LocalDev/backup-and-apply.md.
+--
+-- The ORIGINAL row becomes the CHARGING half and keeps its id. That is
+-- deliberate: data_points.run_id and spec_links.source_run_id both point at it,
+-- and the charging curve is the time series those data points are. The range
+-- half is a new row. Nothing has to be re-pointed.
+--
+-- Expected result on the live database (census taken 2026-08-05):
+--     35 dual-role rows in  →  35 new range rows + 35 sessions
+--     total runs 76 → 111,  range-bearing runs 57 → 57 (unchanged in meaning)
+-- ============================================================
+
+BEGIN;
+
+-- ── Guard: refuse to run against unexpected data ─────────────────────────────
+--
+-- The CHECK constraints below assert that off-role columns are NULL. A row that
+-- is NOT dual-role but carries a column belonging to the other role would fail
+-- them, and a bare constraint violation says little. Fail early with counts
+-- instead, so the cause is legible and the transaction rolls back untouched.
+DO $$
+DECLARE
+    bad_charging int;
+    bad_range    int;
+BEGIN
+    SELECT count(*) INTO bad_charging
+    FROM runs
+    WHERE NOT (has_charging AND has_range)          -- dual rows are handled below
+      AND kind = 'charging'
+      AND (distance_miles IS NOT NULL OR energy_kwh IS NOT NULL
+           OR speed_mph IS NOT NULL OR url IS NOT NULL
+           OR avg_wind_speed_mph IS NOT NULL OR wind_direction_deg IS NOT NULL);
+
+    SELECT count(*) INTO bad_range
+    FROM runs
+    WHERE NOT (has_charging AND has_range)
+      AND kind = 'range'
+      AND (charging_url IS NOT NULL OR charge_energy_kwh IS NOT NULL);
+
+    IF bad_charging > 0 OR bad_range > 0 THEN
+        RAISE EXCEPTION
+            'Refusing to split: % charging run(s) carry range-only columns and % range run(s) carry charging-only columns. Inspect them before running this migration — the CHECK constraints would reject them.',
+            bad_charging, bad_range;
+    END IF;
+END $$;
+
+
+-- ── 1. A session per dual-role row ───────────────────────────────────────────
+--
+-- The session carries what both halves shared, so the halves stop repeating it.
+-- Named after the run, since that name is what the tester actually called the
+-- outing; it also becomes the short chart label for the pair (see #170).
+
+CREATE TEMP TABLE dual_split ON COMMIT DROP AS
+SELECT id AS charging_run_id
+FROM runs
+WHERE has_charging AND has_range;
+
+CREATE TEMP TABLE session_map (
+    charging_run_id bigint PRIMARY KEY,
+    session_id      bigint NOT NULL
+) ON COMMIT DROP;
+
+WITH inserted AS (
+    INSERT INTO test_sessions (name, tested_at, temperature_f, notes)
+    SELECT r.name,
+           -- runs.date is text; only a parseable date becomes a timestamp.
+           CASE WHEN r.date ~ '^\d{4}-\d{2}-\d{2}' THEN r.date::timestamp ELSE NULL END,
+           r.temperature_f,
+           'Created by migration 046 from a dual-role run.'
+    FROM runs r
+    JOIN dual_split d ON d.charging_run_id = r.id
+    ORDER BY r.id
+    RETURNING id
+), numbered_sessions AS (
+    SELECT id, row_number() OVER (ORDER BY id) AS rn FROM inserted
+), numbered_runs AS (
+    SELECT charging_run_id, row_number() OVER (ORDER BY charging_run_id) AS rn FROM dual_split
+)
+INSERT INTO session_map (charging_run_id, session_id)
+SELECT nr.charging_run_id, ns.id
+FROM numbered_runs nr
+JOIN numbered_sessions ns ON ns.rn = nr.rn;
+
+
+-- ── 2. The range half — a new row ────────────────────────────────────────────
+--
+-- start_soc / end_soc are copied to BOTH halves: the charging side needs them
+-- for its curve, the range side to price miles per %SoC. Shared context
+-- (temperature, elevation, trim, conditions, colour) is copied so each half
+-- stands alone in the charts that show it.
+--
+-- is_default is NOT copied — it currently scopes the vehicle's default CHARGING
+-- run, and handing that flag to a range row would make it the default for both
+-- roles at once. Range defaults resolve by recency until a curator sets one.
+
+INSERT INTO runs (
+    vehicle_id, name, date, color, synthetic,
+    has_charging, has_range,
+    software_version, conditions, source, url,
+    start_soc, end_soc, speed_mph,
+    distance_miles, energy_kwh,
+    temperature_f, elevation_gain_ft,
+    avg_wind_speed_mph, wind_direction_deg,
+    trim_id, session_id,
+    paired_charging_run_id
+)
+SELECT
+    r.vehicle_id, r.name, r.date, r.color, r.synthetic,
+    false, true,                       -- the trigger derives kind='range' from these
+    r.software_version, r.conditions, r.source, r.url,
+    r.start_soc, r.end_soc, r.speed_mph,
+    r.distance_miles, r.energy_kwh,
+    r.temperature_f, r.elevation_gain_ft,
+    r.avg_wind_speed_mph, r.wind_direction_deg,
+    r.trim_id, sm.session_id,
+    -- The pairing arrives pre-made: these two halves were measured together, so
+    -- the range row names its charging partner outright. On the live database
+    -- that is ~35 correct pairings with no curation.
+    r.id
+FROM runs r
+JOIN session_map sm ON sm.charging_run_id = r.id;
+
+
+-- ── 3. The charging half — the original row, stripped of range columns ───────
+
+UPDATE runs r
+SET has_range          = false,
+    session_id         = sm.session_id,
+    distance_miles     = NULL,
+    energy_kwh         = NULL,
+    speed_mph          = NULL,
+    url                = NULL,
+    avg_wind_speed_mph = NULL,
+    wind_direction_deg = NULL
+FROM session_map sm
+WHERE r.id = sm.charging_run_id;
+
+
+-- ── 4. Retire the transitional machinery ─────────────────────────────────────
+--
+-- `kind` has been derived from the booleans by a trigger since 044, so the app
+-- could read one column while the booleans stayed authoritative on write. With
+-- no dual-role rows left there is nothing for the booleans to say that `kind`
+-- cannot, and keeping them would let the two disagree.
+
+DROP TRIGGER IF EXISTS trg_runs_sync_kind ON runs;
+DROP FUNCTION IF EXISTS runs_sync_kind();
+DROP FUNCTION IF EXISTS runs_derive_kind(boolean, boolean);
+
+ALTER TABLE runs DROP COLUMN has_charging;
+ALTER TABLE runs DROP COLUMN has_range;
+
+ALTER TABLE runs ALTER COLUMN kind SET DEFAULT 'charging';
+
+
+-- ── 5. Enforce the union ─────────────────────────────────────────────────────
+--
+-- Now that a row has exactly one role, say so in the schema rather than trusting
+-- every future insert to remember.
+
+ALTER TABLE runs ADD CONSTRAINT runs_charging_has_no_range_columns CHECK (
+    kind <> 'charging' OR (
+        distance_miles IS NULL AND energy_kwh IS NULL AND speed_mph IS NULL
+        AND url IS NULL AND avg_wind_speed_mph IS NULL AND wind_direction_deg IS NULL
+    )
+);
+
+ALTER TABLE runs ADD CONSTRAINT runs_range_has_no_charging_columns CHECK (
+    kind <> 'range' OR (charging_url IS NULL AND charge_energy_kwh IS NULL)
+);
+
+COMMIT;
+
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+--
+-- 1. The countable expectation — N dual rows in, 2N rows and N sessions out.
+--    With the pre-split census of 35 dual of 76 total, expect 111 / 35 / 0:
+--
+--      SELECT
+--        (SELECT count(*) FROM runs)                              AS total_runs,
+--        (SELECT count(*) FROM test_sessions)                     AS sessions,
+--        (SELECT count(*) FROM runs WHERE session_id IS NOT NULL) AS runs_in_sessions;
+--
+-- 2. Every session holds exactly one charging row and one range row — expect 0:
+--
+--      SELECT count(*) FROM (
+--        SELECT session_id,
+--               count(*) FILTER (WHERE kind = 'charging') AS c,
+--               count(*) FILTER (WHERE kind = 'range')    AS r
+--        FROM runs WHERE session_id IS NOT NULL GROUP BY session_id
+--      ) s WHERE c <> 1 OR r <> 1;
+--
+-- 3. The pairings arrived pre-made — expect one per session:
+--
+--      SELECT count(*) FROM runs WHERE paired_charging_run_id IS NOT NULL;
+--
+-- 4. Nothing lost its time series. data_points stayed with the charging half,
+--    which kept the original id, so this should be unchanged from before:
+--
+--      SELECT count(*) FROM data_points dp
+--      LEFT JOIN runs r ON r.id = dp.run_id WHERE r.id IS NULL;   -- expect 0
+--
+-- 5. Inherited runs still resolve — spec_links point at charging rows, which
+--    kept their ids — expect 0:
+--
+--      SELECT count(*) FROM spec_links sl
+--      LEFT JOIN runs r ON r.id = sl.source_run_id WHERE r.id IS NULL;


### PR DESCRIPTION
Closes #155. The last phase of #150, and the only destructive one.

## ⚠️ Deploy order is a hard requirement

**Apply migration 046, then deploy the code.** They are not independent, and both wrong orders are bad:

- **Code before migration:** verified against the live database — Charge Compare drops from **73 range rows to 38**, because dual-role rows still carry `kind='charging'` and `isRangeRun` no longer looks at `has_range`.
- **Migration before code** is fine for reads, but any run created in that window would break, since the app still writes columns that no longer exist.

Take a backup first. `LocalDev/backup-and-apply.md` has the procedure.

## What the migration does

One drive recorded as a single row carrying both a charging curve and a measured range test becomes **two rows joined by a session**. That is what the dual role always meant — not a scientific category, just provenance: *"these were measured together"*. A session says it explicitly, and can say it across rows, which a flag on one row never could.

**The original row becomes the charging half and keeps its id.** `data_points.run_id` and `spec_links.source_run_id` both point at it, and the charging curve *is* those data points — so nothing is re-pointed and no inherited run breaks.

- `start_soc` / `end_soc` are copied to **both** halves: the charging side needs them for its curve, the range side to price miles per %SoC.
- `is_default` is **not** copied — it scopes the default *charging* run, and handing it to a range row would make it the default for both roles at once.
- Each range half is created with `paired_charging_run_id` pointing at its charging half, so **the pairing arrives pre-made** — one correct pairing per split, no curation.
- Six charging tests carry vestigial range values (range data that was duplicated across charging events, then un-flagged). Reviewed and confirmed as not belonging to those runs; the migration clears them and **counts them out loud in a NOTICE** rather than folding them into a silent UPDATE or blocking behind a constraint violation.
- Then the transitional machinery retires: the sync trigger and its two functions, and the `has_charging` / `has_range` pair, replaced by CHECK constraints asserting a row carries only its own role's columns.

**Do not trust a remembered count.** A census on 5 Aug found 35 dual-role rows; on 8 Aug it was 28, after duplicate charging tests were retired. Take it immediately before running:

```sql
SELECT count(*) FILTER (WHERE has_charging AND has_range) AS dual_role, count(*) AS total FROM runs;
```

## What the code does

- `isChargingRun` / `isRangeRun` read `kind` alone. Both carried transitional clauses — a boolean fallback in one, `|| !!r.has_range` in the other, because a dual-role row was genuinely both roles and one column could not say so. Those expire with the columns they read, exactly as predicted when they were written.
- `runKindFrom()` is the single derivation for writes.
- `setDefaultRun` is **scoped per kind**: a vehicle has a default charging run *and* a default range test (rank 2 of the range-source order), so clearing across both would make setting one silently unset the other.
- The run editor's two role checkboxes become a single choice, in both create and edit forms. Selecting both is no longer a state the schema allows.

## Testing

Migration run end to end on a throwaway PostgreSQL 18 cluster carrying 044 and 045, with fixtures for dual-role, pure-charging, pure-range and a vestigial-column row, plus data points and a spec link:

- 2 dual of 5 rows → 7 runs, 2 sessions, 2 pre-made pairings
- every session holds exactly one charging and one range row
- data points intact and unorphaned; spec links still resolve
- charging halves stripped of range columns, range halves keep them, SoC on both
- the vestigial row keeps its SoC bounds, `charging_url` and `charge_energy_kwh`, losing only the leftover range values
- constraints reject off-role columns and an invalid kind; valid rows still insert
- booleans, trigger and both functions gone

Not re-runnable: it drops columns it also reads. One shot, after a backup.

## Deferred — flagged, not forgotten

The CSV/Tableau importer still creates **one** run from a file carrying both column sets. It is the largest piece of this phase, it does not block the split, and the second half can be added by hand until it lands. Tracked on #155.

Also unchanged: the `RunsView` session card. Sessions exist in the database and the pairings are pre-made; the card is presentation and can follow.