### PR TITLE
Give test sessions a UI (#184)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -794,6 +794,7 @@ export default function App() {
                             onUpdateVehicleSpecs={updateVehicleSpecs}
                             specCustomFieldSuggestions={specCustomFieldSuggestions}
                             vehicles={vehicles}
+                            onViewVehicle={(v) => setActiveVehicle(v)}
                             onCopyRunToVehicle={(run, targetId) => copyRunToVehicle(currentActiveVehicle.id, run, targetId)}
                         />
                     )}

--- a/src/components/ChargeCompareView.jsx
+++ b/src/components/ChargeCompareView.jsx
@@ -18,6 +18,18 @@ import { resolvePairColors } from '../utils/colorUtils';
 import LoadingSpinner from './LoadingSpinner';
 import ChartInfoBubble from './ChartInfoBubble';
 
+
+/**
+ * A pair's session name, but only when both halves came from the same outing.
+ * One half's session says nothing about the pair, and #170's composer would
+ * then label the series after an event only part of it belongs to.
+ */
+function sharedSessionName(rangeRun, chargingRun, sessions) {
+    const id = rangeRun?.session_id;
+    if (id == null || String(id) !== String(chargingRun?.session_id)) return null;
+    return (sessions || []).find(s => String(s.id) === String(id))?.name?.trim() || null;
+}
+
 // ── Interpolation helper ──────────────────────────────────────────────────────
 // Returns the interpolated yField value at targetX, given points sorted by xField.
 // allowExtrapolateBefore — extends linearly backward past the first point (slope of first two).
@@ -288,7 +300,7 @@ export default function ChargeCompareView({
     verboseLabels = false,
     setChartConfig = null,
 }) {
-    const { units } = useAppContext();
+    const { units, testSessions } = useAppContext();
     const { isDark } = useTheme();
     const [runDataCache,    setRunDataCache]    = useState({});
     const [loading,         setLoading]         = useState(false);
@@ -358,6 +370,7 @@ export default function ChargeCompareView({
                     result.push({
                         key:         pairKey(rangeRun.id, partnerId),
                         vehicle,
+                        sessionName: sharedSessionName(rangeRun, chargingRun, testSessions),
                         rangeRun:    { ...rangeRun, vehicleName: vehicleLabel(vehicle), vehicleId: vehicle.id },
                         chargingRun,
                         rangeSrc,
@@ -367,7 +380,7 @@ export default function ChargeCompareView({
         }
 
         return result;
-    }, [selectedVehicles, pairings]);
+    }, [selectedVehicles, pairings, testSessions]);
 
     const neededRunIds = useMemo(
         () => [...new Set(resolvedPairs.map(p => p.chargingRun?.id).filter(Boolean))],

--- a/src/components/RoadTripView.jsx
+++ b/src/components/RoadTripView.jsx
@@ -27,6 +27,18 @@ import ChartInfoBubble from './ChartInfoBubble';
 
 Chart.register(ZoomPlugin);
 
+/**
+ * A pair's session name, but only when both halves came from the same outing.
+ * One half's session says nothing about the pair, and #170's composer would
+ * then label the series after an event only part of it belongs to.
+ */
+function sharedSessionName(rangeRun, chargingRun, sessions) {
+    const id = rangeRun?.session_id;
+    if (id == null || String(id) !== String(chargingRun?.session_id)) return null;
+    return (sessions || []).find(s => String(s.id) === String(id))?.name?.trim() || null;
+}
+
+
 // ── Speed sweep constants ────────────────────────────────────────────────────
 const SPEED_SWEEP_MIN  = 45;   // mph
 const SPEED_SWEEP_MAX  = 100;  // mph
@@ -373,7 +385,7 @@ export default function RoadTripView({
     verboseLabels = false,
     setChartConfig = null,
 }) {
-    const { units } = useAppContext();
+    const { units, testSessions } = useAppContext();
     const { isDark } = useTheme();
     const canvasRef = useRef(null);
     const chartRef  = useRef(null);
@@ -714,6 +726,7 @@ export default function RoadTripView({
             vehicle:     e.vehicle,
             rangeRun:    e.rangeRun,
             chargingRun: e.run,
+            sessionName: sharedSessionName(e.rangeRun, e.run, testSessions),
         })));
         const entryLabelFull = e => seriesLabels.get(e.key)?.full ?? vehicleLabel(e.vehicle);
         const entryLabel = e => verboseLabels

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo, Fragment } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { fmtSpeed, fmtTemp, fmtDistance, calcEff, effLabel as getEffLabel, roundTo } from '../utils/unitConversions';
 import Papa from 'papaparse';
@@ -7,7 +7,10 @@ import { dataService } from '../services/DataService';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
 import DeleteQueueBar from './DeleteQueueBar';
 import EditVehicleForm from './EditVehicleForm';
+import { groupRunsBySession } from '../utils/testSessions';
 import SessionControl from './SessionControl';
+import SessionGroupHeader from './SessionGroupHeader';
+import SessionEditModal from './SessionEditModal';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 import { RunVoteButtons } from './VoteButtons';
@@ -455,7 +458,7 @@ const DeriveAxisPanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, testSessions, createTestSession, setRunsSession, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, testSessions, createTestSession, updateTestSession, deleteTestSession, setRunsSession, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -1278,6 +1281,19 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     const availableFields  = csvData?.meta.fields || [];
     const allDisplayRuns   = (vehicle.runs || []).filter(r => !committedDeletes.has(r.id));
     const displayRuns      = allDisplayRuns.filter(r => !r._inherited);
+
+    // Runs of one session sit together under a heading that names the outing.
+    // A flat pile said nothing about which two runs were the same test event,
+    // which is the entire reason sessions exist.
+    const groupedRuns = useMemo(() => groupRunsBySession(displayRuns), [displayRuns]);
+    const [collapsedSessions, setCollapsedSessions] = useState(() => new Set());
+    const [editingSessionId, setEditingSessionId] = useState(null);
+    const toggleSessionGroup = (key) => setCollapsedSessions(prev => {
+        const next = new Set(prev);
+        const k = String(key);
+        next.has(k) ? next.delete(k) : next.add(k);
+        return next;
+    });
     const inheritedRuns    = allDisplayRuns.filter(r => r._inherited);
     const barVisible       = pendingDeletes.size > 0 || !!undoState;
 
@@ -1831,14 +1847,31 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             )}
 
             <div className="space-y-4">
-                {displayRuns.map(run => {
+                {groupedRuns.map(({ run, sessionId, isGroupStart, groupSize }) => {
                   // Ensure vote data is loaded for this run (no-op if already loaded)
                   if (!runVotes[run.id]) loadRunVotes([run.id]);
                   const votes = runVotes[run.id] ?? { vouch: 0, flag: 0, myVote: null };
                   const isPending = pendingDeletes.has(run.id);
+                  const groupKey  = sessionId ?? '__none__';
+                  const collapsed = collapsedSessions.has(String(groupKey));
+                  const session   = sessionId != null
+                      ? (testSessions || []).find(x => String(x.id) === String(sessionId)) ?? null
+                      : null;
                   return (
+                    <Fragment key={run.id}>
+                    {isGroupStart && (
+                        <SessionGroupHeader
+                            session={session}
+                            vehicle={vehicle}
+                            vehicles={vehicles}
+                            runsHere={groupSize}
+                            collapsed={collapsed}
+                            onToggle={() => toggleSessionGroup(groupKey)}
+                            onEdit={session && canEdit(vehicle) ? () => setEditingSessionId(session.id) : null}
+                        />
+                    )}
+                    {!collapsed && (
                     <div
-                        key={run.id}
                         className={`card${isPending ? ' opacity-60 border-2 border-red-200' : ''}`}
                     >
                         {editingRunId === run.id ? (
@@ -2338,6 +2371,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                                 sessions={testSessions}
                                                 onAssign={sessionId => setRunsSession([run.id], sessionId)}
                                                 onCreate={createTestSession}
+                                                onUpdate={updateTestSession}
+                                                onDelete={deleteTestSession}
                                             />
                                         )}
                                         {(inferRunFlags(run).includes('range') || run.distance_miles != null) && canEdit(vehicle) && (
@@ -2456,9 +2491,21 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                             </div>
                         )}
                     </div>
+                    )}
+                    </Fragment>
                   );
                 })}
             </div>
+
+            {editingSessionId != null && (
+                <SessionEditModal
+                    session={(testSessions || []).find(x => String(x.id) === String(editingSessionId))}
+                    vehicles={vehicles}
+                    onSave={updateTestSession}
+                    onDelete={deleteTestSession}
+                    onClose={() => setEditingSessionId(null)}
+                />
+            )}
 
             {displayRuns.length === 0 && !showUpload && inheritedRuns.length === 0 && (
                 <div className="empty-state">

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -7,6 +7,7 @@ import { dataService } from '../services/DataService';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
 import DeleteQueueBar from './DeleteQueueBar';
 import EditVehicleForm from './EditVehicleForm';
+import SessionControl from './SessionControl';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
 import { RunVoteButtons } from './VoteButtons';
@@ -454,7 +455,7 @@ const DeriveAxisPanel = ({
 };
 
 export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
-    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
+    const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, testSessions, createTestSession, setRunsSession, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
     const [showEditVehicle, setShowEditVehicle] = useState(false);
@@ -2328,6 +2329,16 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                                         )}
                                         {inferRunFlags(run).includes('charging') && (
                                             <RunChargingMetaLine run={run} calcKwhByRun={calcKwhByRun} onCheckKwh={handleCheckKwh} />
+                                        )}
+                                        {canEdit(vehicle) && (
+                                            <SessionControl
+                                                run={run}
+                                                vehicle={vehicle}
+                                                vehicles={vehicles}
+                                                sessions={testSessions}
+                                                onAssign={sessionId => setRunsSession([run.id], sessionId)}
+                                                onCreate={createTestSession}
+                                            />
                                         )}
                                         {(inferRunFlags(run).includes('range') || run.distance_miles != null) && canEdit(vehicle) && (
                                             <PairedChargingControl

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -457,7 +457,7 @@ const DeriveAxisPanel = ({
     );
 };
 
-export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle }) {
+export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPublish, onAddRun, onUpdateRun, onSetDefaultRun, onDeleteRun, onMergeRunData, onReplaceRunData, onDuplicateRun, onViewChart, onToggleVehicleVisibility, onUpdateVehicle, onDuplicateVehicle, onDeleteVehicle, tags, onCreateTag, onSyncVehicleTags, onUploadVehicleImage, onUpdateVehicleSpecs, specCustomFieldSuggestions, vehicles, onCopyRunToVehicle, onViewVehicle }) {
     const { runVotes, loadRunVotes, toggleRunVote, units, manufacturers, addManufacturer, isContributor, addSpecLink, updateSpecLink, deleteSpecLink, updateRunColor, setPairedChargingRun, clearDefaultRun, testSessions, createTestSession, updateTestSession, deleteTestSession, setRunsSession, searchEpaTestGroups, linkEpaTestGroup, createAndLinkEpaTestGroup, updateEpaMapping, unlinkEpaTestGroup, updateEpaTestGroup } = useAppContext();
 
     // ── Vehicle edit form state ───────────────────────────────────────────────
@@ -1285,7 +1285,7 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
     // Runs of one session sit together under a heading that names the outing.
     // A flat pile said nothing about which two runs were the same test event,
     // which is the entire reason sessions exist.
-    const groupedRuns = useMemo(() => groupRunsBySession(displayRuns), [displayRuns]);
+    const runGroups = useMemo(() => groupRunsBySession(displayRuns), [displayRuns]);
     const [collapsedSessions, setCollapsedSessions] = useState(() => new Set());
     const [editingSessionId, setEditingSessionId] = useState(null);
     const toggleSessionGroup = (key) => setCollapsedSessions(prev => {
@@ -1847,31 +1847,36 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             )}
 
             <div className="space-y-4">
-                {groupedRuns.map(({ run, sessionId, isGroupStart, groupSize }) => {
+                {runGroups.map(group => {
+                  const collapsed = collapsedSessions.has(String(group.key));
+                  const session   = group.sessionId != null
+                      ? (testSessions || []).find(x => String(x.id) === String(group.sessionId)) ?? null
+                      : null;
+                  return (
+                    <div
+                        key={group.key}
+                        className={`session-group${session ? '' : ' is-unassigned'}${collapsed ? ' is-collapsed' : ''}`}
+                    >
+                    <SessionGroupHeader
+                        session={session}
+                        vehicle={vehicle}
+                        vehicles={vehicles}
+                        runsHere={group.runs.length}
+                        collapsed={collapsed}
+                        onToggle={() => toggleSessionGroup(group.key)}
+                        onEdit={session && canEdit(vehicle) ? () => setEditingSessionId(session.id) : null}
+                        onViewVehicle={onViewVehicle}
+                    />
+                    {!collapsed && (
+                    <div className="session-group-body">
+                    {group.runs.map(run => {
                   // Ensure vote data is loaded for this run (no-op if already loaded)
                   if (!runVotes[run.id]) loadRunVotes([run.id]);
                   const votes = runVotes[run.id] ?? { vouch: 0, flag: 0, myVote: null };
                   const isPending = pendingDeletes.has(run.id);
-                  const groupKey  = sessionId ?? '__none__';
-                  const collapsed = collapsedSessions.has(String(groupKey));
-                  const session   = sessionId != null
-                      ? (testSessions || []).find(x => String(x.id) === String(sessionId)) ?? null
-                      : null;
                   return (
-                    <Fragment key={run.id}>
-                    {isGroupStart && (
-                        <SessionGroupHeader
-                            session={session}
-                            vehicle={vehicle}
-                            vehicles={vehicles}
-                            runsHere={groupSize}
-                            collapsed={collapsed}
-                            onToggle={() => toggleSessionGroup(groupKey)}
-                            onEdit={session && canEdit(vehicle) ? () => setEditingSessionId(session.id) : null}
-                        />
-                    )}
-                    {!collapsed && (
                     <div
+                        key={run.id}
                         className={`card${isPending ? ' opacity-60 border-2 border-red-200' : ''}`}
                     >
                         {editingRunId === run.id ? (
@@ -2491,8 +2496,11 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
                             </div>
                         )}
                     </div>
+                  );
+                    })}
+                    </div>
                     )}
-                    </Fragment>
+                    </div>
                   );
                 })}
             </div>

--- a/src/components/SessionBrowserModal.jsx
+++ b/src/components/SessionBrowserModal.jsx
@@ -23,6 +23,7 @@ import { vehicleLabel } from '../utils/specHelpers';
 export default function SessionBrowserModal({
     vehicles, sessions, currentSessionId, vehicleId,
     onPick,          // (sessionId | null) => void
+    onEdit,          // (sessionId) => void
     onClose,
 }) {
     const [query, setQuery] = useState('');
@@ -102,12 +103,21 @@ export default function SessionBrowserModal({
                                             )}
                                         </div>
 
-                                        <button
-                                            onClick={() => { onPick(isCurrent ? null : session.id); onClose(); }}
-                                            className={`btn text-sm shrink-0 ${isCurrent ? 'btn-secondary' : 'btn-primary'}`}
-                                        >
-                                            {isCurrent ? 'Detach' : 'Use'}
-                                        </button>
+                                        <div className="flex items-center gap-2 shrink-0">
+                                            {onEdit && (
+                                                <button
+                                                    onClick={() => onEdit(session.id)}
+                                                    className="session-group-edit"
+                                                    title="Edit session"
+                                                >✎</button>
+                                            )}
+                                            <button
+                                                onClick={() => { onPick(isCurrent ? null : session.id); onClose(); }}
+                                                className={`btn text-sm ${isCurrent ? 'btn-secondary' : 'btn-primary'}`}
+                                            >
+                                                {isCurrent ? 'Detach' : 'Use'}
+                                            </button>
+                                        </div>
                                     </div>
                                 );
                             })}

--- a/src/components/SessionBrowserModal.jsx
+++ b/src/components/SessionBrowserModal.jsx
@@ -1,0 +1,128 @@
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { summariseSessions, filterSessions, sessionLabel } from '../utils/testSessions';
+import { vehicleLabel } from '../utils/specHelpers';
+
+/**
+ * Browse every session and attach one to a run.
+ *
+ * The inline picker deliberately lists only the sessions a vehicle already
+ * appears in — that list stays short and is right almost every time, since a
+ * curator is usually adding another run to an outing this car was already on.
+ * Everything else lives here, because a flat dropdown of every session was
+ * already unreadable at 28 and only grows.
+ *
+ * Search matches the vehicles as well as the name, which matters more than it
+ * sounds: sessions inherit their names from whoever published the test, so "OoS
+ * 10% Challenge" appears eight times over and the name alone cannot tell two
+ * outings apart. The cars on it always can.
+ *
+ * This is the intended home for session management — rename, merge, delete,
+ * bulk assignment — so it is built as a list of rows with room to the right
+ * rather than as a picker that happens to be big.
+ */
+export default function SessionBrowserModal({
+    vehicles, sessions, currentSessionId, vehicleId,
+    onPick,          // (sessionId | null) => void
+    onClose,
+}) {
+    const [query, setQuery] = useState('');
+    const inputRef = useRef(null);
+
+    useEffect(() => { inputRef.current?.focus(); }, []);
+    useEffect(() => {
+        const onKey = e => { if (e.key === 'Escape') onClose(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    const summaries = useMemo(() => summariseSessions(sessions, vehicles), [sessions, vehicles]);
+    const shown     = useMemo(() => filterSessions(summaries, query), [summaries, query]);
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div
+                className="modal-panel rounded-xl shadow-2xl mx-4 flex flex-col"
+                style={{ maxWidth: 'min(92vw, 760px)', maxHeight: '85vh' }}
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="modal-header px-6 py-4" style={{ borderBottom: '1px solid var(--color-border)' }}>
+                    <div>
+                        <h3 className="text-lg font-semibold">All sessions</h3>
+                        <p className="text-sm text-muted">
+                            {summaries.length} session{summaries.length === 1 ? '' : 's'} · search by name, vehicle, date, tester or location
+                        </p>
+                    </div>
+                    <button onClick={onClose} className="btn btn-secondary text-sm">Close</button>
+                </div>
+
+                <div className="px-6 pt-4">
+                    <input
+                        ref={inputRef}
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        placeholder="e.g. oos r1s"
+                        className="form-input w-full"
+                    />
+                </div>
+
+                <div className="modal-body">
+                    {shown.length === 0 ? (
+                        <p className="text-sm text-faint italic py-6 text-center">
+                            No session matches “{query}”.
+                        </p>
+                    ) : (
+                        <div className="session-browser-list">
+                            {shown.map(({ session, runCount, vehicles: inSession, date }) => {
+                                const isCurrent = String(session.id) === String(currentSessionId);
+                                return (
+                                    <div key={session.id} className={`session-browser-row${isCurrent ? ' is-current' : ''}`}>
+                                        <div className="min-w-0">
+                                            <div className="flex items-center gap-2 flex-wrap">
+                                                <span className="font-medium">{sessionLabel(session)}</span>
+                                                <span className="text-xs text-muted">
+                                                    {runCount} run{runCount === 1 ? '' : 's'}
+                                                </span>
+                                                {session.location_name && (
+                                                    <span className="text-xs text-faint">· {session.location_name}</span>
+                                                )}
+                                            </div>
+                                            {inSession.length > 0 ? (
+                                                <div className="flex flex-wrap gap-1 mt-1">
+                                                    {inSession.map(v => (
+                                                        <span
+                                                            key={v.id}
+                                                            className={`session-vehicle-chip${String(v.id) === String(vehicleId) ? ' is-self' : ''}`}
+                                                        >
+                                                            {v.model || v.name}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            ) : (
+                                                <p className="text-xs text-faint italic mt-1">No runs attached yet</p>
+                                            )}
+                                        </div>
+
+                                        <button
+                                            onClick={() => { onPick(isCurrent ? null : session.id); onClose(); }}
+                                            className={`btn text-sm shrink-0 ${isCurrent ? 'btn-secondary' : 'btn-primary'}`}
+                                        >
+                                            {isCurrent ? 'Detach' : 'Use'}
+                                        </button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+
+                {/* Where rename, merge, delete and bulk assignment will go. */}
+                <div className="modal-footer">
+                    <span className="text-xs text-faint mr-auto self-center">
+                        Showing {shown.length} of {summaries.length}
+                    </span>
+                    <button onClick={onClose} className="btn btn-secondary text-sm">Done</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/SessionControl.jsx
+++ b/src/components/SessionControl.jsx
@@ -4,6 +4,7 @@ import {
     sessionDateMismatch, runsInSession,
 } from '../utils/testSessions';
 import { vehicleLabel } from '../utils/specHelpers';
+import SessionBrowserModal from './SessionBrowserModal';
 
 /**
  * Assign a run to a testing session.
@@ -13,9 +14,11 @@ import { vehicleLabel } from '../utils/specHelpers';
  * UI: four cars round one loop become one session because four runs each picked
  * it, not because anything here knows how to select four cars.
  *
- * Sessions this vehicle already appears in are listed first — a curator adding
- * the fourth run of an outing should not hunt for the session the other three
- * are already in.
+ * The dropdown lists ONLY the sessions this vehicle already appears in. That is
+ * the right answer almost every time — a curator is usually adding another run
+ * to an outing this car was already on — and it keeps the list short. A flat
+ * list of every session was unreadable at 28 and only grows, so everything else
+ * lives behind the browser, where it can be searched rather than scrolled.
  */
 export default function SessionControl({
     run, vehicle, vehicles, sessions,
@@ -23,10 +26,11 @@ export default function SessionControl({
     onCreate,          // ({ name, testedAt }) => Promise<session | null>
 }) {
     const [creating, setCreating] = useState(false);
+    const [browsing, setBrowsing] = useState(false);
     const [draftName, setDraftName] = useState('');
     const [saving, setSaving] = useState(false);
 
-    const { used, others } = sessionsForPicker(sessions, vehicles, vehicle.id);
+    const { used } = sessionsForPicker(sessions, vehicles, vehicle.id);
     const current  = (sessions || []).find(s => String(s.id) === String(run.session_id)) ?? null;
     const mismatch = sessionDateMismatch(run, current);
 
@@ -38,7 +42,8 @@ export default function SessionControl({
     const runCount = current ? runsInSession(vehicles, current.id).length : 0;
 
     const handleChange = (value) => {
-        if (value === '__new__') { setCreating(true); setDraftName(''); return; }
+        if (value === '__new__')    { setCreating(true); setDraftName(''); return; }
+        if (value === '__browse__') { setBrowsing(true); return; }
         onAssign(value ? Number(value) : null);
     };
 
@@ -87,17 +92,15 @@ export default function SessionControl({
                 className="form-input text-sm py-0.5"
             >
                 <option value="">— None —</option>
-                {used.length > 0 && (
-                    <optgroup label="This vehicle's sessions">
-                        {used.map(s => <option key={s.id} value={s.id}>{sessionLabel(s)}</option>)}
-                    </optgroup>
-                )}
-                {others.length > 0 && (
-                    <optgroup label="Other sessions">
-                        {others.map(s => <option key={s.id} value={s.id}>{sessionLabel(s)}</option>)}
-                    </optgroup>
+                {/* Only this vehicle's sessions. Everything else is behind the
+                    browser, where it can be searched rather than scrolled. */}
+                {used.map(s => <option key={s.id} value={s.id}>{sessionLabel(s)}</option>)}
+                {/* A session picked from the browser may not be in `used` yet. */}
+                {current && !used.some(s => String(s.id) === String(current.id)) && (
+                    <option value={current.id}>{sessionLabel(current)}</option>
                 )}
                 <option value="__new__">+ New session…</option>
+                <option value="__browse__">🔍 All sessions…</option>
             </select>
 
             {current && runCount > 1 && (
@@ -116,6 +119,16 @@ export default function SessionControl({
                 >
                     ⚠ {mismatch} days from session date
                 </span>
+            )}
+            {browsing && (
+                <SessionBrowserModal
+                    vehicles={vehicles}
+                    sessions={sessions}
+                    currentSessionId={run.session_id}
+                    vehicleId={vehicle.id}
+                    onPick={onAssign}
+                    onClose={() => setBrowsing(false)}
+                />
             )}
         </div>
     );

--- a/src/components/SessionControl.jsx
+++ b/src/components/SessionControl.jsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import {
+    sessionLabel, sessionsForPicker, vehiclesInSession,
+    sessionDateMismatch, runsInSession,
+} from '../utils/testSessions';
+import { vehicleLabel } from '../utils/specHelpers';
+
+/**
+ * Assign a run to a testing session.
+ *
+ * Assignment runs from the RUN's side, like picking a manufacturer. That single
+ * choice is what makes multi-vehicle sessions work without any multi-vehicle
+ * UI: four cars round one loop become one session because four runs each picked
+ * it, not because anything here knows how to select four cars.
+ *
+ * Sessions this vehicle already appears in are listed first — a curator adding
+ * the fourth run of an outing should not hunt for the session the other three
+ * are already in.
+ */
+export default function SessionControl({
+    run, vehicle, vehicles, sessions,
+    onAssign,          // (sessionId | null) => void
+    onCreate,          // ({ name, testedAt }) => Promise<session | null>
+}) {
+    const [creating, setCreating] = useState(false);
+    const [draftName, setDraftName] = useState('');
+    const [saving, setSaving] = useState(false);
+
+    const { used, others } = sessionsForPicker(sessions, vehicles, vehicle.id);
+    const current  = (sessions || []).find(s => String(s.id) === String(run.session_id)) ?? null;
+    const mismatch = sessionDateMismatch(run, current);
+
+    // Who else was there. The point of a session is the shared outing, so the
+    // other cars in it are the most useful thing to show once one is chosen.
+    const others_in = current
+        ? vehiclesInSession(vehicles, current.id).filter(v => String(v.id) !== String(vehicle.id))
+        : [];
+    const runCount = current ? runsInSession(vehicles, current.id).length : 0;
+
+    const handleChange = (value) => {
+        if (value === '__new__') { setCreating(true); setDraftName(''); return; }
+        onAssign(value ? Number(value) : null);
+    };
+
+    const handleCreate = async () => {
+        setSaving(true);
+        try {
+            // Seed the session's date from the run's own, since the run being
+            // assigned is nearly always one of the outing's first.
+            const created = await onCreate({ name: draftName.trim() || null, testedAt: run.date || null });
+            if (created) onAssign(created.id);
+            setCreating(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (creating) {
+        return (
+            <div className="flex items-center gap-2 text-sm mt-1 flex-wrap">
+                <span className="text-label shrink-0">New session:</span>
+                <input
+                    autoFocus
+                    value={draftName}
+                    onChange={e => setDraftName(e.target.value)}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter') handleCreate();
+                        if (e.key === 'Escape') setCreating(false);
+                    }}
+                    placeholder="e.g. OoS 4-car loop"
+                    className="form-input text-sm py-0.5 flex-1 min-w-40"
+                />
+                <button onClick={handleCreate} disabled={saving} className="btn btn-primary text-sm py-0.5">
+                    {saving ? 'Creating…' : 'Create'}
+                </button>
+                <button onClick={() => setCreating(false)} className="btn btn-secondary text-sm py-0.5">Cancel</button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-2 text-sm mt-1 flex-wrap">
+            <span className="text-label shrink-0">Session:</span>
+            <select
+                value={run.session_id ?? ''}
+                onChange={e => handleChange(e.target.value)}
+                className="form-input text-sm py-0.5"
+            >
+                <option value="">— None —</option>
+                {used.length > 0 && (
+                    <optgroup label="This vehicle's sessions">
+                        {used.map(s => <option key={s.id} value={s.id}>{sessionLabel(s)}</option>)}
+                    </optgroup>
+                )}
+                {others.length > 0 && (
+                    <optgroup label="Other sessions">
+                        {others.map(s => <option key={s.id} value={s.id}>{sessionLabel(s)}</option>)}
+                    </optgroup>
+                )}
+                <option value="__new__">+ New session…</option>
+            </select>
+
+            {current && runCount > 1 && (
+                <span className="text-xs text-secondary" title={others_in.map(vehicleLabel).join(', ') || undefined}>
+                    {runCount} runs
+                    {others_in.length > 0 && ` · with ${others_in.map(v => v.model || v.name).join(', ')}`}
+                </span>
+            )}
+
+            {/* Sessions are global, so the realistic mistake is attaching a run to
+                an outing it was not part of. Say so; do not block it. */}
+            {mismatch != null && (
+                <span
+                    className="text-xs text-amber-600"
+                    title={`This run is dated ${run.date}, the session ${String(current.tested_at).slice(0, 10)}. Correct if they really were the same outing.`}
+                >
+                    ⚠ {mismatch} days from session date
+                </span>
+            )}
+        </div>
+    );
+}

--- a/src/components/SessionControl.jsx
+++ b/src/components/SessionControl.jsx
@@ -5,6 +5,7 @@ import {
 } from '../utils/testSessions';
 import { vehicleLabel } from '../utils/specHelpers';
 import SessionBrowserModal from './SessionBrowserModal';
+import SessionEditModal from './SessionEditModal';
 
 /**
  * Assign a run to a testing session.
@@ -24,9 +25,14 @@ export default function SessionControl({
     run, vehicle, vehicles, sessions,
     onAssign,          // (sessionId | null) => void
     onCreate,          // ({ name, testedAt }) => Promise<session | null>
+    onUpdate,          // (id, changes) => void
+    onDelete,          // (id) => void
 }) {
     const [creating, setCreating] = useState(false);
     const [browsing, setBrowsing] = useState(false);
+    const [editing, setEditing] = useState(false);
+    // Editing a session reached from the browser, which need not be this run's.
+    const [browseEditId, setBrowseEditId] = useState(null);
     const [draftName, setDraftName] = useState('');
     const [saving, setSaving] = useState(false);
 
@@ -40,6 +46,12 @@ export default function SessionControl({
         ? vehiclesInSession(vehicles, current.id).filter(v => String(v.id) !== String(vehicle.id))
         : [];
     const runCount = current ? runsInSession(vehicles, current.id).length : 0;
+
+    // Edit reached from the browser may target a session this run is not in,
+    // so it wins over `current` while it is set.
+    const editTarget = browseEditId != null
+        ? (sessions || []).find(x => String(x.id) === String(browseEditId)) ?? null
+        : current;
 
     const handleChange = (value) => {
         if (value === '__new__')    { setCreating(true); setDraftName(''); return; }
@@ -103,6 +115,17 @@ export default function SessionControl({
                 <option value="__browse__">🔍 All sessions…</option>
             </select>
 
+            {/* Editable wherever it is named: noticing a session is misdated
+                happens while looking at a run, not at a management screen. */}
+            {current && onUpdate && (
+                <button onClick={() => setEditing(true)} className="session-group-edit" title="Edit session">✎</button>
+            )}
+
+            {current?.url && (
+                <a href={current.url} target="_blank" rel="noopener noreferrer"
+                   className="text-xs text-blue-500 hover:underline" title={current.url}>source ↗</a>
+            )}
+
             {current && runCount > 1 && (
                 <span className="text-xs text-secondary" title={others_in.map(vehicleLabel).join(', ') || undefined}>
                     {runCount} runs
@@ -120,6 +143,15 @@ export default function SessionControl({
                     ⚠ {mismatch} days from session date
                 </span>
             )}
+            {editing && editTarget && (
+                <SessionEditModal
+                    session={editTarget}
+                    vehicles={vehicles}
+                    onSave={onUpdate}
+                    onDelete={onDelete}
+                    onClose={() => { setEditing(false); setBrowseEditId(null); }}
+                />
+            )}
             {browsing && (
                 <SessionBrowserModal
                     vehicles={vehicles}
@@ -127,6 +159,7 @@ export default function SessionControl({
                     currentSessionId={run.session_id}
                     vehicleId={vehicle.id}
                     onPick={onAssign}
+                    onEdit={onUpdate ? (id) => { setBrowseEditId(id); setBrowsing(false); setEditing(true); } : null}
                     onClose={() => setBrowsing(false)}
                 />
             )}

--- a/src/components/SessionEditModal.jsx
+++ b/src/components/SessionEditModal.jsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { vehiclesInSession, runsInSession } from '../utils/testSessions';
+import { vehicleLabel } from '../utils/specHelpers';
+
+/**
+ * Edit a session's own fields.
+ *
+ * Reachable from anywhere a session is named — the run's picker, the group
+ * header, the browser — because the moment you notice a session is called
+ * "Theoretical" and dated wrongly is the moment you are looking at a run, not
+ * hunting for a management screen.
+ *
+ * Every field here already existed in migration 044 and had never been written
+ * to, `url` included. The environmental columns are the session-level reading:
+ * a run's own temperature stays authoritative for its row, and #154's congruence
+ * tiers prefer the session's when present.
+ */
+const FIELDS = [
+    { key: 'name',         label: 'Name',        type: 'text',   placeholder: 'e.g. OoS R2 & Model Y side-by-side', wide: true },
+    { key: 'testedAt',     label: 'Date',        type: 'date' },
+    { key: 'tester',       label: 'Tester',      type: 'text',   placeholder: 'e.g. Out of Spec' },
+    { key: 'locationName', label: 'Location',    type: 'text',   placeholder: 'e.g. I-70 loop, Denver' },
+    { key: 'temperatureF', label: 'Temp (°F)',   type: 'number', placeholder: 'Session-level reading' },
+    { key: 'sourceName',   label: 'Source',      type: 'text',   placeholder: 'Who published it' },
+    { key: 'url',          label: 'URL',         type: 'url',    placeholder: 'https://…', wide: true },
+];
+
+/** DB row → the camelCase draft the form edits. */
+function toDraft(session) {
+    return {
+        name:         session?.name ?? '',
+        testedAt:     session?.tested_at ? String(session.tested_at).slice(0, 10) : '',
+        tester:       session?.tester ?? '',
+        locationName: session?.location_name ?? '',
+        temperatureF: session?.temperature_f ?? '',
+        sourceName:   session?.source_name ?? '',
+        url:          session?.url ?? '',
+        notes:        session?.notes ?? '',
+    };
+}
+
+export default function SessionEditModal({ session, vehicles, onSave, onDelete, onClose }) {
+    const [draft, setDraft] = useState(() => toDraft(session));
+    const [saving, setSaving] = useState(false);
+    const [confirmDelete, setConfirmDelete] = useState(false);
+
+    useEffect(() => { setDraft(toDraft(session)); }, [session]);
+    useEffect(() => {
+        const onKey = e => { if (e.key === 'Escape') onClose(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    if (!session) return null;
+
+    const members  = runsInSession(vehicles, session.id);
+    const cars     = vehiclesInSession(vehicles, session.id);
+    const set = (key, value) => setDraft(d => ({ ...d, [key]: value }));
+
+    const handleSave = async () => {
+        setSaving(true);
+        try { await onSave(session.id, draft); onClose(); }
+        finally { setSaving(false); }
+    };
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div
+                className="modal-panel rounded-xl shadow-2xl mx-4 flex flex-col"
+                style={{ maxWidth: 'min(92vw, 640px)', maxHeight: '85vh' }}
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="modal-header px-6 py-4" style={{ borderBottom: '1px solid var(--color-border)' }}>
+                    <div>
+                        <h3 className="text-lg font-semibold">Edit session</h3>
+                        <p className="text-sm text-muted">
+                            {members.length} run{members.length === 1 ? '' : 's'}
+                            {cars.length > 0 && ` · ${cars.map(v => v.model || v.name).join(', ')}`}
+                        </p>
+                    </div>
+                    <button onClick={onClose} className="btn btn-secondary text-sm">Close</button>
+                </div>
+
+                <div className="modal-body">
+                    <div className="session-edit-grid">
+                        {FIELDS.map(f => (
+                            <label key={f.key} className={f.wide ? 'session-edit-field is-wide' : 'session-edit-field'}>
+                                <span className="text-label">{f.label}</span>
+                                <input
+                                    type={f.type}
+                                    value={draft[f.key]}
+                                    placeholder={f.placeholder}
+                                    onChange={e => set(f.key, e.target.value)}
+                                    className="form-input text-sm"
+                                />
+                            </label>
+                        ))}
+                        <label className="session-edit-field is-wide">
+                            <span className="text-label">Notes</span>
+                            <textarea
+                                value={draft.notes}
+                                onChange={e => set('notes', e.target.value)}
+                                rows={3}
+                                placeholder="Conditions, anything the fields cannot say"
+                                className="form-input text-sm"
+                            />
+                        </label>
+                    </div>
+
+                    {/* Changing the date can put the session at odds with its own
+                        runs, so name them rather than letting the warning appear
+                        later on each run in turn. */}
+                    {members.length > 0 && (
+                        <div className="mt-4">
+                            <p className="text-label mb-1">Runs in this session</p>
+                            <div className="flex flex-wrap gap-1">
+                                {members.map(({ run, vehicle }) => (
+                                    <span key={run.id} className="session-vehicle-chip" title={vehicleLabel(vehicle)}>
+                                        {vehicle.model || vehicle.name} · {run.name}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                <div className="modal-footer">
+                    {onDelete && (
+                        confirmDelete ? (
+                            <>
+                                <span className="text-xs text-secondary mr-auto self-center">
+                                    Delete this session? Its {members.length} run{members.length === 1 ? '' : 's'} stay, unattached.
+                                </span>
+                                <button onClick={() => setConfirmDelete(false)} className="btn btn-secondary text-sm">Cancel</button>
+                                <button onClick={() => { onDelete(session.id); onClose(); }} className="btn btn-danger text-sm">Delete</button>
+                            </>
+                        ) : (
+                            <button onClick={() => setConfirmDelete(true)} className="btn btn-danger text-sm mr-auto">Delete</button>
+                        )
+                    )}
+                    {!confirmDelete && (
+                        <>
+                            <button onClick={onClose} className="btn btn-secondary text-sm">Cancel</button>
+                            <button onClick={handleSave} disabled={saving} className="btn btn-primary text-sm">
+                                {saving ? 'Saving…' : 'Save'}
+                            </button>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/SessionGroupHeader.jsx
+++ b/src/components/SessionGroupHeader.jsx
@@ -1,4 +1,5 @@
 import { sessionLabel, vehiclesInSession, runsInSession } from '../utils/testSessions';
+import { vehicleLabel } from '../utils/specHelpers';
 
 /**
  * The band above the runs of one session in a vehicle's Tests & Data list.
@@ -13,7 +14,7 @@ import { sessionLabel, vehiclesInSession, runsInSession } from '../utils/testSes
  * makes the comparison trustworthy — invisible from this page otherwise.
  */
 export default function SessionGroupHeader({
-    session, vehicle, vehicles, runsHere, collapsed, onToggle, onEdit,
+    session, vehicle, vehicles, runsHere, collapsed, onToggle, onEdit, onViewVehicle,
 }) {
     // Ungrouped runs get a plain divider — a heading would imply they belong to
     // something, and "no session" is an absence, not a group.
@@ -47,9 +48,26 @@ export default function SessionGroupHeader({
                 {total > runsHere && ` · ${total} in session`}
             </span>
 
+            {/* The other cars are links: a side-by-side is only worth recording
+                because the runs are comparable, and the natural next move on
+                seeing "with R2" is to go and look at the R2's half. */}
             {others.length > 0 && (
                 <span className="text-xs text-secondary">
-                    with {others.map(v => v.model || v.name).join(', ')}
+                    with{' '}
+                    {others.map((v, i) => (
+                        <span key={v.id}>
+                            {i > 0 && ', '}
+                            {onViewVehicle ? (
+                                <button
+                                    onClick={() => onViewVehicle(v)}
+                                    className="session-vehicle-link"
+                                    title={`View ${vehicleLabel(v)} tests & data`}
+                                >
+                                    {v.model || v.name}
+                                </button>
+                            ) : (v.model || v.name)}
+                        </span>
+                    ))}
                 </span>
             )}
 

--- a/src/components/SessionGroupHeader.jsx
+++ b/src/components/SessionGroupHeader.jsx
@@ -1,0 +1,79 @@
+import { sessionLabel, vehiclesInSession, runsInSession } from '../utils/testSessions';
+
+/**
+ * The band above the runs of one session in a vehicle's Tests & Data list.
+ *
+ * A vehicle's runs used to be a flat pile in which nothing said that two of them
+ * were the same outing — which is the whole reason sessions exist. Grouping puts
+ * the charging half and the range half of one test event next to each other
+ * under a heading that names it.
+ *
+ * It reports the runs from OTHER vehicles too. A four-car side-by-side is eight
+ * runs of which this vehicle owns two, and the other six are the context that
+ * makes the comparison trustworthy — invisible from this page otherwise.
+ */
+export default function SessionGroupHeader({
+    session, vehicle, vehicles, runsHere, collapsed, onToggle, onEdit,
+}) {
+    // Ungrouped runs get a plain divider — a heading would imply they belong to
+    // something, and "no session" is an absence, not a group.
+    if (!session) {
+        return (
+            <div className="session-group-header is-unassigned">
+                <button onClick={onToggle} className="session-group-toggle" title={collapsed ? 'Expand' : 'Collapse'}>
+                    <span className={`session-group-chevron${collapsed ? '' : ' is-open'}`}>▶</span>
+                    <span className="text-secondary">No session</span>
+                </button>
+                <span className="text-xs text-faint">
+                    {runsHere} run{runsHere === 1 ? '' : 's'}
+                </span>
+            </div>
+        );
+    }
+
+    const total = runsInSession(vehicles, session.id).length;
+    const cars  = vehiclesInSession(vehicles, session.id);
+    const others = cars.filter(v => String(v.id) !== String(vehicle.id));
+
+    return (
+        <div className="session-group-header">
+            <button onClick={onToggle} className="session-group-toggle" title={collapsed ? 'Expand' : 'Collapse'}>
+                <span className={`session-group-chevron${collapsed ? '' : ' is-open'}`}>▶</span>
+                <span className="font-semibold">{sessionLabel(session)}</span>
+            </button>
+
+            <span className="text-xs text-muted">
+                {runsHere} here
+                {total > runsHere && ` · ${total} in session`}
+            </span>
+
+            {others.length > 0 && (
+                <span className="text-xs text-secondary">
+                    with {others.map(v => v.model || v.name).join(', ')}
+                </span>
+            )}
+
+            {session.location_name && <span className="text-xs text-faint">· {session.location_name}</span>}
+            {session.temperature_f != null && <span className="text-xs text-faint">· {session.temperature_f}°F</span>}
+
+            {session.url && (
+                <a
+                    href={session.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-500 hover:underline"
+                    onClick={e => e.stopPropagation()}
+                    title={session.url}
+                >
+                    source ↗
+                </a>
+            )}
+
+            {onEdit && (
+                <button onClick={onEdit} className="session-group-edit" title="Edit session">
+                    ✎ Edit
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { dataService } from '../services/DataService';
 import { applyDefaultRun, clearDefaultRuns } from '../utils/runUtils';
+import { toSessionRow } from '../utils/testSessions';
 
 const AppContext = createContext(null);
 
@@ -18,6 +19,7 @@ export function AppProvider({ children }) {
     const [runVotes, setRunVotes] = useState({});          // { [runId]: { vouch, flag, myVote } }
     const [units, setUnits] = useState(() => localStorage.getItem('evbench_units') || 'imperial');
     const [manufacturers, setManufacturers] = useState([]);
+    const [testSessions, setTestSessions] = useState([]);
     const [chartHelp, setChartHelp] = useState({});        // { [chart_key]: row } — "About this chart" copy
     const [performanceCounts, setPerformanceCounts] = useState({}); // { [vehicleId]: {accel, braking} } — card badges
 
@@ -72,6 +74,7 @@ export function AppProvider({ children }) {
         const siteSettings = await dataService.getSiteSettings();
         const manufacturersData = dataService.useSupabase ? await dataService.getManufacturers() : [];
         const chartHelpData = dataService.useSupabase ? await dataService.getChartHelp() : {};
+        const sessionsData = dataService.useSupabase ? await dataService.getTestSessions() : [];
         // One extra query, kept out of getVehicles so a missing performance table
         // can never take the vehicles list down with it.
         const perfCounts = dataService.useSupabase ? await dataService.getPerformanceRunCounts() : {};
@@ -94,6 +97,7 @@ export function AppProvider({ children }) {
         setSelectedVehicles(selectedIds);
         setTags(tagsData);
         setManufacturers(manufacturersData);
+        setTestSessions(sessionsData);
         setChartHelp(chartHelpData);
         setPerformanceCounts(perfCounts);
         setHeaderImageUrl(siteSettings.header_image_url || '');
@@ -283,6 +287,66 @@ export function AppProvider({ children }) {
     // runId is the run whose default is being cleared. Without it this cleared
     // every run of the vehicle, so clearing the default range test also cleared
     // the default charging run — the two are independent since migration 046.
+    // ── Test sessions ─────────────────────────────────────────────────────────
+    //
+    // Assignment runs from the RUN's side: a run picks its session, exactly like
+    // it picks a manufacturer. The multi-vehicle case — four cars round one loop
+    // — then needs no multi-vehicle UI at all: it emerges when several runs
+    // choose the same session.
+
+    const createTestSession = async (fields) => {
+        try {
+            const row = await dataService.createTestSession(fields);
+            setTestSessions(prev => [row, ...prev]);
+            return row;
+        } catch (error) {
+            logIfUnauthorized('create_test_session', 'test_session', null, error);
+            showError('Error creating session: ' + error.message);
+            return null;
+        }
+    };
+
+    const updateTestSession = async (id, changes) => {
+        try {
+            await dataService.updateTestSession(id, changes);
+            setTestSessions(prev => prev.map(s => s.id === id ? { ...s, ...toSessionRow(changes) } : s));
+        } catch (error) {
+            logIfUnauthorized('update_test_session', 'test_session', id, error);
+            showError('Error updating session: ' + error.message);
+        }
+    };
+
+    const deleteTestSession = async (id) => {
+        try {
+            await dataService.deleteTestSession(id);
+            setTestSessions(prev => prev.filter(s => s.id !== id));
+            // runs.session_id is ON DELETE SET NULL; mirror that locally.
+            setVehicles(prev => prev.map(v => ({
+                ...v,
+                runs: (v.runs || []).map(r => r.session_id === id ? { ...r, session_id: null } : r),
+            })));
+        } catch (error) {
+            logIfUnauthorized('delete_test_session', 'test_session', id, error);
+            showError('Error deleting session: ' + error.message);
+        }
+    };
+
+    const setRunsSession = async (runIds, sessionId) => {
+        const ids = (Array.isArray(runIds) ? runIds : [runIds]).filter(Boolean);
+        try {
+            await dataService.setRunsSession(ids, sessionId);
+            const idSet = new Set(ids.map(String));
+            setVehicles(prev => prev.map(v => ({
+                ...v,
+                runs: (v.runs || []).map(r =>
+                    idSet.has(String(r.id)) ? { ...r, session_id: sessionId ?? null } : r),
+            })));
+        } catch (error) {
+            logIfUnauthorized('set_run_session', 'run', ids[0] ?? null, error);
+            showError('Error assigning session: ' + error.message);
+        }
+    };
+
     const clearDefaultRun = async (vehicleId, runId = null) => {
         try {
             await dataService.clearDefaultRun(vehicleId, runId);
@@ -1384,6 +1448,11 @@ export function AppProvider({ children }) {
         updateSpecLink,
         deleteSpecLink,
         clearDefaultRun,
+        testSessions,
+        createTestSession,
+        updateTestSession,
+        deleteTestSession,
+        setRunsSession,
         searchEpaTestGroups,
         linkEpaTestGroup,
         createAndLinkEpaTestGroup,

--- a/src/index.css
+++ b/src/index.css
@@ -1406,3 +1406,47 @@ body {
     border-color: var(--color-primary);
     color: var(--color-primary);
 }
+
+/* ── Session grouping in Tests & Data ───────────────────────────────────────── */
+.session-group-header {
+    @apply flex items-center gap-3 flex-wrap px-3 py-2 rounded-lg;
+    background-color: var(--color-surface-sunken);
+    border-left: 3px solid var(--color-primary);
+}
+.session-group-header.is-unassigned {
+    border-left-color: var(--color-border);
+}
+.session-group-toggle {
+    @apply flex items-center gap-2 text-left transition-colors;
+    color: var(--color-text-primary);
+}
+.session-group-toggle:hover {
+    color: var(--color-text-secondary);
+}
+.session-group-chevron {
+    @apply inline-block text-xs transition-transform;
+    color: var(--color-text-faint);
+}
+.session-group-chevron.is-open {
+    transform: rotate(90deg);
+}
+.session-group-edit {
+    @apply ml-auto text-xs px-2 py-0.5 rounded transition-colors;
+    color: var(--color-text-faint);
+}
+.session-group-edit:hover {
+    color: var(--color-primary);
+    background-color: var(--color-card);
+}
+
+/* ── Session edit form ──────────────────────────────────────────────────────── */
+.session-edit-grid {
+    @apply grid gap-3;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.session-edit-field {
+    @apply flex flex-col gap-1;
+}
+.session-edit-field.is-wide {
+    grid-column: 1 / -1;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1383,3 +1383,26 @@ body {
 .run-selector-actions {
     @apply flex items-center gap-4 shrink-0;
 }
+
+/* ── Session browser ────────────────────────────────────────────────────────── */
+.session-browser-list {
+    @apply flex flex-col gap-2;
+}
+.session-browser-row {
+    @apply flex items-center justify-between gap-4 rounded-lg px-3 py-2;
+    background-color: var(--color-surface-sunken);
+    border: 1px solid transparent;
+}
+.session-browser-row.is-current {
+    border-color: var(--color-primary);
+}
+.session-vehicle-chip {
+    @apply text-xs px-1.5 py-0.5 rounded;
+    background-color: var(--color-card);
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+}
+.session-vehicle-chip.is-self {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1409,12 +1409,8 @@ body {
 
 /* ── Session grouping in Tests & Data ───────────────────────────────────────── */
 .session-group-header {
-    @apply flex items-center gap-3 flex-wrap px-3 py-2 rounded-lg;
+    @apply flex items-center gap-3 flex-wrap px-3 py-2;
     background-color: var(--color-surface-sunken);
-    border-left: 3px solid var(--color-primary);
-}
-.session-group-header.is-unassigned {
-    border-left-color: var(--color-border);
 }
 .session-group-toggle {
     @apply flex items-center gap-2 text-left transition-colors;
@@ -1449,4 +1445,31 @@ body {
 }
 .session-edit-field.is-wide {
     grid-column: 1 / -1;
+}
+
+/* The session card CONTAINS its runs, so collapsing visibly folds them away
+   rather than making a band and some cards disappear independently. */
+.session-group {
+    @apply rounded-xl overflow-hidden;
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-primary);
+}
+.session-group.is-unassigned {
+    border-left-color: var(--color-border);
+}
+.session-group-body {
+    @apply flex flex-col gap-3 p-3;
+    background-color: var(--color-surface-sunken);
+}
+/* Nested cards sit on the sunken group background, so they lose the outer
+   border that would otherwise read as a second frame inside the first. */
+.session-group-body > .card {
+    @apply mb-0 shadow-none;
+}
+.session-vehicle-link {
+    @apply underline decoration-dotted underline-offset-2 transition-colors;
+    color: var(--color-text-secondary);
+}
+.session-vehicle-link:hover {
+    color: var(--color-primary);
 }

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -1,6 +1,7 @@
 import { getSupabase } from './supabase';
 import { vehicleLabel } from '../utils/specHelpers';
 import { roundTo, } from '../utils/unitConversions';
+import { toSessionRow } from '../utils/testSessions';
 import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId, runKindFrom, applyDefaultRun, clearDefaultRuns } from '../utils/runUtils';
 
 const roundField = roundTo;
@@ -184,6 +185,62 @@ class DataService {
     const { data, error } = await getSupabase().from('manufacturers').select('*').order('name');
     if (error) throw error;
     return data || [];
+  }
+
+  // ── Test sessions ──────────────────────────────────────────────────────────
+  //
+  // A session is one testing outing: same day, same road, same weather, same
+  // crew. It deliberately has NO vehicle_id (migration 044) because the outings
+  // worth recording are often side-by-side — four cars round one loop — and the
+  // shared conditions are the point.
+  //
+  // Fetched globally rather than per vehicle for the same reason: a session a
+  // vehicle belongs to may have been created while curating a different one.
+
+  async getTestSessions() {
+    if (!this.useSupabase) return [];
+    const { data, error } = await getSupabase()
+      .from('test_sessions').select('*').order('tested_at', { ascending: false, nullsFirst: false });
+    if (error) throw error;
+    return data || [];
+  }
+
+  async createTestSession(fields) {
+    const { data, error } = await getSupabase()
+      .from('test_sessions')
+      .insert(toSessionRow(fields))
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  async updateTestSession(id, changes) {
+    const { error } = await getSupabase()
+      .from('test_sessions').update(toSessionRow(changes)).eq('id', id);
+    if (error) throw error;
+  }
+
+  async deleteTestSession(id) {
+    // runs.session_id is ON DELETE SET NULL, so the runs survive unattached.
+    const { error } = await getSupabase().from('test_sessions').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  /**
+   * Attach runs to a session, or detach them with a null sessionId.
+   *
+   * Takes a LIST because a session is usually assigned to several runs at once —
+   * eight in a two-car speed sweep — and one round trip per run is the shape
+   * that makes bulk assignment feel like a chore.
+   */
+  async setRunsSession(runIds, sessionId) {
+    if (!this.useSupabase || !runIds?.length) return;
+    const real = runIds.filter(id => !isInheritedRunId(id)).map(Number);
+    if (!real.length) return;
+    const { error } = await getSupabase()
+      .from('runs').update({ session_id: sessionId ?? null }).in('id', real);
+    if (error) throw error;
   }
 
   async addManufacturer(name, country = null) {

--- a/src/utils/testSessions.js
+++ b/src/utils/testSessions.js
@@ -194,17 +194,17 @@ export function summariseSessions(sessions, vehicles) {
 }
 
 /**
- * Order a vehicle's runs so each session's runs sit together, and mark where
- * each group starts.
+ * Group a vehicle's runs by session, so each session can be rendered as one
+ * container holding its runs.
  *
  * Sessions appear in the order their first run does, so a curator's existing
  * sense of the list is preserved rather than resorted underneath them.
  * Unassigned runs collect at the end: they are an absence, not an outing, and
  * putting them first would bury the grouping under the ungrouped.
  *
- * Returns a flat list — [{ run, sessionId, isGroupStart, groupSize }] — because
- * the caller renders one card per run and only needs to know where to insert a
- * heading.
+ * Returns [{ key, sessionId, runs }] — a real nesting rather than a flat list
+ * with markers, because the session card CONTAINS its runs on screen and
+ * collapsing it should visibly fold them away.
  */
 export function groupRunsBySession(runs) {
     const order = [];
@@ -220,15 +220,9 @@ export function groupRunsBySession(runs) {
     const keys = order.filter(k => k !== '__none__');
     if (bySession.has('__none__')) keys.push('__none__');
 
-    const out = [];
-    for (const key of keys) {
-        const group = bySession.get(key);
-        group.forEach((run, i) => out.push({
-            run,
-            sessionId:    key === '__none__' ? null : key,
-            isGroupStart: i === 0,
-            groupSize:    group.length,
-        }));
-    }
-    return out;
+    return keys.map(key => ({
+        key,
+        sessionId: key === '__none__' ? null : key,
+        runs: bySession.get(key),
+    }));
 }

--- a/src/utils/testSessions.js
+++ b/src/utils/testSessions.js
@@ -145,3 +145,50 @@ export function suggestedPairing(vehicles, sessionId, vehicleId) {
     if (charging.length !== 1 || range.length !== 1) return null;
     return { rangeRunId: range[0].id, chargingRunId: charging[0].id };
 }
+
+/**
+ * One row's worth of what a session IS, for browsing: when, how big, and — the
+ * part that actually identifies an outing — which cars were on it.
+ */
+export function sessionSummary(session, vehicles) {
+    const rows = runsInSession(vehicles, session.id);
+    return {
+        session,
+        runCount: rows.length,
+        vehicles: vehiclesInSession(vehicles, session.id),
+        date: session.tested_at ? String(session.tested_at).slice(0, 10) : null,
+    };
+}
+
+/**
+ * Search sessions by name OR by the vehicles taking part.
+ *
+ * Matching on vehicles matters more than it sounds: sessions inherit their names
+ * from whoever published the test ("OoS 10% Challenge" appears eight times), so
+ * the name alone often cannot tell two outings apart, while "the one with the
+ * R1S and the Model Y" always can.
+ *
+ * Terms are AND-ed, so "oos r1s" finds the OoS outing the R1S was on.
+ */
+export function filterSessions(summaries, query) {
+    const terms = String(query || '').toLowerCase().split(/\s+/).filter(Boolean);
+    if (!terms.length) return summaries;
+
+    return summaries.filter(s => {
+        const haystack = [
+            s.session.name ?? '',
+            s.date ?? '',
+            s.session.location_name ?? '',
+            s.session.tester ?? '',
+            ...s.vehicles.flatMap(v => [v.name, v.make, v.model, v.trim, v.year].filter(Boolean)),
+        ].join(' ').toLowerCase();
+        return terms.every(t => haystack.includes(t));
+    });
+}
+
+/** Every session, summarised, newest first — the browser's backing list. */
+export function summariseSessions(sessions, vehicles) {
+    return (sessions || [])
+        .map(s => sessionSummary(s, vehicles))
+        .sort((a, b) => String(b.date ?? '').localeCompare(String(a.date ?? '')));
+}

--- a/src/utils/testSessions.js
+++ b/src/utils/testSessions.js
@@ -192,3 +192,43 @@ export function summariseSessions(sessions, vehicles) {
         .map(s => sessionSummary(s, vehicles))
         .sort((a, b) => String(b.date ?? '').localeCompare(String(a.date ?? '')));
 }
+
+/**
+ * Order a vehicle's runs so each session's runs sit together, and mark where
+ * each group starts.
+ *
+ * Sessions appear in the order their first run does, so a curator's existing
+ * sense of the list is preserved rather than resorted underneath them.
+ * Unassigned runs collect at the end: they are an absence, not an outing, and
+ * putting them first would bury the grouping under the ungrouped.
+ *
+ * Returns a flat list — [{ run, sessionId, isGroupStart, groupSize }] — because
+ * the caller renders one card per run and only needs to know where to insert a
+ * heading.
+ */
+export function groupRunsBySession(runs) {
+    const order = [];
+    const bySession = new Map();
+
+    for (const run of runs || []) {
+        const key = run.session_id == null ? '__none__' : String(run.session_id);
+        if (!bySession.has(key)) { bySession.set(key, []); order.push(key); }
+        bySession.get(key).push(run);
+    }
+
+    // The absence goes last, however early its first run appeared.
+    const keys = order.filter(k => k !== '__none__');
+    if (bySession.has('__none__')) keys.push('__none__');
+
+    const out = [];
+    for (const key of keys) {
+        const group = bySession.get(key);
+        group.forEach((run, i) => out.push({
+            run,
+            sessionId:    key === '__none__' ? null : key,
+            isGroupStart: i === 0,
+            groupSize:    group.length,
+        }));
+    }
+    return out;
+}

--- a/src/utils/testSessions.js
+++ b/src/utils/testSessions.js
@@ -1,0 +1,147 @@
+/**
+ * Test sessions — one testing outing: same day, same road, same weather, same
+ * crew.
+ *
+ * A session deliberately has NO vehicle (migration 044). The outings worth
+ * recording are often side-by-side — four cars round one loop, or two cars at
+ * 50/60/70/80 mph — and the shared conditions are exactly the point. Membership
+ * is expressed from the RUN's side (`runs.session_id`), so the multi-vehicle
+ * case needs no multi-vehicle UI: it emerges when several runs pick the same
+ * session.
+ *
+ * A session is NOT a pairing. Sessions holding only charging runs (10-80, 20-80,
+ * 30-80 to shape a curve) or only range runs (a speed sweep) are ordinary. But
+ * when one vehicle contributes exactly one run of each kind, that IS the pairing
+ * — see suggestedPairing below.
+ *
+ * Pure module — no React, no Supabase.
+ */
+
+import { runKindFrom } from './runUtils';
+
+/** camelCase field → database column. One definition, so the writer and the
+ *  optimistic update cannot drift — which is how the per-kind default bug
+ *  survived a fix. */
+export const SESSION_COLUMNS = {
+    name:         'name',
+    testedAt:     'tested_at',
+    tester:       'tester',
+    locationName: 'location_name',
+    temperatureF: 'temperature_f',
+    sourceName:   'source_name',
+    url:          'url',
+    notes:        'notes',
+};
+
+const NUMERIC = new Set(['temperatureF']);
+
+/** Translate a partial camelCase change set into a database payload. */
+export function toSessionRow(changes = {}) {
+    const row = {};
+    for (const [key, col] of Object.entries(SESSION_COLUMNS)) {
+        if (!(key in changes)) continue;
+        const v = changes[key];
+        row[col] = NUMERIC.has(key)
+            ? (v != null && v !== '' ? Number(v) : null)
+            : (v || null);
+    }
+    return row;
+}
+
+/**
+ * What to call a session on screen.
+ *
+ * An unnamed session still has to be pickable, so it falls back to its date and
+ * then to its id — never to an empty string, which would render a blank option
+ * that looks like "no session".
+ */
+export function sessionLabel(session) {
+    if (!session) return '';
+    const name = session.name?.trim();
+    const date = session.tested_at ? String(session.tested_at).slice(0, 10) : null;
+    if (name && date) return `${name} (${date})`;
+    if (name) return name;
+    if (date) return `Untitled session (${date})`;
+    return `Session #${session.id}`;
+}
+
+/** Every run across every vehicle that belongs to `sessionId`. */
+export function runsInSession(vehicles, sessionId) {
+    if (sessionId == null) return [];
+    const out = [];
+    for (const v of vehicles || []) {
+        for (const r of v.runs || []) {
+            if (r._inherited) continue;          // a link, not a test event
+            if (String(r.session_id) === String(sessionId)) out.push({ run: r, vehicle: v });
+        }
+    }
+    return out;
+}
+
+/** The distinct vehicles taking part, in the order encountered. */
+export function vehiclesInSession(vehicles, sessionId) {
+    const seen = new Map();
+    for (const { vehicle } of runsInSession(vehicles, sessionId)) {
+        if (!seen.has(vehicle.id)) seen.set(vehicle.id, vehicle);
+    }
+    return [...seen.values()];
+}
+
+/**
+ * Sessions ordered for a picker: the ones this vehicle already appears in
+ * first, then everything else by date. A curator adding the fourth run of an
+ * outing should not have to hunt for the session the first three are in.
+ */
+export function sessionsForPicker(sessions, vehicles, vehicleId) {
+    const mine = new Set();
+    for (const v of vehicles || []) {
+        if (String(v.id) !== String(vehicleId)) continue;
+        for (const r of v.runs || []) {
+            // Inherited runs are links to another vehicle's test event. Their
+            // session belongs to the source vehicle, not this one — counting it
+            // here would offer a session this car never attended.
+            if (r._inherited) continue;
+            if (r.session_id != null) mine.add(String(r.session_id));
+        }
+    }
+    const byDate = (a, b) => String(b.tested_at ?? '').localeCompare(String(a.tested_at ?? ''));
+    const used   = (sessions || []).filter(s => mine.has(String(s.id))).sort(byDate);
+    const others = (sessions || []).filter(s => !mine.has(String(s.id))).sort(byDate);
+    return { used, others };
+}
+
+/**
+ * Flag a run whose own date is far from its session's.
+ *
+ * Sessions are global, so the realistic mistake is attaching a run to an outing
+ * it was not part of. This does not block anything — a curator may know better,
+ * and a session spanning midnight is real — it just says so.
+ */
+export function sessionDateMismatch(run, session, toleranceDays = 1) {
+    const runDate = run?.date ?? run?.tested_at;
+    if (!runDate || !session?.tested_at) return null;
+    const a = new Date(runDate), b = new Date(session.tested_at);
+    if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return null;
+    const days = Math.abs(a - b) / 86400000;
+    return days > toleranceDays ? Math.round(days) : null;
+}
+
+/**
+ * The pairing a session implies for one vehicle.
+ *
+ * Exactly one charging run and one range run from the same vehicle in the same
+ * outing can only go together, which turns the most common curation chore into
+ * a side effect of saying where a run came from. Anything else — a speed sweep,
+ * three charging curves — implies nothing, and returns null rather than
+ * guessing.
+ */
+export function suggestedPairing(vehicles, sessionId, vehicleId) {
+    const rows = runsInSession(vehicles, sessionId)
+        .filter(({ vehicle }) => String(vehicle.id) === String(vehicleId))
+        .map(({ run }) => run);
+
+    const charging = rows.filter(r => runKindFrom(r) === 'charging');
+    const range    = rows.filter(r => runKindFrom(r) === 'range');
+    if (charging.length !== 1 || range.length !== 1) return null;
+    return { rangeRunId: range[0].id, chargingRunId: charging[0].id };
+}


### PR DESCRIPTION
Closes the assignment half of #184. No migration — the schema and RLS policies both landed in 044.

## The shape

Assignment runs **from the run's side**: a run picks its session, exactly like it picks a manufacturer. That single decision is what lets sessions span vehicles without any multi-vehicle UI — four cars round one loop become one session because four runs each chose it. It is what dissolved the "selection/assignment would be hard" concern in the issue.

## What's in

- `DataService` — session CRUD plus `setRunsSession(runIds, sessionId)`, which takes a **list** because a session is normally assigned to several runs at once (eight in a two-car speed sweep).
- `AppContext` — `testSessions` loaded alongside manufacturers and tags, with optimistic updates. Deleting a session mirrors `ON DELETE SET NULL` locally.
- `src/utils/testSessions.js` — pure helpers: field mapping, labels, membership across vehicles, picker ordering, the date guard, and `suggestedPairing`.
- `SessionControl` — the per-run picker: sessions this vehicle is already in first, then the rest by date, plus inline "+ New session…". Shows how many runs the session holds and which other cars were there.
- The session-name seam from #170 is now live in Charge Compare and Road Trip.

## Judgement calls worth reviewing

- **A session names a pair only when both halves came from it.** One half's session says nothing about the pair, and labelling a series after an event only part of it belongs to would be worse than the composed name.
- **The date guard warns, never blocks.** Sessions being global makes "attached to the wrong outing" the realistic error, but a curator may know better and an outing can span midnight.
- **Inherited runs are excluded from a vehicle's session list.** Their session belongs to the source vehicle. The tests caught this; the browser would not have.
- **`suggestedPairing` is built but not surfaced.** When a vehicle contributes exactly one charging and one range run to a session, that is unambiguously the pairing — but wiring it to write `paired_charging_run_id` is a curation action deserving its own review.

## Not in this PR

- Bulk assign UI (the service already takes a list).
- Editing a session's weather, tester or location — creation sets name and date only.
- Group-by-session in the chart run selectors.
- Anything that creates a session on import. Today only migration 046 ever made one, which is the point issue #184 flags as deciding how far this is worth taking.

## Testing

25 assertions on the pure helpers, covering all four of the curator's use cases — the 10% challenge, the four-car side-by-side, the two-car speed sweep, and the three-charging-curve SoC sweep.

Verified in the preview by **temporarily lifting the `canEdit` gate**, since the preview is signed out; the gate is restored. The picker renders on all 8 runs of a vehicle, both option groups populate from the 28 real sessions, current values show, and the "2 runs" hint appears only where a session really holds two. **Writes are not exercised** — they need an authenticated session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)