### PR TITLE
Hold auto-assigned chart colours steady as runs are toggled

### DIFF
--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -17,7 +17,7 @@ import { rangePartnersOfCharging, setChargingPartner } from '../utils/pairings';
 import { resolveRangeSource, epaRangeOption, isEpaPartnerId, EPA_PARTNER_ID } from '../utils/rangeSource';
 import { copyChartAsPng, chartToPngDataUrl } from '../utils/chartUtils';
 import LoadingSpinner from './LoadingSpinner';
-import { resolveChartColors } from '../utils/colorUtils';
+import { useStickyChartColors } from '../hooks/useStickyChartColors';
 import ChartInfoBubble from './ChartInfoBubble';
 
 export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig, setChartConfig, onUpdateRunColor, chartMode, pairings = {}, setPairings = () => {}, presentationMode = false }) {
@@ -41,12 +41,18 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
     // Resolve display colors for all selected runs.
     // In 'manual' mode only default-blue runs get nudged; in 'auto' mode all
     // runs get Okabe-Ito assignment with hue-family bias toward their stored color.
-    const colorMap = useMemo(() => {
-        const runs = selectedVehicles.flatMap(v =>
+    // Sticky in auto mode: toggling a run adds or removes ONE colour instead of
+    // re-solving the whole set and shuffling every series (hooks/useStickyChartColors).
+    const colorableRuns = useMemo(
+        () => selectedVehicles.flatMap(v =>
             (v.runs || []).filter(r => chartConfig.selectedRuns.includes(r.id))
-        );
-        return resolveChartColors(runs, {}, chartConfig.autoColor ? 'auto' : 'manual');
-    }, [selectedVehicles, chartConfig.selectedRuns, chartConfig.autoColor]);
+        ),
+        [selectedVehicles, chartConfig.selectedRuns]
+    );
+    const colorMap = useStickyChartColors(colorableRuns, {
+        autoColor: chartConfig.autoColor,
+        resetKey: selectedVehicleIds.join(','),
+    });
 
     // Ref so the auto-select effect can read chartMode without it being a dep
     // (avoids changing the deps array size, which React disallows mid-session).

--- a/src/components/RangeChartView.jsx
+++ b/src/components/RangeChartView.jsx
@@ -14,7 +14,7 @@ import {
 } from '../utils/unitConversions';
 import { filterRangeRuns, isRangeRun } from '../utils/runUtils';
 import { copyChartAsPng } from '../utils/chartUtils';
-import { resolveChartColors } from '../utils/colorUtils';
+import { useStickyChartColors } from '../hooks/useStickyChartColors';
 import ChartInfoBubble from './ChartInfoBubble';
 
 // ── Chart type definitions ────────────────────────────────────────────────────
@@ -100,10 +100,13 @@ export default function RangeChartView({ selectedVehicles, selectedRuns, setChar
     // Perceptual color resolution.  In auto mode every run gets an Okabe-Ito
     // slot (with hue-family bias toward the stored color); in manual mode only
     // default-blue runs are nudged.
-    const colorMap = useMemo(
-        () => resolveChartColors(plottableRuns, {}, autoColor ? 'auto' : 'manual'),
-        [plottableRuns, autoColor]
-    );
+    // Sticky in auto mode — see hooks/useStickyChartColors. Colours are added as
+    // runs are selected and held until the vehicle set changes or Auto Color is
+    // cycled, so the chart you were reading does not recolour under you.
+    const colorMap = useStickyChartColors(plottableRuns, {
+        autoColor,
+        resetKey: selectedVehicles.map(v => v.id).join(','),
+    });
 
     // ── Run toggle ────────────────────────────────────────────────────────────
     const toggleRun = (runId) => {

--- a/src/hooks/useStickyChartColors.js
+++ b/src/hooks/useStickyChartColors.js
@@ -1,0 +1,56 @@
+import { useMemo, useRef } from 'react';
+import { resolveChartColors } from '../utils/colorUtils';
+
+/**
+ * Auto-assigned chart colours that stay put.
+ *
+ * resolveChartColors assigns Okabe-Ito slots across the whole set at once, so
+ * adding or removing one run re-solved every other run and the chart's colours
+ * shuffled underneath you. Reading a chart you had already made sense of meant
+ * re-reading the legend.
+ *
+ * This remembers what each run was given and feeds those back in as session
+ * overrides, which resolveChartColors treats as highest priority AND adds to its
+ * collision list — so a newly added run picks a slot that avoids the colours
+ * already on screen, and everything already plotted keeps what it had.
+ *
+ * Colours are ADDED, never reshuffled. They reset only when:
+ *   • the vehicle set changes  — a different comparison, so a fresh palette
+ *   • Auto Color is switched off and back on — the explicit "redo this" gesture
+ *
+ * A removed run keeps its remembered colour, so toggling one off and on again
+ * returns it to the same colour rather than moving it to the end of the queue.
+ *
+ * @param {Array}   runs      the runs to colour
+ * @param {Object}  opts
+ * @param {boolean} opts.autoColor  auto mode on/off
+ * @param {string}  opts.resetKey   changes when the vehicle set changes
+ */
+export function useStickyChartColors(runs, { autoColor, resetKey }) {
+    const assigned = useRef({});          // runId → colour, sticky for the session
+    const prevResetKey = useRef(resetKey);
+    const prevAutoColor = useRef(autoColor);
+
+    return useMemo(() => {
+        const cycledBackOn = autoColor && !prevAutoColor.current;
+        if (resetKey !== prevResetKey.current || cycledBackOn) {
+            assigned.current = {};
+        }
+        prevResetKey.current = resetKey;
+        prevAutoColor.current = autoColor;
+
+        // Only auto mode is sticky. Manual mode already honours each run's own
+        // stored colour, so there is nothing to hold still.
+        if (!autoColor) {
+            assigned.current = {};
+            return resolveChartColors(runs, {}, 'manual');
+        }
+
+        const resolved = resolveChartColors(runs, assigned.current, 'auto');
+        // Remember, so the next call holds these in place. Idempotent: React may
+        // run a memo more than once, and re-merging the same answer changes
+        // nothing — unlike a mutation whose result depends on not having run yet.
+        assigned.current = { ...assigned.current, ...resolved };
+        return resolved;
+    }, [runs, autoColor, resetKey]);
+}


### PR DESCRIPTION
User gripe: with Auto Color on, adding or removing a run recoloured the existing series, so a chart you had already made sense of had to be re-read against the legend.

## Cause

`resolveChartColors` assigns Okabe-Ito slots across the **whole set at once**. One more run re-solved every other run.

## Fix

It already accepted a `sessionOverrides` map at highest priority — and seeds those into its collision list. So remembering what each run was given and feeding it back keeps existing series put, while a newly added run still picks a slot that avoids the colours already on screen. No change to the colour algorithm itself; `hooks/useStickyChartColors.js` is a thin memory in front of it.

**Colours are added, never reshuffled.** They reset only on the two gestures that mean "this is a different comparison":

- the **vehicle set** changes
- **Auto Color** is switched off and back on

A removed run keeps its remembered colour, so toggling it off and on again returns it to the same colour rather than sending it to the back of the queue.

## Testing

In the browser, against the live data:

| | |
|---|---|
| Charging — add a run | 28 → 29 series, **0 of 27** shared series changed colour |
| Charging — remove a run | **0 of 28** changed |
| Charging — cycle Auto Color | re-solves, as intended |
| Range & Efficiency — add a run | **0 of 30** bars changed |

`vite build` clean.

## Left alone deliberately

**Road Trip** and **EPA Curves** colour by *vehicle* rather than by the selected subset, so they never had this problem — toggling runs there never shuffled anything. Their colours do change when the vehicle set changes, which is one of the agreed reset conditions regardless. Wiring them would add a memory that never gets used.

## Note on the implementation

The remembered map is merged inside a `useMemo`, which is normally where I would be wary of a side effect — React can run a memo more than once. It is safe here because re-merging the same answer changes nothing, unlike a mutation whose result depends on not having run before. That distinction is called out in the file, since the unsafe version of it caused a bug earlier in this epic.