### PR TITLE
Make the single-default rule kind-aware

### DIFF
--- a/supabase/migrations/049_single_default_per_kind.sql
+++ b/supabase/migrations/049_single_default_per_kind.sql
@@ -1,0 +1,57 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 049: make the single-default rule kind-aware.
+--
+-- A vehicle has TWO defaults since migration 046 split dual-role runs: a
+-- default charging run (the fallback curve) and a default range test (rank 2 of
+-- the range-source resolution order). #183 taught the application to scope its
+-- clearing per kind — and it had no effect, because the database was undoing it.
+--
+-- `enforce_single_default_run` clears every other default row for the vehicle,
+-- regardless of kind. Setting a range default therefore cleared the charging
+-- default in the same statement. The symptom was that both defaults appeared to
+-- work in-session (the optimistic UI is per-kind and correct) and only the last
+-- one survived a reload.
+--
+-- Evidence: on vehicle 26 every run carries the identical updated_at of
+-- 2026-08-10T13:11:15 — one write, fanned out across the whole vehicle.
+--
+-- This trigger and its function appear in NO migration; they were created out of
+-- band, like runs.elevation_gain_ft before migration 047. Both are (re)created
+-- here so the migration set finally describes the real database.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION ensure_single_default_run() RETURNS trigger AS $$
+DECLARE
+    v_kind text;
+BEGIN
+    IF NEW.is_default IS NOT TRUE THEN
+        RETURN NEW;
+    END IF;
+
+    -- The kind this row will actually have once every BEFORE trigger has run.
+    --
+    -- Same-timing triggers fire in alphabetical order, so this one runs BEFORE
+    -- trg_runs_sync_kind — which means NEW.kind may not yet be synced from the
+    -- legacy boolean pair on an INSERT. Deriving it here makes the result
+    -- independent of trigger order rather than dependent on a naming accident.
+    v_kind := COALESCE(NEW.kind, runs_derive_kind(NEW.has_charging, NEW.has_range));
+
+    UPDATE runs
+       SET is_default = false
+     WHERE vehicle_id = NEW.vehicle_id
+       AND id IS DISTINCT FROM NEW.id
+       AND is_default
+       AND COALESCE(kind, runs_derive_kind(has_charging, has_range)) = v_kind;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreated so the trigger exists for a database built from these files alone.
+DROP TRIGGER IF EXISTS enforce_single_default_run ON runs;
+CREATE TRIGGER enforce_single_default_run
+    BEFORE INSERT OR UPDATE ON runs
+    FOR EACH ROW EXECUTE FUNCTION ensure_single_default_run();
+
+COMMENT ON FUNCTION ensure_single_default_run() IS
+    'Keeps at most one default run per vehicle PER KIND: a vehicle may have both a default charging run and a default range test.';


### PR DESCRIPTION
Setting a default **range** test cleared the default **charging** run. #183 fixed the *application* to scope its clearing per kind — and it had no effect, because the database was undoing it one statement later.

## Cause

```sql
enforce_single_default_run BEFORE INSERT OR UPDATE ON public.runs
  FOR EACH ROW EXECUTE FUNCTION ensure_single_default_run()
```

It clears every other default row for the vehicle, **regardless of kind**. The optimistic UI is per-kind and correct, so both defaults appeared to work in-session and only the last survived a reload — exactly as reported.

## The evidence

Every run on vehicle 26 carries the **identical** `updated_at`:

```
137 range     DEFAULT  2026-08-10T13:11:15   ← the one that was set
115 charging           2026-08-10T13:11:15   ← cleared by the trigger
135 range              2026-08-10T13:11:15
153 range              2026-08-10T13:11:15
```

One write, fanned out across the whole vehicle. The application only ever touched `kind = 'range'`.

Across the database: **16 vehicles have a default, and not one has both kinds** — the rule has been enforced universally, and invisibly.

## Not in any migration

Neither the trigger nor its function appears anywhere under `supabase/migrations/`. They were created out of band, like `runs.elevation_gain_ft` before migration 047. Both are `CREATE OR REPLACE`d here so the file set finally describes the real database and a fresh deploy behaves like production.

That is now **two** out-of-band objects found in as many weeks. Worth a follow-up: diff the live schema against the migrations and catch up whatever else is missing, before something is deployed that quietly lacks it.

## One detail worth reviewing

The function derives the kind rather than trusting `NEW.kind`:

```sql
v_kind := COALESCE(NEW.kind, runs_derive_kind(NEW.has_charging, NEW.has_range));
```

Same-timing triggers fire in **alphabetical order**, so `enforce_single_default_run` runs *before* `trg_runs_sync_kind` — meaning `NEW.kind` may not be synced yet on an INSERT. Deriving makes the result independent of trigger order rather than dependent on a naming accident.

## Ruled out

- `idx_runs_default` is a plain partial btree on `(vehicle_id, is_default)`, **not unique** — a lookup index, no enforcement.
- The application paths are all correct: `setDefaultRun` scopes per kind, `addRun` only inserts, `updateRun` never writes the flag, `updateSpecLink` clears `kind = 'charging'` only.

## Open question before merge

I need the existing function body to be sure I am not dropping behaviour — my replacement assumes it only touches `runs`, and if it also clears `spec_links` that must be preserved:

```sql
select prosrc from pg_proc where proname = 'ensure_single_default_run';
```

## After merge

Apply `049_single_default_per_kind.sql`, then re-set the second default on any vehicle that should have both — existing rows are not backfilled, since the intent of a cleared default cannot be recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)