### PR TITLE
Select one row per vehicle by default

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ import PerformanceCurveView from './components/PerformanceCurveView';
 import AdminView from './components/AdminView';
 import { CHART_CATEGORIES, DEFAULT_CHART_MODE, ALL_CHART_MODES, categoryForMode, categoryByKey, isChartCategory } from './constants/chartNav';
 import { encodePairings, decodePairings, prunePairings } from './utils/pairings';
-import { EPA_PARTNER_ID } from './utils/rangeSource';
+import { isEpaPartnerId } from './utils/rangeSource';
 
 export default function App() {
     const {
@@ -423,9 +423,11 @@ export default function App() {
         const liveRunIds = vehicles
             .filter(v => selectedVehicles.includes(v.id))
             .flatMap(v => (v.runs || []).map(r => r.id));
-        // EPA rated range is a valid pairing side with no run behind it, so it
-        // would otherwise be pruned as an unknown id on every selection change.
-        liveRunIds.push(EPA_PARTNER_ID);
+        // EPA rated range is a valid pairing side with no run behind it, so its
+        // per-vehicle ids would otherwise be pruned as unknown on every change.
+        for (const v of vehicles) {
+            if (selectedVehicles.includes(v.id) && v.range > 0) liveRunIds.push(`epa:${v.id}`);
+        }
         setPairings(prev => {
             const pruned = prunePairings(prev, liveRunIds);
             // Same-value guard: returning a fresh object every time would retrigger

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Chart from 'chart.js/auto';
 import { dataService } from '../services/DataService';
 import RunSelector from './RunSelector';
@@ -8,7 +8,7 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, fmtSpeed, fmtTemp, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
-import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { resolveRangeSource, epaRangeOption, defaultRangeRun, isEpaPartnerId, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import { useRunSelection } from '../hooks/useRunSelection';
 import LoadingSpinner from './LoadingSpinner';
@@ -347,7 +347,7 @@ export default function ChargeCompareView({
                     // matter when the chosen test carries no usable data.
                     const rangeSrc = resolveRangeSource(chargingRun, {
                         vehicle,
-                        explicitPairing: rangeRun.id === EPA_PARTNER_ID ? EPA_PARTNER_ID : rangeRun,
+                        explicitPairing: isEpaPartnerId(rangeRun.id) ? EPA_PARTNER_ID : rangeRun,
                     });
 
                     result.push({
@@ -423,11 +423,34 @@ export default function ChargeCompareView({
         () => resolvedPairs.map(p => ({
             key: p.key,
             vehicleId: p.rangeRun.vehicleId,
-            groupId: p.rangeRun.id,     // survives a repin, which changes the key
+            // Scoped to the vehicle: the EPA row's id is a shared sentinel, so a
+            // bare run id would make every vehicle's EPA row one group and the
+            // hook's carry rule would select them all together.
+            groupId: `${p.rangeRun.vehicleId}:${p.rangeRun.id}`,
         })),
         [resolvedPairs]
     );
-    const { selected: selectedRuns, toggle: toggleRun } = useRunSelection(selectionRows);
+
+    // One row per vehicle on arrival, not every range test. A car with a dozen
+    // range tests buries the chart otherwise, and the per-vehicle "all" link is
+    // there for when you want the rest.
+    //
+    // Prefers the vehicle's default range test, falling back to its first row:
+    // defaultRangeRun() requires measurable distance/SoC data, and a range test
+    // without it would otherwise leave the vehicle with nothing selected at all.
+    const bootstrapOneRow = useCallback((vehicleId, vehicleRows) => {
+        const vehicle = selectedVehicles.find(v => v.id === vehicleId);
+        const preferred = vehicle ? defaultRangeRun(vehicle) : null;
+        const match = preferred
+            ? vehicleRows.find(r => String(r.groupId) === `${vehicleId}:${preferred.id}`)
+            : null;
+        const pick = match ?? vehicleRows[0];
+        return pick ? [pick.key] : [];
+    }, [selectedVehicles]);
+
+    const { selected: selectedRuns, toggle: toggleRun } = useRunSelection(
+        selectionRows, { shouldBootstrap: bootstrapOneRow }
+    );
 
     const activePairs = resolvedPairs.filter(p => selectedRuns.includes(p.key));
 

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -14,7 +14,7 @@ import { useTheme } from '../hooks/useTheme';
 import { convDistance, convTemp, distanceLabel, tempLabel } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isChargingRun, isRangeRun } from '../utils/runUtils';
 import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
-import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { resolveRangeSource, epaRangeOption, isEpaPartnerId, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
 import { resolveChartColors } from '../utils/colorUtils';
@@ -210,7 +210,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             const pairedRangeIds = rangePartnersOfCharging(pairings, runId);
                             const own = (parentVehicle?.runs || []).filter(r => !r._inherited && isRangeRun(r));
                             const pairedRange = pairedRangeIds.length
-                                ? (pairedRangeIds[0] === EPA_PARTNER_ID
+                                ? (isEpaPartnerId(pairedRangeIds[0])
                                     ? EPA_PARTNER_ID
                                     : own.find(r => String(r.id) === pairedRangeIds[0]) ?? null)
                                 : null;
@@ -228,7 +228,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                 // the real, non-linear shape; prefer it. Most range
                                 // tests are scalar (distance + SoC bounds), so the
                                 // linear miPerSoc model is the usual path.
-                                if (src.sourceRun?.id && src.sourceRun.id !== EPA_PARTNER_ID) {
+                                if (src.sourceRun?.id && !isEpaPartnerId(src.sourceRun.id)) {
                                     try {
                                         lookup = await dataService.buildRangePerSocLookup(src.sourceRun.id);
                                     } catch (_) { /* fall through to linear */ }

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Chart from 'chart.js/auto';
 import ZoomPlugin from 'chartjs-plugin-zoom';
 import { vehicleLabel } from '../utils/specHelpers';
@@ -7,7 +7,7 @@ import { useAppContext } from '../context/AppContext';
 import { useTheme } from '../hooks/useTheme';
 import { convDistance, distanceLabel, speedLabel, fmtSpeed, MI_TO_KM } from '../utils/unitConversions';
 import { filterChargingRuns, filterRangeRuns, isRangeRun, pairedChargingRun } from '../utils/runUtils';
-import { resolveRangeSource, epaRangeOption, EPA_PARTNER_ID } from '../utils/rangeSource';
+import { resolveRangeSource, epaRangeOption, defaultRangeRun, isEpaPartnerId, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { pairKey, partnersFor, addPartner, replacePartner, removePartner } from '../utils/pairings';
 import RunSelector from './RunSelector';
 import AxisScaleControls from './AxisScaleControls';
@@ -439,7 +439,7 @@ export default function RoadTripView({
                     const src = resolveRangeSource(chargingRun, {
                         vehicle,
                         batteryKwh: vehicle.battery,
-                        explicitPairing: rangeRun.id === EPA_PARTNER_ID ? EPA_PARTNER_ID : rangeRun,
+                        explicitPairing: isEpaPartnerId(rangeRun.id) ? EPA_PARTNER_ID : rangeRun,
                     });
 
                     const key = pairKey(rangeRun.id, partnerId);
@@ -476,12 +476,33 @@ export default function RoadTripView({
         () => [...allPairsInfo.values()].map(e => ({
             key: e.key,
             vehicleId: e.vehicle.id,
-            groupId: e.rangeRun.id,     // survives a repin, which changes the key
+            // Scoped to the vehicle: the EPA row's id is a shared sentinel, so a
+            // bare run id would make every vehicle's EPA row one group and the
+            // hook's carry rule would select them all together.
+            groupId: `${e.vehicle.id}:${e.rangeRun.id}`,
         })),
         [allPairsInfo]
     );
+
+    // One row per vehicle on arrival, not every range test. A car with a dozen
+    // range tests buries the chart otherwise, and the per-vehicle "all" link is
+    // there for when you want the rest.
+    //
+    // Prefers the vehicle's default range test, falling back to its first row:
+    // defaultRangeRun() requires measurable distance/SoC data, and a range test
+    // without it would otherwise leave the vehicle with nothing selected at all.
+    const bootstrapOneRow = useCallback((vehicleId, vehicleRows) => {
+        const vehicle = selectedVehicles.find(v => v.id === vehicleId);
+        const preferred = vehicle ? defaultRangeRun(vehicle) : null;
+        const match = preferred
+            ? vehicleRows.find(r => String(r.groupId) === `${vehicleId}:${preferred.id}`)
+            : null;
+        const pick = match ?? vehicleRows[0];
+        return pick ? [pick.key] : [];
+    }, [selectedVehicles]);
+
     const { selected: selectedRunIds, toggle: toggleRunId } = useRunSelection(
-        selectionRows, { initial: initialRunIds }
+        selectionRows, { initial: initialRunIds, shouldBootstrap: bootstrapOneRow }
     );
 
     // ── Active run entries — ordered by vehicle pill position ─────────────────

--- a/src/utils/rangeSource.js
+++ b/src/utils/rangeSource.js
@@ -66,10 +66,28 @@ import { isRangeRun } from './runUtils';
  */
 export const EPA_PARTNER_ID = 'epa';
 
+/**
+ * The EPA row's id is scoped PER VEHICLE — 'epa:12', not a bare 'epa'.
+ *
+ * Selections and chart series are keyed by run id, so a sentinel shared across
+ * vehicles collides: every vehicle's EPA row computed the same key, so one
+ * selection rendered all of them as chosen, toggling one toggled all, and the
+ * chart plotted every vehicle's EPA bar at once.
+ */
+export function epaPartnerId(vehicle) {
+    return `${EPA_PARTNER_ID}:${vehicle?.id}`;
+}
+
+/** True for any EPA row id, scoped or bare. */
+export function isEpaPartnerId(id) {
+    const s = String(id ?? '');
+    return s === EPA_PARTNER_ID || s.startsWith(`${EPA_PARTNER_ID}:`);
+}
+
 /** The EPA option for a vehicle's partner dropdown, or null when it has no rated range. */
 export function epaRangeOption(vehicle) {
     return vehicle?.range > 0
-        ? { id: EPA_PARTNER_ID, name: 'EPA range', _synthetic: true }
+        ? { id: epaPartnerId(vehicle), name: 'EPA range', _synthetic: true }
         : null;
 }
 
@@ -192,7 +210,7 @@ export function resolveRangeSource(chargingRun, {
     // one percent of SoC buys one hundredth of it. Only ever reachable by
     // explicit choice — it is never resolved automatically, because a real
     // measured test on this vehicle is always the better default.
-    const wantsEpa = explicitPairing === EPA_PARTNER_ID || explicitPairing?.id === EPA_PARTNER_ID;
+    const wantsEpa = isEpaPartnerId(explicitPairing) || isEpaPartnerId(explicitPairing?.id);
     if (wantsEpa && vehicle?.range > 0) {
         return {
             source: 'epa',


### PR DESCRIPTION
Closes #175.

## The change

Charge Compare and Road Trip opened with **every** range test of every vehicle selected — 66 rows — which buried the charts. They now select exactly **one row per vehicle**, through the `shouldBootstrap` seam `useRunSelection` already carried for this purpose.

The rule: the vehicle's **default range test**, falling back to its **first row**. `defaultRangeRun()` requires measurable distance/SoC data, and applying it alone selected *nothing at all* on this database — the fallback is what makes the rule usable rather than theoretical. That was the reason this was reverted the first time it was attempted, in #173.

The per-vehicle **all / none** links remain for pulling the rest in.

## A real bug this exposed

The EPA row's id was the bare sentinel `'epa'` — **identical across every vehicle**. Selections and chart series are keyed by run id, so all 22 EPA rows computed the same pair key. Consequences, all live before this PR:

- one selection rendered **every** EPA row as chosen — the header read *44 selected* against 26 actual
- toggling one vehicle's EPA row would have toggled all of them
- the chart would have plotted every vehicle's EPA bar together

EPA ids are now scoped per vehicle (`epa:12`), with `isEpaPartnerId()` accepting either form so resolution still recognises them. Selection **groups** are scoped to the vehicle too, since the hook's carry rule matches on group and a shared group id dragged every vehicle's EPA row along with the first.

## Testing

In the browser, against the post-046 database:

- **Charge Compare:** 26 selected of 66 rows, across 26 vehicles, exactly one each, zero offenders
- **Road Trip:** same 26, simulating 25 (one vehicle lacks usable efficiency data)
- The four EPA rows still selected belong to vehicles whose *only* row is EPA — correct
- No console errors

`vite build` clean.

## Note

Road Trip briefly blanked during development because `useCallback` was imported into one component and not the other — caught and fixed before commit, mentioned only because a white screen from a missing import is worth recognising quickly if it recurs.