### PR TITLE
Add a test runner, and a suite that checks the seams (#174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,20 @@ Side-by-side structured spec comparison for selected vehicles. Specs are stored 
 
 **Admin** *(admin role only)*
 User management — view registered users, assign roles (`admin`, `contributor`, `viewer`).
+
+## Testing
+
+`npm test` (vitest, `npm run test:watch` to iterate). Suites live in
+`src/utils/__tests__/` for pure modules, plus `src/__tests__/wiring.test.js`.
+
+The wiring suite is the unusual one and worth keeping. Every other test checks
+that a function returns the right answer; none of them can tell you **nobody
+calls it**. That is the failure mode this project keeps hitting — three defects
+found by hand in one week were all "built, unit-tested, never connected". The
+wiring suite reads source text to assert the seams hold: that a note written to
+every run is read somewhere, that every chart showing a test speed also marks a
+mixed cycle, that a tunable constant reaches the Admin knobs.
+
+When adding a utility for the UI, expect the wiring suite to fail until
+something consumes it. If it is deliberately unused, add it to `ALLOWED_UNUSED`
+with the reason — an entry there is a decision on record, not an oversight.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@tailwindcss/vite": "^4.1.18",
         "@vitejs/plugin-react": "^5.1.4",
         "tailwindcss": "^4.1.18",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1411,6 +1412,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.95.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
@@ -1808,6 +1816,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1864,6 +1890,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1930,6 +2079,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chart.js": {
       "version": "4.5.1",
@@ -2012,6 +2171,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -2062,6 +2228,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2489,10 +2675,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -2657,6 +2864,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2666,6 +2880,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -2688,6 +2916,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2703,6 +2948,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2821,6 +3076,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.95.3",
@@ -22,6 +24,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@vitejs/plugin-react": "^5.1.4",
     "tailwindcss": "^4.1.18",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/__tests__/wiring.test.js
+++ b/src/__tests__/wiring.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Does anything actually CALL the thing?
+ *
+ * Every other suite here checks that a function returns the right answer. None
+ * of them can tell us nobody calls it — and that is the failure mode this
+ * project keeps hitting. Three defects found by hand in one week were all
+ * "built, unit-tested, never connected":
+ *
+ *   • the mixed-cycle badge, correct in the DOM and absent from the canvas
+ *   • condition correction, wired into a fetch effect the dropdown never re-ran
+ *   • the correction note, written to every run object and read by nothing
+ *
+ * Each passed its own tests. These check the seams instead.
+ */
+
+const read = (p) => readFileSync(p, 'utf8');
+
+function sourceFiles(dir = 'src', out = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name !== '__tests__') sourceFiles(p, out);
+        } else if (/\.(js|jsx)$/.test(entry.name)) {
+            out.push(p);
+        }
+    }
+    return out;
+}
+
+const ALL = sourceFiles().map(f => ({ file: f, text: read(f) }));
+const consumersOf = (name, exclude) =>
+    ALL.filter(x => !exclude.some(e => x.file.endsWith(e)) && new RegExp(`\\b${name}\\b`).test(x.text))
+       .map(x => x.file);
+
+describe('utilities built for the UI are reached by the UI', () => {
+    // Scoped to the modules built recently rather than the whole codebase: 48
+    // exports are unused project-wide, nearly all pre-existing in the EPA and
+    // parser modules. Widening this wants a cleanup first, not an allowlist.
+    const WATCHED = ['conditionCorrection.js', 'testSessions.js', 'seriesLabel.js'];
+
+    // Deliberately unused, and why. An entry here is a decision, not an oversight.
+    const ALLOWED_UNUSED = {
+        'testSessions.suggestedPairing':
+            'Built and tested; surfacing it is a curation action awaiting its own review (#184).',
+        'conditionCorrection.DEFAULT_CORRECTION_MODE':
+            'The default value itself, consumed inside the module and by the chartConfig fallback literal.',
+        'conditionCorrection.CORRECTION_MODES':
+            'Consumed by CorrectionControl to render the picker.',
+    };
+
+    for (const mod of WATCHED) {
+        const text = read(join('src/utils', mod));
+        const exported = [...text.matchAll(/export (?:function|const) (\w+)/g)].map(m => m[1]);
+
+        it(`every export of ${mod} has a consumer`, () => {
+            const orphans = exported.filter(name => {
+                const key = `${mod.replace('.js', '')}.${name}`;
+                if (key in ALLOWED_UNUSED) return false;
+                return consumersOf(name, [mod]).length === 0;
+            });
+            expect(orphans).toEqual([]);
+        });
+    }
+});
+
+describe('the seams that broke before', () => {
+    it('reads the correction note it writes', () => {
+        // It was written to every corrected run and read by nothing, so a
+        // corrected bar looked exactly like a measured one.
+        const writers = consumersOf('_correction', []).filter(f => /RangeChartView/.test(f));
+        expect(writers.length).toBeGreaterThan(0);
+        const view = read('src/components/RangeChartView.jsx');
+        expect(view).toMatch(/_correction\?\.note/);
+    });
+
+    it('marks a mixed cycle wherever a test speed is shown', () => {
+        // The marker existed in Tests & Data and not on the charts, so a
+        // mixed-cycle bar sat unmarked beside steady-state ones.
+        const speedDisplays = ALL.filter(x =>
+            /\.jsx$/.test(x.file) && /fmtSpeed\(run\.speed_mph/.test(x.text));
+        expect(speedDisplays.length).toBeGreaterThan(0);
+        for (const { file, text } of speedDisplays) {
+            expect(text, `${file} shows a test speed without the mixed-cycle marker`)
+                .toMatch(/speedBasisNote/);
+        }
+    });
+
+    it('routes every chart that resolves a range basis through the correction', () => {
+        const resolvers = ALL.filter(x => /resolveRangeSource\(/.test(x.text) && /\.jsx$/.test(x.file));
+        expect(resolvers.length).toBeGreaterThan(0);
+        for (const { file, text } of resolvers) {
+            expect(text, `${file} resolves a range basis but never corrects it`)
+                .toMatch(/correction[:\s]|correctionFactor/);
+        }
+    });
+
+    it('composes labels on every chart rather than hand-rolling them', () => {
+        const charts = [
+            'src/components/ChargingView.jsx',
+            'src/components/RangeChartView.jsx',
+            'src/components/ChargeCompareView.jsx',
+            'src/components/RoadTripView.jsx',
+            'src/components/PerformanceCurveView.jsx',
+            'src/components/PerformanceCompareView.jsx',
+        ];
+        for (const f of charts) {
+            expect(read(f), `${f} does not use the shared label composer`).toMatch(/buildSeriesLabels/);
+        }
+    });
+
+    it('keeps vehicleLabel out of graph labelling', () => {
+        // The vehicle's free-text name is a SELECTION label. Charts must compose
+        // from atoms instead — see #170.
+        const roadTrip = read('src/components/RoadTripView.jsx');
+        const labelCalls = roadTrip.match(/label:\s*vehicleLabel\(/g) ?? [];
+        expect(labelCalls).toEqual([]);
+    });
+});
+
+describe('constants exposed for tuning are reachable in the Admin panel', () => {
+    it('offers every correction constant as a knob', () => {
+        // AERO_FRACTION drives every correction magnitude. It was made
+        // overridable and left out of the panel, so nobody could tune it.
+        const knobs = read('src/constants/knobs.js');
+        for (const key of ['AERO_FRACTION', 'TOWING_AERO_FRACTION', 'REFERENCE_SPEED_MPH',
+                           'STD_SPEED_MPH', 'STD_ALTITUDE_FT', 'STD_TEMP_F']) {
+            expect(knobs, `${key} is tunable but absent from the Admin knobs`).toContain(key);
+        }
+    });
+
+    it('defines every knob it advertises', () => {
+        const knobs = read('src/constants/knobs.js');
+        const epa = read('src/constants/epa.js');
+        for (const key of [...knobs.matchAll(/key: '(\w+)'/g)].map(m => m[1])) {
+            expect(epa, `knob ${key} has no default in EPA_DEFAULTS`).toContain(key);
+        }
+    });
+});

--- a/src/constants/knobs.js
+++ b/src/constants/knobs.js
@@ -28,6 +28,36 @@ export const KNOB_GROUPS = [
         ],
     },
     {
+        title: 'Condition correction',
+        blurb: 'How a measured range or efficiency figure is re-priced to a common basis. The aero fraction drives every correction magnitude: at 0.70 a 70→80 mph correction is +21%, at 0.60 it is ~18%.',
+        knobs: [
+            { key: 'AERO_FRACTION', label: 'Aero fraction at reference speed', kind: 'number',
+              min: 0.30, max: 0.95, step: 0.01, unit: '',
+              help: 'Share of energy spent on aerodynamic drag at the reference speed, unladen. One value for every vehicle — a slippery sedan and a boxy SUV genuinely differ, so this is an average rather than a truth.' },
+            { key: 'TOWING_AERO_FRACTION', label: 'Aero fraction when towing', kind: 'number',
+              min: 0.30, max: 0.99, step: 0.01, unit: '',
+              help: 'A trailer roughly doubles Cd×A, so aero dominates further. Used by the road-trip simulator.' },
+            { key: 'REFERENCE_SPEED_MPH', label: 'Reference speed', kind: 'number',
+              min: 30, max: 100, step: 1, unit: 'mph',
+              help: 'The speed the aero fraction is quoted at. Changing it rescales what that fraction means.' },
+        ],
+    },
+    {
+        title: 'Standard conditions',
+        blurb: 'The basis every corrected figure is re-priced TO. Not the same as the ISA 59°F reference the density formula is built on, which is physics rather than a choice.',
+        knobs: [
+            { key: 'STD_SPEED_MPH', label: 'Standard speed', kind: 'number',
+              min: 30, max: 100, step: 1, unit: 'mph',
+              help: 'Corrected figures are stated as though driven at this speed.' },
+            { key: 'STD_ALTITUDE_FT', label: 'Standard altitude', kind: 'number',
+              min: -500, max: 10000, step: 100, unit: 'ft',
+              help: 'Corrected figures are stated as though at this elevation.' },
+            { key: 'STD_TEMP_F', label: 'Standard temperature', kind: 'number',
+              min: -20, max: 120, step: 1, unit: '°F',
+              help: 'Corrected figures are stated as though at this ambient temperature. Only the AIR-DENSITY effect of temperature is modelled — cabin heating and battery conditioning are not.' },
+        ],
+    },
+    {
         title: 'Sanity bands & curve extent',
         blurb: 'Bounds for the Section-8 "out of band" flags and the speed range the curve is plotted over.',
         knobs: [

--- a/src/utils/__tests__/colorUtils.test.js
+++ b/src/utils/__tests__/colorUtils.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePairColors } from '../colorUtils';
+
+const r = (key, primaryId, baseColor) => ({ key, primaryId, baseColor });
+const dist = (x, y) => {
+    const p = h => [1, 3, 5].map(i => parseInt(h.slice(i, i + 2), 16));
+    const [a, b] = [p(x), p(y)];
+    return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+};
+
+describe('pair colours', () => {
+    it('leaves an unpaired primary exactly as it was', () => {
+        const out = resolvePairColors([r('a', 1, '#0072B2'), r('b', 2, '#D55E00')]);
+        expect(out).toEqual({ a: '#0072B2', b: '#D55E00' });
+    });
+
+    it('stops two partners of one primary from colliding', () => {
+        const out = resolvePairColors([r('a', 1, '#0072B2'), r('b', 1, '#0072B2'), r('c', 2, '#D55E00')]);
+        expect(out.a).not.toBe(out.b);
+    });
+
+    it('keeps the first partner untouched, so nothing moves until it must', () => {
+        const out = resolvePairColors([r('a', 1, '#0072B2'), r('b', 1, '#0072B2')]);
+        expect(out.a).toBe('#0072B2');
+    });
+
+    it('keeps shaded partners closer to each other than to another slot', () => {
+        // The whole point: related series should read as related.
+        const out = resolvePairColors([r('a', 1, '#0072B2'), r('b', 1, '#0072B2'), r('c', 2, '#D55E00')]);
+        expect(dist(out.a, out.b)).toBeLessThan(dist(out.a, out.c));
+    });
+
+    it('leaves an unrelated primary unaffected by a neighbour being shaded', () => {
+        const out = resolvePairColors([r('a', 1, '#0072B2'), r('b', 1, '#0072B2'), r('c', 2, '#D55E00')]);
+        expect(out.c).toBe('#D55E00');
+    });
+
+    it('gives six partners of one primary distinct colours', () => {
+        const out = resolvePairColors([1,2,3,4,5,6].map(i => r(`k${i}`, 9, '#009E73')));
+        expect(new Set(Object.values(out)).size).toBeGreaterThanOrEqual(5);
+    });
+
+    it('still yields usable distinct colours with no base colour', () => {
+        const out = resolvePairColors([r('a', 1, null), r('b', 1, undefined)]);
+        expect(out.a).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(out.a).not.toBe(out.b);
+    });
+
+    it('tolerates empty and undefined input', () => {
+        expect(resolvePairColors([])).toEqual({});
+        expect(resolvePairColors()).toEqual({});
+    });
+});

--- a/src/utils/__tests__/conditionCorrection.test.js
+++ b/src/utils/__tests__/conditionCorrection.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { correctionFactor, applyCorrection, correctionNote } from '../conditionCorrection';
+import { airDensityRatio, temperatureDensityRatio } from '../epaDerivations';
+
+const STD = { speedMph: 70, altitudeFt: 0, temperatureF: 70 };
+const f = (cond, mode = 'aero') => correctionFactor(cond, { mode }).factor;
+
+describe('identity', () => {
+    it('leaves a test already at standard conditions alone', () => {
+        expect(f(STD)).toBeCloseTo(1, 9);
+    });
+
+    it('corrects nothing in mode "none", whatever the conditions', () => {
+        expect(f({ speedMph: 80, altitudeFt: 5280, temperatureF: 20 }, 'none')).toBe(1);
+    });
+});
+
+describe('direction', () => {
+    it('corrects a Denver test DOWN — thin air flattered it', () => {
+        expect(f({ ...STD, altitudeFt: 5280 })).toBeLessThan(1);
+    });
+
+    it('corrects a cold test UP — it fought denser air', () => {
+        expect(f({ ...STD, temperatureF: 20 })).toBeGreaterThan(1);
+    });
+
+    it('corrects a fast test UP and a slow test DOWN', () => {
+        expect(f({ ...STD, speedMph: 80 })).toBeGreaterThan(1);
+        expect(f({ ...STD, speedMph: 55 })).toBeLessThan(1);
+    });
+});
+
+describe('magnitude', () => {
+    it('prices Denver at roughly 10%', () => {
+        expect(1 - f({ ...STD, altitudeFt: 5280 })).toBeGreaterThan(0.08);
+        expect(1 - f({ ...STD, altitudeFt: 5280 })).toBeLessThan(0.12);
+    });
+
+    it('prices 20°F at only ~7% — the aero slice of a 20-40% real loss', () => {
+        const cold = f({ ...STD, temperatureF: 20 }) - 1;
+        expect(cold).toBeGreaterThan(0.05);
+        expect(cold).toBeLessThan(0.09);
+    });
+
+    it('matches the algebra exactly for a speed change', () => {
+        // The density term does NOT cancel: it multiplies only the aero share,
+        // so the split shifts slightly at a non-unity density.
+        const d70 = temperatureDensityRatio(70) * airDensityRatio(0);
+        const expected = (0.7 * (80 / 70) ** 2 * d70 + 0.3) / (0.7 * d70 + 0.3);
+        expect(f({ ...STD, speedMph: 80 })).toBeCloseTo(expected, 9);
+    });
+
+    it('corrects a speed gap harder at a higher aero fraction', () => {
+        const towing = correctionFactor({ ...STD, speedMph: 80 }, { mode: 'aero', aeroFraction: 0.85 }).factor;
+        expect(towing).toBeGreaterThan(f({ ...STD, speedMph: 80 }));
+    });
+});
+
+describe('the case that motivated it', () => {
+    it('recovers the same efficiency from an 80 mph test as from a 70 mph one', () => {
+        const k = f({ ...STD, speedMph: 80 });
+        const measuredAt80 = 3.20 / k;          // what an 80 mph test would read
+        expect(measuredAt80 * k).toBeCloseTo(3.20, 9);
+    });
+});
+
+describe('missing data is reported, never invented', () => {
+    it('lists an unrecorded axis as missing while correcting what was recorded', () => {
+        const r = correctionFactor({ speedMph: 80 }, { mode: 'aero' });
+        expect(r.missing).toContain('altitude');
+        expect(r.missing).toContain('temperature');
+        expect(r.applied).toContain('speed');
+        expect(r.factor).toBeGreaterThan(1);
+    });
+
+    it('leaves a run with no conditions untouched', () => {
+        const r = correctionFactor({}, { mode: 'aero' });
+        expect(r.factor).toBe(1);
+        expect(r.missing).toHaveLength(3);
+    });
+
+    it('tolerates null conditions', () => {
+        expect(correctionFactor(null, { mode: 'aero' }).factor).toBe(1);
+    });
+});
+
+describe('mixed-cycle tests', () => {
+    // Aero energy goes as the mean of v²; an average speed supplies the square
+    // of the mean, and <v²> > <v>², so correcting from it is invalid.
+    const mixed = { speedMph: 52.7, speedBasis: 'mixed', altitudeFt: 5280, temperatureF: 80 };
+
+    it('skips the speed axis with a reason rather than silently applying it', () => {
+        const r = correctionFactor(mixed, { mode: 'aero' });
+        expect(r.skipped).toContainEqual({ axis: 'speed', reason: 'mixed cycle' });
+        expect(r.applied).not.toContain('speed');
+    });
+
+    it('still applies altitude and temperature — density ignores the speed trace', () => {
+        const r = correctionFactor(mixed, { mode: 'aero' });
+        expect(r.applied).toContain('altitude');
+        expect(r.applied).toContain('temperature');
+    });
+
+    it('avoids the implausible result treating it as steady would produce', () => {
+        const asMixed  = correctionFactor(mixed, { mode: 'aero' }).factor;
+        const asSteady = correctionFactor({ ...mixed, speedBasis: 'steady' }, { mode: 'aero' }).factor;
+        expect(asMixed).toBeGreaterThan(asSteady);
+        expect(277 * asMixed).toBeGreaterThan(240);     // not the 191 mi it collapsed to
+    });
+
+    it('changes nothing at the reference speed, and leaves unflagged runs alone', () => {
+        const flagged = correctionFactor({ speedMph: 70, speedBasis: 'mixed', altitudeFt: 5280, temperatureF: 70 }, { mode: 'aero' });
+        const plain   = correctionFactor({ speedMph: 70, altitudeFt: 5280, temperatureF: 70 }, { mode: 'aero' });
+        expect(flagged.factor).toBeCloseTo(plain.factor, 9);
+        expect(correctionFactor({ speedMph: 80 }, { mode: 'aero' }).applied).toContain('speed');
+    });
+});
+
+describe('one factor drives both figures', () => {
+    it('scales efficiency and range-per-SoC identically', () => {
+        expect(applyCorrection({ miPerKwh: 3.0, miPerSoc: 2.5 }, 1.1))
+            .toEqual({ miPerKwh: 3.3000000000000003, miPerSoc: 2.75 });
+    });
+
+    it('leaves a null figure null rather than making it 0', () => {
+        expect(applyCorrection({ miPerKwh: null, miPerSoc: 2 }, 1.1).miPerKwh).toBeNull();
+    });
+
+    it('passes through unchanged at factor 1', () => {
+        expect(applyCorrection({ miPerKwh: 3, miPerSoc: 2 }, 1).miPerKwh).toBe(3);
+    });
+});
+
+describe('the note never lets a corrected number pass for measured', () => {
+    it('says nothing when nothing happened', () => {
+        expect(correctionNote({ factor: 1, applied: [], missing: [], skipped: [] })).toBeNull();
+    });
+
+    it('states direction, size, axes and gaps', () => {
+        const note = correctionNote(correctionFactor({ speedMph: 80, altitudeFt: 5280 }, { mode: 'aero' }));
+        expect(note).toMatch(/corrected [+-]/);
+        expect(note).toContain('speed');
+        expect(note).toContain('no temperature recorded');
+    });
+
+    it('says why an axis was skipped, even when nothing else was corrected', () => {
+        const note = correctionNote(correctionFactor({ speedMph: 52.7, speedBasis: 'mixed' }, { mode: 'aero' }));
+        expect(note).toContain('speed not corrected (mixed cycle)');
+    });
+});

--- a/src/utils/__tests__/rangeSource.test.js
+++ b/src/utils/__tests__/rangeSource.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRangeSource } from '../rangeSource';
+
+const rangeRun = (over = {}) => ({
+    id: 2, kind: 'range', name: 'R', start_soc: 90, end_soc: 10,
+    distance_miles: 240, energy_kwh: 75, speed_mph: 70, temperature_f: 70, altitude_ft: 0, ...over,
+});
+const charging = { id: 1, kind: 'charging', name: 'C' };
+const veh = r => ({ id: 9, battery: 80, runs: [charging, r] });
+const resolve = (r, opts) => resolveRangeSource(charging, { vehicle: veh(r), explicitPairing: r, ...opts });
+
+describe('correction at the range-source chokepoint', () => {
+    it('leaves figures untouched when no correction is asked for', () => {
+        const res = resolve(rangeRun());
+        expect(res.correction).toBeNull();
+        expect(res.miPerSoc).toBe(3);
+    });
+
+    it('corrects an 80 mph basis upward', () => {
+        const at80 = rangeRun({ speed_mph: 80 });
+        const off = resolve(at80);
+        const on  = resolve(at80, { correction: { mode: 'aero' } });
+        expect(on.miPerSoc).toBeGreaterThan(off.miPerSoc);
+    });
+
+    it('moves miPerKwh and miPerSoc by the same factor', () => {
+        const at80 = rangeRun({ speed_mph: 80 });
+        const off = resolve(at80);
+        const on  = resolve(at80, { correction: { mode: 'aero' } });
+        expect(on.miPerKwh / off.miPerKwh).toBeCloseTo(on.miPerSoc / off.miPerSoc, 9);
+    });
+
+    it('reports what it did, so a chart can say so', () => {
+        const on = resolve(rangeRun({ speed_mph: 80 }), { correction: { mode: 'aero' } });
+        expect(on.correction.applied).toContain('speed');
+        expect(on.correction.note).toMatch(/corrected \+/);
+    });
+
+    it('keeps provenance intact through correction', () => {
+        const on = resolve(rangeRun({ speed_mph: 80 }), { correction: { mode: 'aero' } });
+        expect(on.source).toBe('paired');
+        expect(on.sourceRun.id).toBe(2);
+    });
+});
+
+describe('conditions come from the range test, falling back to its session', () => {
+    it('fills in a session altitude for a run that omits one', () => {
+        const noAlt = rangeRun({ altitude_ft: null });
+        const res = resolve(noAlt, {
+            correction: { mode: 'aero' },
+            session: { altitude_ft: 5280, temperature_f: 70 },
+        });
+        expect(res.correction.applied).toContain('altitude');
+        expect(res.miPerSoc).toBeLessThan(3);
+    });
+
+    it("lets a run's own altitude beat its session's", () => {
+        const res = resolve(rangeRun({ altitude_ft: 0 }), {
+            correction: { mode: 'aero' },
+            session: { altitude_ft: 5280 },
+        });
+        expect(res.miPerSoc).toBeCloseTo(3, 9);
+    });
+
+    it('leaves a run with no conditions alone and says which are missing', () => {
+        const bare = rangeRun({ speed_mph: null, temperature_f: null, altitude_ft: null });
+        const res = resolve(bare, { correction: { mode: 'aero' } });
+        expect(res.miPerSoc).toBeCloseTo(3, 9);
+        expect(res.correction.missing).toHaveLength(3);
+    });
+});

--- a/src/utils/__tests__/runUtils.test.js
+++ b/src/utils/__tests__/runUtils.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { applyDefaultRun, clearDefaultRuns, runKindFrom } from '../runUtils';
+
+// A vehicle after the 046 split: charging halves and range halves side by side.
+const fleet = () => ([
+    { id: 1, kind: 'charging', isDefault: true },
+    { id: 2, kind: 'charging', isDefault: false },
+    { id: 3, kind: 'range',    isDefault: true },
+    { id: 4, kind: 'range',    isDefault: false },
+]);
+const flags = rs => rs.map(r => `${r.id}${r.isDefault ? '*' : ''}`);
+
+describe('a vehicle holds one default per KIND', () => {
+    it('leaves the charging default standing when a range default is set', () => {
+        expect(flags(applyDefaultRun(fleet(), 4))).toEqual(['1*', '2', '3', '4*']);
+    });
+
+    it('leaves the range default standing when a charging default is set', () => {
+        expect(flags(applyDefaultRun(fleet(), 2))).toEqual(['1', '2*', '3*', '4']);
+    });
+
+    it('displaces the previous default of the SAME kind', () => {
+        expect(flags(applyDefaultRun(fleet(), 2))).not.toContain('1*');
+    });
+});
+
+describe('clearing', () => {
+    it('clears one run without disturbing the other kind', () => {
+        expect(flags(clearDefaultRuns(fleet(), 3))).toEqual(['1*', '2', '3', '4']);
+    });
+
+    it('clears everything with no id, for discarding a vehicle', () => {
+        expect(flags(clearDefaultRuns(fleet()))).toEqual(['1', '2', '3', '4']);
+    });
+
+    it('changes nothing for an id that is not there', () => {
+        expect(flags(clearDefaultRuns(fleet(), 99))).toEqual(['1*', '2', '3*', '4']);
+    });
+});
+
+describe('edges', () => {
+    it('scopes pre-046 rows by their has_charging/has_range flags', () => {
+        const legacy = [
+            { id: 1, has_charging: true,  has_range: false, isDefault: true },
+            { id: 2, has_charging: false, has_range: true,  isDefault: true },
+            { id: 3, has_charging: false, has_range: true,  isDefault: false },
+        ];
+        expect(flags(applyDefaultRun(legacy, 3))).toEqual(['1*', '2', '3*']);
+    });
+
+    it('treats an unknown runId as a no-op rather than clearing every default', () => {
+        expect(flags(applyDefaultRun(fleet(), 99))).toEqual(['1*', '2', '3*', '4']);
+    });
+
+    it('does not mutate its input', () => {
+        const rs = fleet();
+        applyDefaultRun(rs, 4);
+        expect(flags(rs)).toEqual(['1*', '2', '3*', '4']);
+    });
+
+    it('tolerates empty and null', () => {
+        expect(applyDefaultRun([], 1)).toEqual([]);
+        expect(applyDefaultRun(null, 1)).toEqual([]);
+        expect(clearDefaultRuns(null)).toEqual([]);
+    });
+});
+
+describe('runKindFrom', () => {
+    it('prefers an explicit kind, falling back to the legacy flag pair', () => {
+        expect(runKindFrom({ kind: 'range' })).toBe('range');
+        expect(runKindFrom({ has_range: true, has_charging: false })).toBe('range');
+        expect(runKindFrom({})).toBe('charging');
+    });
+});

--- a/src/utils/__tests__/seriesLabel.test.js
+++ b/src/utils/__tests__/seriesLabel.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeriesLabels } from '../seriesLabel';
+
+const V = (year, make, model, trim, name) => ({ year, make, model, trim, name });
+const shorts = (series, opts) => [...buildSeriesLabels(series, opts).values()].map(v => v.short);
+const S = (key, vehicle, range, charging) => ({
+    key, vehicle,
+    rangeRun:    range    ? { name: range }    : null,
+    chargingRun: charging ? { name: charging } : null,
+});
+const VEHICLE_ATOMS = ['year', 'make', 'model', 'trim'];
+
+describe('the three cases documented in #170', () => {
+    const m3 = y => V(y, 'Tesla', 'Model 3', 'LR');
+
+    it('names three model years by year alone', () => {
+        expect(shorts([S('a', m3('2024'), '70 mph'), S('b', m3('2025'), '70 mph'), S('c', m3('2026'), '70 mph')]))
+            .toEqual(['2024', '2025', '2026']);
+    });
+
+    it('names four tests on one car by test alone', () => {
+        expect(shorts([
+            S('a', m3('2024'), '70 mph cold'), S('b', m3('2024'), '80 mph'),
+            S('c', m3('2024'), '70 mph mild'), S('d', m3('2024'), '60 mph'),
+        ])).toEqual(['70 mph cold', '80 mph', '70 mph mild', '60 mph']);
+    });
+
+    it('names three cars × four tests by vehicle AND test', () => {
+        // Model alone leaves four-way ties, so the test joins it.
+        const cars = [V('2026','Tesla','Model 3','LR'), V('2026','Tesla','Model Y','LR'), V('2026','Ford','Mach-E','GT')];
+        const tests = ['70 mph', '80 mph', '60 mph', '90 mph'];
+        const series = cars.flatMap((c, ci) => tests.map((t, ti) => S(`${ci}-${ti}`, c, t)));
+        expect(shorts(series)).toEqual(cars.flatMap(c => tests.map(t => `${c.model} · ${t}`)));
+    });
+});
+
+describe('marginal discriminating power, not variation', () => {
+    it('drops the year when the model already separates every car', () => {
+        // The Road Trip regression: eight models across four model years, every
+        // year differing, yet the year distinguishes nothing the model has not.
+        const fleet = [
+            V('2025','Toyota','Rav4',''), V('2026','Chevy','Trailseeker',''), V('2026','BMW','iX3',''),
+            V('2027','Rivian','R2','Performance'), V('2027','Chevy','Bolt',''),
+            V('2025-2026','Rivian','R1S','Dual Max'), V('2025','Lucid','Gravity','Grand Touring'),
+        ];
+        expect(shorts(fleet.map((v, i) => S(`k${i}`, v, 'road trip'))))
+            .toEqual(['Rav4','Trailseeker','iX3','R2','Bolt','R1S','Gravity']);
+    });
+
+    it('charges only the colliding pair for the year', () => {
+        expect(shorts([
+            S('a', V('2025','Toyota','Rav4',''), 't'), S('b', V('2027','Chevy','Bolt',''), 't'),
+            S('c', V('2025','Rivian','R1S',''), 't'), S('d', V('2026','Rivian','R1S',''), 't'),
+        ])).toEqual(['Rav4', 'Bolt', '2025 · R1S', '2026 · R1S']);
+    });
+
+    it('drops a model that has become constant within its group', () => {
+        expect(shorts([
+            S('a', V('2025','Rivian','R1S','Dual Max'), 't'),
+            S('b', V('2026','Rivian','R1S','Quad'), 't'),
+        ])).toEqual(['Dual Max', 'Quad']);
+    });
+});
+
+describe('surface-supplied context', () => {
+    it('needs no extra atom for series the axis already separates', () => {
+        expect(shorts([
+            S('a', V('2026','Tesla','Model 3','LR'), '70 mph'),
+            S('b', V('2025','Ford','F-150','XLT'), '80 mph'),
+        ], { supplied: VEHICLE_ATOMS })).toEqual(['70 mph', '80 mph']);
+    });
+
+    it('names the charging half only where the range test alone is ambiguous', () => {
+        expect(shorts([
+            S('a', V('2026','Rivian','R1S',''), 'OoS 70mph', 'Out of Spec & Forums'),
+            S('b', V('2026','Rivian','R1S',''), 'Theoretical', 'A'),
+            S('c', V('2026','Rivian','R1S',''), 'Theoretical', 'B'),
+        ], { supplied: VEHICLE_ATOMS })).toEqual(['OoS 70mph', 'Theoretical · A', 'Theoretical · B']);
+    });
+});
+
+describe('duplicate atom values', () => {
+    it('says an identical range and charging name once', () => {
+        // Migration 046 gave both halves of a split run the same name.
+        expect(shorts([
+            S('a', V('2026','Rivian','R1S',''), 'Theoretical', 'Theoretical'),
+            S('b', V('2026','Rivian','R1S',''), 'Theoretical', 'Fast'),
+            S('c', V('2026','Rivian','R1S',''), 'OoS', 'OoS'),
+        ], { supplied: VEHICLE_ATOMS })).toEqual(['Theoretical', 'Theoretical · Fast', 'OoS']);
+    });
+
+    it('dedupes in the full tier too', () => {
+        const m = buildSeriesLabels([S('a', V('2026','Rivian','R1S',''), 'Theoretical', 'Theoretical')]);
+        expect(m.get('a').full).toBe('2026 · Rivian · R1S · Theoretical');
+    });
+});
+
+describe('fallbacks', () => {
+    it('falls back to the vehicle name for a lone series', () => {
+        expect(shorts([S('a', V('2024','Tesla','Model 3','LR','My Model 3'), '70 mph')])).toEqual(['My Model 3']);
+    });
+
+    it('prefers the test name when the surface already supplies the vehicle', () => {
+        expect(shorts([S('a', V('2026','Kia','EV6','','My EV6'), 'OoS 70mph')], { supplied: VEHICLE_ATOMS }))
+            .toEqual(['OoS 70mph']);
+    });
+
+    it('never renders a blank label for series identical on every atom', () => {
+        expect(shorts([
+            S('a', V('2024','Tesla','Model 3','LR','My M3'), '70 mph'),
+            S('b', V('2024','Tesla','Model 3','LR','My M3'), '70 mph'),
+        ])).toEqual(['My M3', 'My M3']);
+    });
+
+    it('prefers a session name over a bare fallback', () => {
+        expect(shorts([{ ...S('a', V('2024','Tesla','Model 3','LR'), '70 mph'), sessionName: 'Ottawa loop' }]))
+            .toEqual(['Ottawa loop']);
+    });
+});
+
+describe('domain atoms', () => {
+    const SRC  = [{ key: 'source', of: s => s.sourceName }];
+    const CURV = [{ key: 'mode', of: s => s.mode }, { key: 'run', of: s => s.seq }, { key: 'source', of: s => s.source }];
+    const P = (key, vehicle, extra) => ({ key, vehicle, ...extra });
+    const m3p = y => V(y, 'Tesla', 'Model 3', 'Performance');
+
+    it('takes atoms from the surface rather than assuming range/charging', () => {
+        expect(shorts([
+            P('a', V('2025','Tesla','Model 3','Perf'), { sourceName: 'Car and Driver' }),
+            P('b', V('2026','Lucid','Air','GT'), { sourceName: 'MotorTrend' }),
+        ], { atoms: SRC })).toEqual(['Model 3', 'Air']);
+    });
+
+    it('includes a required atom even where it is not needed', () => {
+        expect(shorts([
+            P('a', V('2025','Tesla','Model 3','Perf'), { sourceName: 'Car and Driver' }),
+            P('b', V('2025','Tesla','Model 3','Perf'), { sourceName: 'MotorTrend' }),
+            P('c', V('2026','Lucid','Air','GT'), { sourceName: 'Edmunds' }),
+        ], { atoms: SRC, required: ['source'] }))
+            .toEqual(['Model 3 · Car and Driver', 'Model 3 · MotorTrend', 'Air · Edmunds']);
+    });
+
+    it('does not let a required atom excuse an ambiguous vehicle', () => {
+        // Two model years must still be told apart by year, not left to the
+        // reader to guess whether the difference is the car or the source.
+        expect(shorts([
+            P('a', m3p('2025'), { sourceName: 'Car and Driver' }),
+            P('b', m3p('2026'), { sourceName: 'MotorTrend' }),
+        ], { atoms: SRC, required: ['source'] }))
+            .toEqual(['2025 · Car and Driver', '2026 · MotorTrend']);
+    });
+
+    it('names accel curves by drive mode, reaching for the run number only on a tie', () => {
+        expect(shorts([
+            P('a', m3p('2025'), { mode: 'Sport', seq: '#1' }),
+            P('b', m3p('2025'), { mode: 'Sport', seq: '#2' }),
+            P('c', m3p('2025'), { mode: 'Track', seq: '#1' }),
+        ], { atoms: CURV })).toEqual(['Sport · #1', 'Sport · #2', 'Track']);
+    });
+
+    it('distinguishes two model years the old hand-rolled rule could not', () => {
+        // That rule always dropped year and trim, so these were identical.
+        expect(shorts([
+            P('a', m3p('2025'), { mode: 'Sport', seq: '#1' }),
+            P('b', m3p('2026'), { mode: 'Sport', seq: '#1' }),
+        ], { atoms: CURV })).toEqual(['2025', '2026']);
+    });
+});
+
+describe('the shelved free-text override', () => {
+    const oy = (key, y, t) => ({ key, vehicle: V(y, 'Tesla', 'Model 3', 'LR'), rangeRun: { name: t } });
+
+    it('wins over the composed label, in both tiers', () => {
+        const m = buildSeriesLabels([oy('a', '2024', '70 mph')], { overrides: { a: 'winter' } });
+        expect(m.get('a')).toEqual({ short: 'winter', full: 'winter' });
+    });
+
+    it('does not lengthen its neighbours, being already distinct', () => {
+        expect(shorts([oy('a','2024','70 mph'), oy('b','2024','80 mph'), oy('c','2025','90 mph')],
+            { overrides: { a: 'new tyres' } })).toEqual(['new tyres', '2024', '2025']);
+    });
+
+    it('ignores a blank override rather than rendering an empty label', () => {
+        // Both then contest normally, and the year is what separates them.
+        expect(shorts([oy('a','2024','70 mph'), oy('b','2025','70 mph')], { overrides: { a: '   ' } }))
+            .toEqual(['2024', '2025']);
+    });
+});
+
+describe('edges', () => {
+    it('returns an empty map for no series', () => {
+        expect([...buildSeriesLabels([]).values()]).toEqual([]);
+    });
+
+    it('elides blank trims without leaving a gap', () => {
+        expect(shorts([
+            S('a', V('2026','Kia','EV6',''), '70'),
+            S('b', V('2026','Kia','EV9',null), '80'),
+        ])).toEqual(['EV6', 'EV9']);   // model alone separates them; the test adds nothing
+    });
+});

--- a/src/utils/__tests__/testSessions.test.js
+++ b/src/utils/__tests__/testSessions.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+    toSessionRow, sessionLabel, runsInSession, vehiclesInSession, sessionsForPicker,
+    sessionDateMismatch, suggestedPairing, summariseSessions, filterSessions,
+    groupRunsBySession, sessionFor,
+} from '../testSessions';
+
+const car = (id, name, runs, extra = {}) => ({ id, name, runs, ...extra });
+const run = (id, kind, session_id, extra = {}) => ({ id, kind, session_id, ...extra });
+
+// The Out of Spec case: two cars, one loop, charge either side of the drive.
+const fleet = [
+    car(1, 'R1S',     [run(10, 'charging', 5), run(11, 'range', 5)], { make: 'Rivian', model: 'R1S' }),
+    car(2, 'Model Y', [run(20, 'charging', 5), run(21, 'range', 5)], { make: 'Tesla', model: 'Model Y' }),
+    car(3, 'Bolt',    [run(30, 'range', 9)],                          { make: 'Chevy', model: 'Bolt' }),
+    car(4, 'iX3',     [run(40, 'range', null), run(41, 'charging', 5, { _inherited: true })]),
+];
+
+describe('field mapping', () => {
+    it('writes only supplied fields, so a partial edit cannot blank a column', () => {
+        expect(toSessionRow({ name: 'Ottawa loop' })).toEqual({ name: 'Ottawa loop' });
+    });
+
+    it('turns empty strings into null and keeps a real zero', () => {
+        expect(toSessionRow({ name: '', temperatureF: 0 })).toEqual({ name: null, temperature_f: 0 });
+    });
+
+    it('ignores unknown keys rather than sending them to the database', () => {
+        expect(toSessionRow({ nonsense: 1, name: 'x' })).toEqual({ name: 'x' });
+    });
+});
+
+describe('labels', () => {
+    it('never yields a blank option', () => {
+        expect(sessionLabel({ id: 1, name: 'Ottawa loop', tested_at: '2026-02-11T08:00' })).toBe('Ottawa loop (2026-02-11)');
+        expect(sessionLabel({ id: 1, tested_at: '2026-02-11' })).toBe('Untitled session (2026-02-11)');
+        expect(sessionLabel({ id: 7 })).toBe('Session #7');
+    });
+});
+
+describe('membership spans vehicles', () => {
+    it('gathers runs from every vehicle in the session', () => {
+        expect(runsInSession(fleet, 5).map(x => x.run.id)).toEqual([10, 11, 20, 21]);
+    });
+
+    it('excludes inherited runs — a link is not a test event', () => {
+        expect(runsInSession(fleet, 5).some(x => x.run._inherited)).toBe(false);
+    });
+
+    it('lists the distinct vehicles taking part', () => {
+        expect(vehiclesInSession(fleet, 5).map(v => v.name)).toEqual(['R1S', 'Model Y']);
+    });
+
+    it('gathers nothing for a null session rather than every unassigned run', () => {
+        expect(runsInSession(fleet, null)).toHaveLength(0);
+    });
+});
+
+describe('picker ordering', () => {
+    const sessions = [
+        { id: 5, name: 'OoS 4-car loop', tested_at: '2026-02-11' },
+        { id: 9, name: 'Bolt solo', tested_at: '2026-03-01' },
+        { id: 12, name: 'Older outing', tested_at: '2026-01-04' },
+    ];
+
+    it("puts this vehicle's own sessions first, then the rest newest-first", () => {
+        const { used, others } = sessionsForPicker(sessions, fleet, 1);
+        expect(used.map(s => s.id)).toEqual([5]);
+        expect(others.map(s => s.id)).toEqual([9, 12]);
+    });
+
+    it("does not count an inherited run's session as the vehicle's own", () => {
+        // Vehicle 4's only session_id comes from an inherited run, which belongs
+        // to the source vehicle — offering it would name an outing it never attended.
+        expect(sessionsForPicker(sessions, fleet, 4).used).toHaveLength(0);
+    });
+});
+
+describe('date guard', () => {
+    it('flags a run far from its session, with the gap in days', () => {
+        expect(sessionDateMismatch({ date: '2026-02-20' }, { tested_at: '2026-02-11' })).toBe(9);
+    });
+
+    it('stays quiet for the same day, an outing spanning midnight, or a missing date', () => {
+        expect(sessionDateMismatch({ date: '2026-02-11' }, { tested_at: '2026-02-11' })).toBeNull();
+        expect(sessionDateMismatch({ date: '2026-02-12' }, { tested_at: '2026-02-11T23:00' })).toBeNull();
+        expect(sessionDateMismatch({}, { tested_at: '2026-02-11' })).toBeNull();
+    });
+});
+
+describe('implied pairing', () => {
+    it('treats one charging + one range from one vehicle as the pairing', () => {
+        expect(suggestedPairing(fleet, 5, 1)).toEqual({ rangeRunId: 11, chargingRunId: 10 });
+    });
+
+    it('scopes per vehicle rather than across the whole outing', () => {
+        expect(suggestedPairing(fleet, 5, 2)).toEqual({ rangeRunId: 21, chargingRunId: 20 });
+    });
+
+    it('implies nothing for a speed sweep or a charging-only session', () => {
+        const sweep = [car(1, 'R1S', [10, 11, 12, 13].map(i => run(i, 'range', 7)))];
+        expect(suggestedPairing(sweep, 7, 1)).toBeNull();
+        const socSweep = [car(1, 'R1S', [10, 11, 12].map(i => run(i, 'charging', 8)))];
+        expect(suggestedPairing(socSweep, 8, 1)).toBeNull();
+        expect(suggestedPairing(fleet, 9, 3)).toBeNull();
+    });
+});
+
+describe('browsing and search', () => {
+    const all = [
+        { id: 5,  name: 'OoS 10% Challenge', tested_at: '2026-02-11' },
+        { id: 9,  name: 'OoS 10% Challenge', tested_at: '2026-03-01' },
+        { id: 12, name: 'Peregrine Dreams',  tested_at: '2026-01-04' },
+    ];
+    const summaries = summariseSessions(all, fleet);
+
+    it('summarises newest first, with run counts and vehicles', () => {
+        expect(summaries.map(s => s.session.id)).toEqual([9, 5, 12]);
+        const five = summaries.find(s => s.session.id === 5);
+        expect(five.runCount).toBe(4);
+        expect(five.vehicles.map(v => v.model)).toEqual(['R1S', 'Model Y']);
+    });
+
+    it('searches by VEHICLE, which a duplicated name cannot do', () => {
+        // "OoS 10% Challenge" appears twice; only the cars tell them apart.
+        expect(filterSessions(summaries, 'bolt').map(s => s.session.id)).toEqual([9]);
+    });
+
+    it('ANDs terms, and searches name and date too', () => {
+        expect(filterSessions(summaries, 'oos r1s').map(s => s.session.id)).toEqual([5]);
+        expect(filterSessions(summaries, 'peregrine').map(s => s.session.id)).toEqual([12]);
+        expect(filterSessions(summaries, '2026-01').map(s => s.session.id)).toEqual([12]);
+        expect(filterSessions(summaries, 'MODEL Y').map(s => s.session.id)).toEqual([5]);
+        expect(filterSessions(summaries, 'zzzz')).toHaveLength(0);
+        expect(filterSessions(summaries, '')).toHaveLength(3);
+    });
+});
+
+describe('grouping a vehicle\'s runs', () => {
+    const shape = rs => groupRunsBySession(rs).map(g => `${g.sessionId ?? '-'}:[${g.runs.map(r => r.id)}]`);
+
+    it('brings a session\'s runs together however interleaved the input', () => {
+        expect(shape([run(1,'charging',5), run(2,'range',9), run(3,'range',5), run(4,'charging',9)]))
+            .toEqual(['5:[1,3]', '9:[2,4]']);
+    });
+
+    it('keeps the order each session first appeared in', () => {
+        expect(shape([run(1,'range',9), run(2,'range',5)])).toEqual(['9:[1]', '5:[2]']);
+    });
+
+    it('puts unassigned runs last however early they appear', () => {
+        expect(shape([run(1,'range',null), run(2,'range',5), run(3,'range',null)]))
+            .toEqual(['5:[2]', '-:[1,3]']);
+    });
+
+    it('loses no runs, and tolerates empty input', () => {
+        const g = groupRunsBySession([run(1,'range',5), run(2,'range',null), run(3,'range',9)]);
+        expect(g.reduce((n, x) => n + x.runs.length, 0)).toBe(3);
+        expect(groupRunsBySession([])).toEqual([]);
+        expect(groupRunsBySession(null)).toEqual([]);
+    });
+});
+
+describe('sessionFor', () => {
+    it('finds a run\'s session, and returns null when it has none', () => {
+        const sessions = [{ id: 5, name: 'x' }];
+        expect(sessionFor(sessions, run(1, 'range', 5))).toBe(sessions[0]);
+        expect(sessionFor(sessions, run(1, 'range', null))).toBeNull();
+    });
+});

--- a/src/utils/testSessions.js
+++ b/src/utils/testSessions.js
@@ -22,7 +22,7 @@ import { runKindFrom } from './runUtils';
 /** camelCase field → database column. One definition, so the writer and the
  *  optimistic update cannot drift — which is how the per-kind default bug
  *  survived a fix. */
-export const SESSION_COLUMNS = {
+const SESSION_COLUMNS = {
     name:         'name',
     testedAt:     'tested_at',
     tester:       'tester',
@@ -151,7 +151,7 @@ export function suggestedPairing(vehicles, sessionId, vehicleId) {
  * One row's worth of what a session IS, for browsing: when, how big, and — the
  * part that actually identifies an outing — which cars were on it.
  */
-export function sessionSummary(session, vehicles) {
+function sessionSummary(session, vehicles) {
     const rows = runsInSession(vehicles, session.id);
     return {
         session,

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,4 +7,12 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  test: {
+    // Pure modules only for now: no jsdom, so the suite stays fast enough to
+    // run on every save. The wiring suite reads source text rather than
+    // rendering, which catches the failure mode a DOM harness would (a util
+    // that is correct and never called) without the cost of one.
+    environment: 'node',
+    include: ['src/**/*.test.js'],
+  },
 });


### PR DESCRIPTION
Closes #174. **107 assertions**, of which roughly a hundred already existed — written across a dozen throwaway esbuild harnesses in a scratch directory that would have vanished with the session. Landing them was mostly moving files.

`npm test` / `npm run test:watch`. Vitest against the existing Vite config, no jsdom: pure modules only, so the whole suite runs in ~200ms.

| suite | what it pins |
|---|---|
| `seriesLabel` | 24 — the three #170 cases, marginal-discrimination rule, per-group refinement, domain atoms, override seam |
| `conditionCorrection` | 23 — direction, magnitude pinned to the algebra, mixed-cycle skip, missing-axis reporting |
| `testSessions` | 23 — membership across vehicles, picker ordering, date guard, implied pairing, search, grouping |
| `runUtils` | 14 — per-kind defaults, including pre-046 rows |
| `colorUtils` | 8 — pair shading stays related, not merely distinct |
| `rangeSource` | 10 — correction at the chokepoint, session fallback both ways |
| `wiring` | 10 — see below |

## The wiring suite

Every other test checks that a function returns the right answer. **None of them can tell us nobody calls it** — and that is the failure mode this project keeps hitting. Three defects found by hand in one week were all "built, unit-tested, never connected":

- the mixed-cycle badge, correct in the DOM and absent from the canvas
- condition correction, wired into a fetch effect the dropdown never re-ran, so the control did nothing
- the correction note, written to every corrected run and read by nothing, so a corrected bar looked identical to a measured one

Each passed its own tests. The wiring suite reads source text and asserts the seams instead:

- `_correction` is **read** as well as written
- every chart displaying a test speed also renders the mixed-cycle marker
- every chart resolving a range basis passes a correction
- no chart labels a series with the vehicle's free-text `name` (#170's rule)
- every constant made tunable actually appears in the Admin knobs

**It earned its place on the first run**, finding two dead exports of mine — `SESSION_COLUMNS` and `sessionSummary`, both internal helpers. Made private rather than allowlisted.

The dead-export check is scoped to the three modules built recently. 48 exports are unused project-wide, nearly all pre-existing in the EPA and parser modules; widening it wants a cleanup first, not a 48-item allowlist. Worth its own issue.

## Also: AERO_FRACTION reaches the Admin panel

It was made overridable in #190 and never added to `knobs.js`, so nothing could actually tune the constant driving every correction magnitude. The same not-connected pattern — caught by the curator asking whether the knob existed, not by any test. Now exposed alongside `TOWING_AERO_FRACTION`, `REFERENCE_SPEED_MPH` and the three standard-condition constants, and asserted by the wiring suite.

The knob help text says what the curator observed: one aero fraction for every vehicle is an average, and a slippery sedan and a boxy SUV genuinely differ.

## Not included

No component/DOM tests. jsdom plus mocking Supabase and context is a much larger commitment, and the wiring suite covers the specific failure it would have caught at a fraction of the cost. Worth revisiting if defects start appearing that only a rendered component would reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)