### PR TITLE
Repair 049: it referenced a dropped column and a dropped function

### DIFF
--- a/supabase/migrations/050_fix_default_trigger_refs.sql
+++ b/supabase/migrations/050_fix_default_trigger_refs.sql
@@ -1,0 +1,42 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 050: repair 049 — it referenced a column and a function that no longer exist.
+--
+-- 049 guarded against a trigger-ordering hazard by deriving the kind:
+--
+--     v_kind := COALESCE(NEW.kind, runs_derive_kind(NEW.has_charging, NEW.has_range));
+--
+-- Every part of that fallback is dead. Migration 046 dropped runs.has_charging,
+-- runs.has_range, the runs_derive_kind() function, AND trg_runs_sync_kind — the
+-- very trigger whose firing order the fallback existed to survive. There is no
+-- ordering hazard left to defend against.
+--
+-- plpgsql resolves record fields at EXECUTION time, so the migration applied
+-- cleanly and the function only failed when a default was actually set:
+--
+--     Error setting default run: record "new" has no field "has_charging"
+--
+-- runs.kind is NOT NULL in practice and set explicitly by the application on
+-- insert, so it can simply be trusted.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION ensure_single_default_run() RETURNS trigger AS $$
+BEGIN
+    IF NEW.is_default IS NOT TRUE THEN
+        RETURN NEW;
+    END IF;
+
+    -- Per KIND: a vehicle may hold both a default charging run and a default
+    -- range test. Clearing across kinds is what this migration series fixes.
+    UPDATE runs
+       SET is_default = false
+     WHERE vehicle_id = NEW.vehicle_id
+       AND id IS DISTINCT FROM NEW.id
+       AND is_default
+       AND kind = NEW.kind;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION ensure_single_default_run() IS
+    'Keeps at most one default run per vehicle PER KIND: a vehicle may have both a default charging run and a default range test.';


### PR DESCRIPTION
**Setting any default currently fails.** My error in #196.

```
Error setting default run: record "new" has no field "has_charging"
```

## What I got wrong

049 guarded against a trigger-ordering hazard by deriving the kind:

```sql
v_kind := COALESCE(NEW.kind, runs_derive_kind(NEW.has_charging, NEW.has_range));
```

Every part of that fallback is dead. Migration **046** dropped:

- `runs.has_charging`
- `runs.has_range`
- the `runs_derive_kind()` function
- `trg_runs_sync_kind` — *the very trigger whose firing order the fallback existed to survive*

So the hazard I was defending against had been removed months ago, and the defence referenced three things that no longer exist.

## Why it got through

plpgsql resolves record fields at **execution** time. The migration applied cleanly, reported success, and only failed when someone actually set a default. A migration that applies is not a migration that works.

`runs.kind` is set explicitly by the application on insert and is populated on every row, so it can simply be trusted:

```sql
AND kind = NEW.kind
```

## The lesson I should have already learned

I verified the live database before writing several things today — whether PostgREST allowed aggregates, whether the stored SoC columns agreed with the data points, whether `idx_runs_default` was unique. I did not verify this one, because I was writing *defensive* code rather than load-bearing code, and treated it as not needing the same scrutiny.

That is the same mistake that made migration 046 fail three times: writing SQL from an assumed schema instead of the real one.

## After merge

Apply `050_fix_default_trigger_refs.sql`. Then setting both a charging and a range default on one vehicle should finally persist — which is what #196 was supposed to deliver and did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)