### PR TITLE
Let a vehicle hold both a default charging run and a default range test

### DIFF
--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -2342,7 +2342,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                     <div className="run-actions-row">
                                         {/* Set Default — ghost text, green on hover, pale blue + × when active */}
                                         <button
-                                            onClick={() => run.isDefault ? clearDefaultRun(vehicle.id) : onSetDefaultRun(run.id)}
+                                            onClick={() => run.isDefault ? clearDefaultRun(vehicle.id, run.id) : onSetDefaultRun(run.id)}
                                             title={!canCreate ? 'Sign in to save changes' : run.isDefault ? 'Click to clear default' : 'Set as default for charts'}
                                             className={`text-sm px-2 py-1 rounded transition-colors ${
                                                 run.isDefault

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { dataService } from '../services/DataService';
+import { applyDefaultRun, clearDefaultRuns } from '../utils/runUtils';
 
 const AppContext = createContext(null);
 
@@ -279,12 +280,15 @@ export function AppProvider({ children }) {
         }
     };
 
-    const clearDefaultRun = async (vehicleId) => {
+    // runId is the run whose default is being cleared. Without it this cleared
+    // every run of the vehicle, so clearing the default range test also cleared
+    // the default charging run — the two are independent since migration 046.
+    const clearDefaultRun = async (vehicleId, runId = null) => {
         try {
-            await dataService.clearDefaultRun(vehicleId);
+            await dataService.clearDefaultRun(vehicleId, runId);
             setVehicles(prev => prev.map(v =>
                 v.id === vehicleId
-                    ? { ...v, runs: v.runs.map(r => ({ ...r, isDefault: false })) }
+                    ? { ...v, runs: clearDefaultRuns(v.runs, runId) }
                     : v
             ));
         } catch (error) {
@@ -296,17 +300,12 @@ export function AppProvider({ children }) {
     const setDefaultRun = async (vehicleId, runId) => {
         try {
             await dataService.setDefaultRun(vehicleId, runId);
+            // Only the runs of the SAME KIND lose their default. The service has
+            // scoped this per kind since #177; the local copy had not, so setting
+            // a default range test cleared the default charging run on screen and
+            // the two disagreed until a reload.
             setVehicles(prev => prev.map(v =>
-                v.id === vehicleId
-                    ? {
-                        ...v,
-                        runs: v.runs.map(r => ({
-                            ...r,
-                            isDefault: r.id === runId
-                        }))
-                    }
-                    : v
-            ));
+                v.id === vehicleId ? { ...v, runs: applyDefaultRun(v.runs, runId) } : v));
         } catch (error) {
             logIfUnauthorized('set_default_run', 'run', runId, error);
             showError('Error setting default run: ' + error.message);

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1,7 +1,7 @@
 import { getSupabase } from './supabase';
 import { vehicleLabel } from '../utils/specHelpers';
 import { roundTo, } from '../utils/unitConversions';
-import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId, runKindFrom } from '../utils/runUtils';
+import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId, runKindFrom, applyDefaultRun, clearDefaultRuns } from '../utils/runUtils';
 
 const roundField = roundTo;
 
@@ -271,7 +271,10 @@ class DataService {
     // When promoting an inherited run to default, first clear all existing
     // defaults for this vehicle so exactly one is ever marked at a time.
     if (changes.useAsDefault && targetVehicleId) {
-      await getSupabase().from('runs').update({ is_default: false }).eq('vehicle_id', targetVehicleId);
+      // Inherited runs are charging curves, so promoting one must not clear the
+      // vehicle's default RANGE test — see setDefaultRun.
+      await getSupabase().from('runs')
+        .update({ is_default: false }).eq('vehicle_id', targetVehicleId).eq('kind', 'charging');
       await getSupabase().from('spec_links').update({ is_default: false }).eq('target_vehicle_id', targetVehicleId);
     }
     const payload = {};
@@ -589,8 +592,28 @@ class DataService {
     if (error) throw error;
   }
 
-  async clearDefaultRun(vehicleId) {
-    if (!this.useSupabase || !this.user) return;
+  /**
+   * Clear a default. Pass the run being cleared: since migration 046 a vehicle
+   * holds a default charging run AND a default range test, so clearing every
+   * run of the vehicle meant clicking × on one silently dropped the other.
+   *
+   * With no runId this still clears the lot, which is what deleting a vehicle's
+   * data wants; nothing in the UI calls it that way.
+   */
+  async clearDefaultRun(vehicleId, runId = null) {
+    if (!this.useSupabase || !this.user) {
+      const saved = localStorage.getItem('evData');
+      const data = saved ? JSON.parse(saved) : { vehicles: [], selectedVehicles: [] };
+      data.vehicles = data.vehicles.map(v =>
+        v.id === vehicleId ? { ...v, runs: clearDefaultRuns(v.runs, runId) } : v);
+      localStorage.setItem('evData', JSON.stringify(data));
+      return;
+    }
+    if (runId != null) {
+      const { error } = await getSupabase().from('runs').update({ is_default: false }).eq('id', runId);
+      if (error) throw error;
+      return;
+    }
     await getSupabase().from('runs').update({ is_default: false }).eq('vehicle_id', vehicleId);
     await getSupabase().from('spec_links').update({ is_default: false }).eq('target_vehicle_id', vehicleId);
   }
@@ -600,8 +623,7 @@ class DataService {
       const saved = localStorage.getItem('evData');
       const data = saved ? JSON.parse(saved) : { vehicles: [], selectedVehicles: [] };
       data.vehicles = data.vehicles.map(v =>
-        v.id === vehicleId ? { ...v, runs: v.runs.map(r => ({ ...r, isDefault: r.id === runId }))} : v
-      );
+        v.id === vehicleId ? { ...v, runs: applyDefaultRun(v.runs, runId) } : v);
       localStorage.setItem('evData', JSON.stringify(data));
       return;
     }

--- a/src/utils/runUtils.js
+++ b/src/utils/runUtils.js
@@ -103,3 +103,35 @@ export const parseInheritedRunId = (id) => {
     const [, linkId, realRunId] = id.split('_');
     return { linkId: parseInt(linkId, 10), realRunId: parseInt(realRunId, 10) };
 };
+
+// ── Default runs ─────────────────────────────────────────────────────────────
+
+/**
+ * Mark `runId` as its vehicle's default, leaving the OTHER kind alone.
+ *
+ * A vehicle has two independent defaults since migration 046: a default charging
+ * run (the fallback curve) and a default range test (rank 2 of the range-source
+ * order). Marking one used to clear both, so setting a default range test
+ * silently dropped the default charging run.
+ *
+ * Pure, and shared by the optimistic update and the offline store so the two
+ * cannot drift — they already had, which is how this survived: the service
+ * scoped it per kind while the copy on screen did not, and they disagreed until
+ * a reload.
+ */
+export function applyDefaultRun(runs, runId) {
+    const target = (runs || []).find(r => r.id === runId);
+    if (!target) return runs || [];
+    const kind = runKindFrom(target);
+    return runs.map(r =>
+        runKindFrom(r) !== kind ? r : { ...r, isDefault: r.id === runId });
+}
+
+/**
+ * Clear the default flag on one run, or — with no runId — on every run of the
+ * vehicle, which is what discarding a vehicle's data wants.
+ */
+export function clearDefaultRuns(runs, runId = null) {
+    return (runs || []).map(r =>
+        (runId == null || r.id === runId) ? { ...r, isDefault: false } : r);
+}


### PR DESCRIPTION
Reported while using the site: Tests & Data allows only one default per vehicle, so a default range test and a default charging run cannot coexist.

## Cause

Migration 046 split dual-role runs, giving a vehicle two independent defaults — the fallback charging curve, and the range test at rank 2 of the range-source order. `DataService.setDefaultRun` was scoped per kind in #177, but three other paths were not:

| path | what it did |
|---|---|
| `AppContext.setDefaultRun` | rewrote `isDefault` on every run of the vehicle |
| `clearDefaultRun` | took only a vehicleId, cleared every run |
| `updateSpecLink` | cleared both kinds when promoting an inherited run |

The first is the interesting one: the correct per-kind write reached the database while the copy on screen cleared the other default, so the two disagreed until a reload. That is also why the #177 fix looked complete.

## Fix

One pure rule — `applyDefaultRun` / `clearDefaultRuns` in `runUtils` — used by the optimistic update and the offline store alike. Two copies of this rule is precisely what let the bug survive: the service was fixed and the copy on screen was not. `clearDefaultRun` now takes the run being cleared; with no runId it still clears the lot, which is what discarding a vehicle's data wants. Inherited runs are charging curves, so promoting one no longer touches the default range test.

## Testing

10 assertions, including pre-046 rows that carry `has_charging`/`has_range` rather than `kind`, an unknown runId being a no-op rather than clearing everything, and non-mutation of the input.

**Not verified against the live database.** Writes need an authenticated session and the preview is signed out, so the Supabase statements are reviewed by inspection; the shared local rule is what the tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)