### PR TITLE
perf: parallel startup queries, image thumbnails, lazy utility chunks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>EVBench</title>
+    <!-- Supabase origin, substituted from env at build time. Warms DNS+TLS, which
+         otherwise landed on the critical path at ~1.2s because the browser cannot
+         discover this origin until the bundle has parsed and run. crossorigin is
+         required for the connection to be reused by supabase-js's cors fetches. -->
+    <link rel="preconnect" href="%VITE_SUPABASE_URL%" crossorigin>
+    <link rel="dns-prefetch" href="%VITE_SUPABASE_URL%">
 </head>
 <body class="bg-gray-50">
     <div id="root"></div>

--- a/src/__tests__/wiring.test.js
+++ b/src/__tests__/wiring.test.js
@@ -112,6 +112,40 @@ describe('the seams that broke before', () => {
         }
     });
 
+    it('renders vehicle images through the thumbnail resolver', () => {
+        // image_url is the FULL-resolution original — 1600x900, ~210KB each, and
+        // 91% of a cold first load when 23 of them render at once. Displaying it
+        // directly is the regression: every surface must go through
+        // displayImageUrl so it gets the card-sized rendition with a fallback.
+        //
+        // Presence checks (`vehicle.image_url ? 'Replace' : 'Upload'`) are fine
+        // and deliberately not matched here — only uses that put the URL on the
+        // wire are.
+        const rendersRaw = ALL.filter(({ file, text }) =>
+            /\.jsx$/.test(file) && (
+                /src=\{[^}]*\.image_url/.test(text) ||
+                /url\(\$\{[^}]*\.image_url/.test(text)
+            ));
+        expect(rendersRaw.map(x => x.file)).toEqual([]);
+    });
+
+    it('loads the startup queries in parallel', () => {
+        // Seven independent queries were awaited one after another, six of them
+        // returning under 4KB. That was ~900ms of blank screen spent purely on
+        // round trips. An eighth query appended below the Promise.all rather
+        // than inside it silently restores the waterfall.
+        const ctx = read('src/context/AppContext.jsx');
+        const init = ctx.slice(ctx.indexOf('async function initializeApp'));
+        const body = init.slice(0, init.indexOf('\n    }'));
+
+        expect(body, 'initializeApp no longer batches its startup queries')
+            .toMatch(/await Promise\.all\(\[/);
+
+        const serialAwaits = body.match(/(?:const|let)\s+\w+\s*=\s*await\s+dataService\./g) ?? [];
+        expect(serialAwaits, 'a startup query is awaited outside the Promise.all')
+            .toEqual([]);
+    });
+
     it('keeps vehicleLabel out of graph labelling', () => {
         // The vehicle's free-text name is a SELECTION label. Charts must compose
         // from atoms instead — see #170.

--- a/src/components/AdminView.jsx
+++ b/src/components/AdminView.jsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
-import ImportTableauModal from './ImportTableauModal';
-import EpaImportModal from './EpaImportModal';
-import EpaPdfImportModal from './EpaPdfImportModal';
+import LazyBoundary from './LazyBoundary';
+import { ImportTableauModal, EpaImportModal, EpaPdfImportModal } from './lazyComponents';
 import EpaDataCard from './EpaDataCard';
 import RolesPermissions from './admin/RolesPermissions';
 import ConstantsKnobs from './admin/ConstantsKnobs';
@@ -72,25 +71,31 @@ export default function AdminView({ getUsersForAdmin, setUserRole, currentUserId
     return (
         <div>
             {showTableauModal && (
-                <ImportTableauModal
-                    vehicles={vehicles}
-                    onImport={importTableauSessions}
-                    onClose={() => setShowTableauModal(false)}
-                />
+                <LazyBoundary>
+                    <ImportTableauModal
+                        vehicles={vehicles}
+                        onImport={importTableauSessions}
+                        onClose={() => setShowTableauModal(false)}
+                    />
+                </LazyBoundary>
             )}
             {showEpaModal && (
-                <EpaImportModal
-                    vehicles={vehicles}
-                    onImport={importEpaTestGroups}
-                    onClose={() => setShowEpaModal(false)}
-                />
+                <LazyBoundary>
+                    <EpaImportModal
+                        vehicles={vehicles}
+                        onImport={importEpaTestGroups}
+                        onClose={() => setShowEpaModal(false)}
+                    />
+                </LazyBoundary>
             )}
             {showEpaPdfModal && (
-                <EpaPdfImportModal
-                    onImport={importEpaCsiGroups}
-                    getExistingIds={getExistingEpaTestGroupIds}
-                    onClose={() => setShowEpaPdfModal(false)}
-                />
+                <LazyBoundary>
+                    <EpaPdfImportModal
+                        onImport={importEpaCsiGroups}
+                        getExistingIds={getExistingEpaTestGroupIds}
+                        onClose={() => setShowEpaPdfModal(false)}
+                    />
+                </LazyBoundary>
             )}
 
             <div className="flex justify-between items-center mb-4">

--- a/src/components/EditVehicleForm.jsx
+++ b/src/components/EditVehicleForm.jsx
@@ -4,43 +4,39 @@
 import { useState, useRef, useCallback } from 'react';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
+import { FULL_MAX, buildRenditions, displayImageUrl } from '../utils/imageRenditions';
 
 const ASPECT = 16 / 9;
-const MAX_W = 1600;
-const MAX_H = 900;
 
-// Render the completed crop region to a canvas and return a JPEG blob,
-// scaled down to fit within MAX_W × MAX_H if needed.
-function getCroppedBlob(imgEl, completedCrop) {
-    return new Promise((resolve, reject) => {
-        const canvas = document.createElement('canvas');
-        const scaleX = imgEl.naturalWidth / imgEl.width;
-        const scaleY = imgEl.naturalHeight / imgEl.height;
+// Extract the completed crop region into an offscreen canvas at full rendition
+// resolution. Encoding is left to buildRenditions, which needs one shared source
+// to derive the full and thumbnail JPEGs from.
+function getCroppedCanvas(imgEl, completedCrop) {
+    const scaleX = imgEl.naturalWidth / imgEl.width;
+    const scaleY = imgEl.naturalHeight / imgEl.height;
 
-        const naturalW = completedCrop.width * scaleX;
-        const naturalH = completedCrop.height * scaleY;
-        const scale = Math.min(1, MAX_W / naturalW, MAX_H / naturalH);
+    const naturalW = completedCrop.width * scaleX;
+    const naturalH = completedCrop.height * scaleY;
+    const scale = Math.min(1, FULL_MAX.width / naturalW, FULL_MAX.height / naturalH);
 
-        canvas.width = Math.round(naturalW * scale);
-        canvas.height = Math.round(naturalH * scale);
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.round(naturalW * scale);
+    canvas.height = Math.round(naturalH * scale);
 
-        const ctx = canvas.getContext('2d');
-        ctx.drawImage(
-            imgEl,
-            completedCrop.x * scaleX,
-            completedCrop.y * scaleY,
-            naturalW,
-            naturalH,
-            0, 0,
-            canvas.width,
-            canvas.height,
-        );
-        canvas.toBlob(
-            blob => blob ? resolve(blob) : reject(new Error('Canvas toBlob failed')),
-            'image/jpeg',
-            0.92,
-        );
-    });
+    const ctx = canvas.getContext('2d');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(
+        imgEl,
+        completedCrop.x * scaleX,
+        completedCrop.y * scaleY,
+        naturalW,
+        naturalH,
+        0, 0,
+        canvas.width,
+        canvas.height,
+    );
+    return canvas;
 }
 
 export default function EditVehicleForm({
@@ -96,11 +92,11 @@ export default function EditVehicleForm({
 
     const handleCropConfirm = async () => {
         if (!completedCrop || !imgRef.current) return;
-        const blob = await getCroppedBlob(imgRef.current, completedCrop);
+        const renditions = await buildRenditions(getCroppedCanvas(imgRef.current, completedCrop));
         setImgSrc('');
         setCrop(undefined);
         setCompletedCrop(null);
-        onImageReady(blob);
+        onImageReady(renditions);
     };
 
     const handleCropCancel = () => {
@@ -279,10 +275,11 @@ export default function EditVehicleForm({
                 {editingId && (
                     <div className="form-section mt-4">
                         <label className="block font-medium mb-2">Card Background Image</label>
-                        {editingVehicle?.image_url && (
+                        {displayImageUrl(editingVehicle) && (
                             <img
-                                src={editingVehicle.image_url}
+                                src={displayImageUrl(editingVehicle)}
                                 alt="Current"
+                                decoding="async"
                                 className="h-24 w-full object-cover rounded mb-2 border"
                             />
                         )}

--- a/src/components/EpaVehicleSection.jsx
+++ b/src/components/EpaVehicleSection.jsx
@@ -12,7 +12,8 @@ import SectionHeader, { SectionAction } from './SectionHeader';
 import { EPA_EXPLAINERS } from '../utils/epaExplainers';
 import DerivedValues from './epa/DerivedValues';
 import EpaCuratorEditor from './epa/EpaCuratorEditor';
-import EpaPdfImportModal from './EpaPdfImportModal';
+import LazyBoundary from './LazyBoundary';
+import { EpaPdfImportModal } from './lazyComponents';
 import { useAppContext } from '../context/AppContext';
 
 const CONFIDENCE_COLORS = {
@@ -440,12 +441,14 @@ export default function EpaVehicleSection({ vehicle, canEdit, searchEpaTestGroup
                         📑 Import from EPA lab PDF
                     </button>
                     {showPdfModal && (
-                        <EpaPdfImportModal
-                            targetVehicle={vehicle}
-                            onImport={importEpaCsiGroups}
-                            getExistingIds={getExistingEpaTestGroupIds}
-                            onClose={() => setShowPdfModal(false)}
-                        />
+                        <LazyBoundary>
+                            <EpaPdfImportModal
+                                targetVehicle={vehicle}
+                                onImport={importEpaCsiGroups}
+                                getExistingIds={getExistingEpaTestGroupIds}
+                                onClose={() => setShowPdfModal(false)}
+                            />
+                        </LazyBoundary>
                     )}
 
                     {/* Create from scratch — for vehicles with only a lab-submission PDF */}

--- a/src/components/LazyBoundary.jsx
+++ b/src/components/LazyBoundary.jsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react';
+
+/**
+ * Suspense wrapper for the lazily-loaded utility components in lazyComponents.js.
+ *
+ * Every one of them is a modal or an edit form opened by an explicit click, so
+ * the fallback is deliberately quiet: a spinner that flashes for the ~50ms a
+ * cached chunk takes is worse than nothing, and the click has already given the
+ * user feedback. On a cold chunk fetch the modal simply appears a beat later.
+ *
+ * Rendering the boundary *outside* the conditional that mounts the lazy child
+ * would defeat the point — keep `{open && <LazyBoundary><Thing/></LazyBoundary>}`,
+ * not `<LazyBoundary>{open && <Thing/>}</LazyBoundary>`.
+ */
+export default function LazyBoundary({ children, fallback = null }) {
+    return <Suspense fallback={fallback}>{children}</Suspense>;
+}

--- a/src/components/PerformanceVehicleSection.jsx
+++ b/src/components/PerformanceVehicleSection.jsx
@@ -19,8 +19,8 @@ import SectionHeader, { SectionAction } from './SectionHeader';
 import TestedResults from './performance/TestedResults';
 import PerformanceSessionCard from './performance/PerformanceSessionCard';
 import PerformanceSummaryCard from './performance/PerformanceSummaryCard';
-import PerformanceImportModal from './PerformanceImportModal';
-import PastePublishedResultsModal from './PastePublishedResultsModal';
+import LazyBoundary from './LazyBoundary';
+import { PerformanceImportModal, PastePublishedResultsModal } from './lazyComponents';
 
 const SECTION_HELP =
     'Independently-tested acceleration and braking results. Separate from the ' +
@@ -289,20 +289,24 @@ export default function PerformanceVehicleSection({ vehicle, canEdit }) {
             )}
 
             {showPaste && (
-                <PastePublishedResultsModal
-                    vehicle={vehicle}
-                    onImport={handlePasteImport}
-                    onClose={() => setShowPaste(false)}
-                />
+                <LazyBoundary>
+                    <PastePublishedResultsModal
+                        vehicle={vehicle}
+                        onImport={handlePasteImport}
+                        onClose={() => setShowPaste(false)}
+                    />
+                </LazyBoundary>
             )}
 
             {showImport && (
-                <PerformanceImportModal
-                    vehicle={vehicle}
-                    onImport={handleImport}
-                    onMerge={handleMerge}
-                    onClose={() => setShowImport(false)}
-                />
+                <LazyBoundary>
+                    <PerformanceImportModal
+                        vehicle={vehicle}
+                        onImport={handleImport}
+                        onMerge={handleMerge}
+                        onClose={() => setShowImport(false)}
+                    />
+                </LazyBoundary>
             )}
         </div>
     );

--- a/src/components/RunsView.jsx
+++ b/src/components/RunsView.jsx
@@ -6,7 +6,8 @@ import { parseCSV, parseCSVText } from '../utils/parseCSV';
 import { dataService } from '../services/DataService';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
 import DeleteQueueBar from './DeleteQueueBar';
-import EditVehicleForm from './EditVehicleForm';
+import LazyBoundary from './LazyBoundary';
+import { EditVehicleForm } from './lazyComponents';
 import { groupRunsBySession } from '../utils/testSessions';
 import SessionControl from './SessionControl';
 import RunSpecRows from './RunSpecRows';
@@ -20,6 +21,7 @@ import { RunVoteButtons } from './VoteButtons';
 import EpaVehicleSection from './EpaVehicleSection';
 import PerformanceVehicleSection from './PerformanceVehicleSection';
 import { deriveChargingAxis } from '../utils/deriveChargingAxis';
+import { displayImageUrl } from '../utils/imageRenditions';
 import { filterChargingRuns, defaultChargingRun, isRangeRun, runKindFrom, linkableRuns, linkableCounts } from '../utils/runUtils';
 import { isTimestampValue, timestampToMs } from '../utils/parseElapsedTime';
 
@@ -433,10 +435,10 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
         closeEditVehicle();
     };
 
-    const handleVehicleImageReady = async (blob) => {
-        if (!blob) return;
+    const handleVehicleImageReady = async (renditions) => {
+        if (!renditions) return;
         setVehicleImageUploading(true);
-        await onUploadVehicleImage(blob);
+        await onUploadVehicleImage(renditions);
         setVehicleImageUploading(false);
     };
 
@@ -1265,8 +1267,8 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             {/* Vehicle summary header */}
             <div className="card py-3 px-4 flex items-center gap-4 mb-6">
                 <div className="list-thumbnail">
-                    {vehicle.image_url
-                        ? <img src={vehicle.image_url} alt={vehicle.name} className="w-full h-full object-cover" />
+                    {displayImageUrl(vehicle)
+                        ? <img src={displayImageUrl(vehicle)} alt={vehicle.name} decoding="async" className="w-full h-full object-cover" />
                         : <span>🚗</span>
                     }
                 </div>
@@ -2921,33 +2923,35 @@ export default function RunsView({ vehicle, canCreate, canEdit, canDelete, canPu
             {showEditVehicle && (
                 <div className="modal-overlay" onClick={closeEditVehicle}>
                     <div className="modal-panel rounded-xl shadow-2xl max-w-xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-                        <EditVehicleForm
-                            formData={vehicleFormData}
-                            onFormChange={setVehicleFormData}
-                            editingId={vehicle.id}
-                            formTags={vehicleFormTags}
-                            onAddTag={(tag) => { if (!vehicleFormTags.some(t => t.id === tag.id)) setVehicleFormTags(prev => [...prev, tag]); }}
-                            onRemoveTag={(tagId) => setVehicleFormTags(prev => prev.filter(t => t.id !== tagId))}
-                            newTagName={vehicleNewTagName}
-                            onNewTagNameChange={setVehicleNewTagName}
-                            onCreateTag={async () => {
-                                const trimmed = vehicleNewTagName.trim();
-                                if (!trimmed) return;
-                                const existing = (tags || []).find(t => t.name.toLowerCase() === trimmed.toLowerCase());
-                                const tag = existing || await onCreateTag(trimmed);
-                                if (tag && !vehicleFormTags.some(t => t.id === tag.id)) setVehicleFormTags(prev => [...prev, tag]);
-                                setVehicleNewTagName('');
-                            }}
-                            tags={tags || []}
-                            availableTagsForForm={vehicleAvailableTags}
-                            editingVehicle={vehicle}
-                            imageUploading={vehicleImageUploading}
-                            onImageReady={handleVehicleImageReady}
-                            onSubmit={handleVehicleSubmit}
-                            onCancel={closeEditVehicle}
-                            manufacturers={manufacturers}
-                            onAddManufacturer={addManufacturer}
-                        />
+                        <LazyBoundary>
+                            <EditVehicleForm
+                                formData={vehicleFormData}
+                                onFormChange={setVehicleFormData}
+                                editingId={vehicle.id}
+                                formTags={vehicleFormTags}
+                                onAddTag={(tag) => { if (!vehicleFormTags.some(t => t.id === tag.id)) setVehicleFormTags(prev => [...prev, tag]); }}
+                                onRemoveTag={(tagId) => setVehicleFormTags(prev => prev.filter(t => t.id !== tagId))}
+                                newTagName={vehicleNewTagName}
+                                onNewTagNameChange={setVehicleNewTagName}
+                                onCreateTag={async () => {
+                                    const trimmed = vehicleNewTagName.trim();
+                                    if (!trimmed) return;
+                                    const existing = (tags || []).find(t => t.name.toLowerCase() === trimmed.toLowerCase());
+                                    const tag = existing || await onCreateTag(trimmed);
+                                    if (tag && !vehicleFormTags.some(t => t.id === tag.id)) setVehicleFormTags(prev => [...prev, tag]);
+                                    setVehicleNewTagName('');
+                                }}
+                                tags={tags || []}
+                                availableTagsForForm={vehicleAvailableTags}
+                                editingVehicle={vehicle}
+                                imageUploading={vehicleImageUploading}
+                                onImageReady={handleVehicleImageReady}
+                                onSubmit={handleVehicleSubmit}
+                                onCancel={closeEditVehicle}
+                                manufacturers={manufacturers}
+                                onAddManufacturer={addManufacturer}
+                            />
+                        </LazyBoundary>
                     </div>
                 </div>
             )}

--- a/src/components/VehiclesView.jsx
+++ b/src/components/VehiclesView.jsx
@@ -2,12 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { DATA_CATEGORIES, vehicleDataCategories, hasDataCategory, filterByDataCategories } from '../utils/vehicleDataCategories';
 import { fmtDistance } from '../utils/unitConversions';
+import { displayImageUrl } from '../utils/imageRenditions';
 import { useDeleteQueue } from '../hooks/useDeleteQueue';
 import DeleteQueueBar from './DeleteQueueBar';
-import EditVehicleForm from './EditVehicleForm';
 import EditSpecsForm from './EditSpecsForm';
 import ViewSpecsModal from './ViewSpecsModal';
-import ImportVehiclesModal from './ImportVehiclesModal';
+import LazyBoundary from './LazyBoundary';
+import { EditVehicleForm, ImportVehiclesModal } from './lazyComponents';
 
 // ── Test-count row ────────────────────────────────────────────────────────────
 
@@ -196,10 +197,10 @@ export default function VehiclesView({
         setNewTagName('');
     };
 
-    const handleImageReady = async (blob) => {
-        if (!blob || !editingId) return;
+    const handleImageReady = async (renditions) => {
+        if (!renditions || !editingId) return;
         setImageUploading(true);
-        await onUploadVehicleImage(editingId, blob);
+        await onUploadVehicleImage(editingId, renditions);
         setImageUploading(false);
     };
 
@@ -790,12 +791,12 @@ export default function VehiclesView({
                                     }}
                                 >
                                     {/* Background image + overlay — purely decorative, must not intercept clicks */}
-                                    {vehicle.image_url && (
+                                    {displayImageUrl(vehicle) && (
                                         <>
                                             <div
                                                 className="absolute inset-0 pointer-events-none"
                                                 style={{
-                                                    backgroundImage: `url(${vehicle.image_url})`,
+                                                    backgroundImage: `url(${displayImageUrl(vehicle)})`,
                                                     backgroundSize: 'cover',
                                                     backgroundPosition: 'center',
                                                 }}
@@ -937,8 +938,8 @@ export default function VehiclesView({
 
                                     {/* Thumbnail */}
                                     <div className="list-thumbnail">
-                                        {vehicle.image_url
-                                            ? <img src={vehicle.image_url} alt={vehicle.name} className="w-full h-full object-cover" />
+                                        {displayImageUrl(vehicle)
+                                            ? <img src={displayImageUrl(vehicle)} alt={vehicle.name} loading="lazy" decoding="async" className="w-full h-full object-cover" />
                                             : <span>🚗</span>
                                         }
                                     </div>
@@ -1037,7 +1038,7 @@ export default function VehiclesView({
             {showForm && (
                 <div className="modal-overlay" onClick={handleCancel}>
                     <div className="modal-panel rounded-xl shadow-2xl max-w-xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-                        <EditVehicleForm {...editFormProps} />
+                        <LazyBoundary><EditVehicleForm {...editFormProps} /></LazyBoundary>
                     </div>
                 </div>
             )}
@@ -1062,7 +1063,9 @@ export default function VehiclesView({
 
             {/* Bulk import modal (contributors/owners) */}
             {showImportModal && (
-                <ImportVehiclesModal onClose={() => setShowImportModal(false)} />
+                <LazyBoundary>
+                    <ImportVehiclesModal onClose={() => setShowImportModal(false)} />
+                </LazyBoundary>
             )}
         </div>
     );

--- a/src/components/admin/ImageMaintenance.jsx
+++ b/src/components/admin/ImageMaintenance.jsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useAppContext } from '../../context/AppContext';
+import { THUMB_MAX } from '../../utils/imageRenditions';
+
+/**
+ * Admin card: generate the card-sized rendition for vehicle images uploaded
+ * before migration 051.
+ *
+ * A one-time catch-up, not a routine chore — every upload since has written both
+ * renditions itself. It stays in the UI because it is idempotent (it only looks
+ * at rows where image_thumb_url is null) and because a vehicle imported with a
+ * bare image_url would otherwise have no way to get one.
+ *
+ * This runs in the browser rather than as a script so it uses the signed-in
+ * admin's session and stays subject to the same RLS as every other write.
+ */
+export default function ImageMaintenance() {
+    const { backfillVehicleThumbnails } = useAppContext();
+    const [running, setRunning] = useState(false);
+    const [progress, setProgress] = useState(null);
+    const [result, setResult] = useState(null);
+    const [error, setError] = useState(null);
+
+    async function handleRun() {
+        setRunning(true);
+        setResult(null);
+        setError(null);
+        setProgress({ done: 0, total: 0, label: '' });
+        try {
+            const outcome = await backfillVehicleThumbnails((done, total, label) =>
+                setProgress({ done, total, label }));
+            setResult(outcome);
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setRunning(false);
+            setProgress(null);
+        }
+    }
+
+    return (
+        <div className="card p-5">
+            <h3 className="section-title">Vehicle image thumbnails</h3>
+            <p className="text-sm text-secondary mt-0.5 mb-3">
+                Vehicle images are stored twice: the full-resolution original, and a{' '}
+                {THUMB_MAX.width}×{THUMB_MAX.height} rendition that is what the cards and lists
+                actually display. Images uploaded before this split have only the original, so
+                the grid falls back to sending the full file. Run this once to generate the
+                missing thumbnails — originals are left untouched.
+            </p>
+
+            <button className="btn btn-secondary text-sm" onClick={handleRun} disabled={running}>
+                {running ? 'Generating…' : '🖼 Generate missing thumbnails'}
+            </button>
+
+            {progress && progress.total > 0 && (
+                <p className="text-sm text-secondary mt-3">
+                    {progress.done} / {progress.total}
+                    {progress.label ? ` — ${progress.label}` : ''}
+                </p>
+            )}
+
+            {result && (
+                <div className="text-sm mt-3">
+                    <p className="text-secondary">
+                        {result.updated === 0 && result.failures.length === 0
+                            ? 'Nothing to do — every vehicle image already has a thumbnail.'
+                            : `Generated ${result.updated} thumbnail${result.updated === 1 ? '' : 's'}.`}
+                    </p>
+                    {result.failures.length > 0 && (
+                        <ul className="mt-2 space-y-0.5 text-red-700 dark:text-red-400">
+                            {result.failures.map(f => (
+                                <li key={f.id}>{f.name || `#${f.id}`}: {f.error}</li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+
+            {error && (
+                <p className="text-sm mt-3 text-red-700 dark:text-red-400">⚠️ {error}</p>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/InterfaceSettings.jsx
+++ b/src/components/admin/InterfaceSettings.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
 import TypographyKnobs from './TypographyKnobs';
+import ImageMaintenance from './ImageMaintenance';
 
 /**
  * Admin sub-tab: site-wide interface settings.
@@ -54,6 +55,8 @@ export default function InterfaceSettings() {
                     />
                 </label>
             </div>
+
+            <ImageMaintenance />
 
             <TypographyKnobs />
 

--- a/src/components/lazyComponents.js
+++ b/src/components/lazyComponents.js
@@ -1,0 +1,39 @@
+import { lazy } from 'react';
+
+/**
+ * The lazily-loaded set, in one place so it is reviewable as a policy rather
+ * than scattered across the components that happen to open them.
+ *
+ * The policy: **views stay eager, utilities go lazy.**
+ *
+ * Every tab-level view and every chart is imported normally, because switching
+ * tabs should never wait on a network fetch — that is the interaction users
+ * perform constantly and it has to feel instant. What is deferred here is the
+ * other kind of thing: importers, editors and one-off wizards, opened by an
+ * explicit click, by a fraction of visitors, at most a handful of times each.
+ * A first-time click on one of these pays a chunk fetch; the reward is that
+ * nobody pays for all of them on every cold load.
+ *
+ * EditVehicleForm carries react-image-crop and its stylesheet, which is why an
+ * edit form appears in a list otherwise made of modals.
+ *
+ * Render these through LazyBoundary, and keep the mount conditional *outside*
+ * the boundary so the chunk is not requested until the thing is actually opened.
+ */
+
+// Opened from VehiclesView / RunsView by contributors and admins only.
+export const EditVehicleForm = lazy(() => import('./EditVehicleForm'));
+export const ImportVehiclesModal = lazy(() => import('./ImportVehiclesModal'));
+
+// Admin import wizards.
+export const ImportTableauModal = lazy(() => import('./ImportTableauModal'));
+export const EpaImportModal = lazy(() => import('./EpaImportModal'));
+
+// Also opened per-vehicle from EpaVehicleSection. Its pdf.js dependency is
+// already a dynamic import inside extractPdfText, so this defers the modal's own
+// weight, not the parser's.
+export const EpaPdfImportModal = lazy(() => import('./EpaPdfImportModal'));
+
+// Performance-tab importers, opened from PerformanceVehicleSection.
+export const PerformanceImportModal = lazy(() => import('./PerformanceImportModal'));
+export const PastePublishedResultsModal = lazy(() => import('./PastePublishedResultsModal'));

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -68,16 +68,32 @@ export function AppProvider({ children }) {
         setUser(dataService.user);
         setUserRole(dataService.role);
 
-        const vehiclesData = await dataService.getVehicles();
-        const selectedIds = await dataService.getSelectedVehicles();
-        const tagsData = dataService.useSupabase ? await dataService.getTags() : [];
-        const siteSettings = await dataService.getSiteSettings();
-        const manufacturersData = dataService.useSupabase ? await dataService.getManufacturers() : [];
-        const chartHelpData = dataService.useSupabase ? await dataService.getChartHelp() : {};
-        const sessionsData = dataService.useSupabase ? await dataService.getTestSessions() : [];
-        // One extra query, kept out of getVehicles so a missing performance table
-        // can never take the vehicles list down with it.
-        const perfCounts = dataService.useSupabase ? await dataService.getPerformanceRunCounts() : {};
+        // These queries are independent of one another. Awaiting them in sequence
+        // cost ~900ms of round-trip latency on a warm load — six of the seven
+        // return under 4KB, so the time was almost entirely waiting, not transfer.
+        // Keep them in one Promise.all; adding a new startup query below this line
+        // rather than inside it silently reintroduces the waterfall.
+        const [
+            vehiclesData,
+            selectedIds,
+            tagsData,
+            siteSettings,
+            manufacturersData,
+            chartHelpData,
+            sessionsData,
+            perfCounts,
+        ] = await Promise.all([
+            dataService.getVehicles(),
+            dataService.getSelectedVehicles(),
+            dataService.useSupabase ? dataService.getTags() : [],
+            dataService.getSiteSettings(),
+            dataService.useSupabase ? dataService.getManufacturers() : [],
+            dataService.useSupabase ? dataService.getChartHelp() : {},
+            dataService.useSupabase ? dataService.getTestSessions() : [],
+            // One extra query, kept out of getVehicles so a missing performance table
+            // can never take the vehicles list down with it.
+            dataService.useSupabase ? dataService.getPerformanceRunCounts() : {},
+        ]);
 
         // Derive custom field name suggestions from all vehicles' specs._custom objects
         const suggestions = {};
@@ -742,14 +758,23 @@ export function AppProvider({ children }) {
         return { created, updated, failures };
     };
 
-    const uploadVehicleImage = async (vehicleId, file) => {
+    const uploadVehicleImage = async (vehicleId, renditions) => {
         try {
-            const imageUrl = await dataService.uploadVehicleImage(vehicleId, file);
-            setVehicles(prev => prev.map(v => v.id === vehicleId ? { ...v, image_url: imageUrl } : v));
-            return imageUrl;
+            const urls = await dataService.uploadVehicleImage(vehicleId, renditions);
+            setVehicles(prev => prev.map(v => v.id === vehicleId ? { ...v, ...urls } : v));
+            return urls;
         } catch (error) {
             showError('Error uploading image: ' + error.message);
         }
+    };
+
+    const backfillVehicleThumbnails = async (onProgress) => {
+        const result = await dataService.backfillVehicleThumbnails(onProgress);
+        // Re-read rather than patching locally: the backfill writes rows this
+        // context did not touch, and a partial run must not leave the grid
+        // claiming thumbnails that were not written.
+        if (result.updated > 0) await softRefreshVehicles();
+        return result;
     };
 
     const toggleVehicleVisibility = async (vehicleId, newVisibility) => {
@@ -1417,6 +1442,7 @@ export function AppProvider({ children }) {
         createTag,
         syncVehicleTags,
         uploadVehicleImage,
+        backfillVehicleThumbnails,
         toggleVehicleVisibility,
         replaceRunData,
         mergeRunData,

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -3,8 +3,17 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { roundTo, } from '../utils/unitConversions';
 import { toSessionRow } from '../utils/testSessions';
 import { detectPopulatedFields, buildInheritedRunId, isInheritedRunId, parseInheritedRunId, runKindFrom, applyDefaultRun, clearDefaultRuns } from '../utils/runUtils';
+import { THUMB_MAX, THUMB_QUALITY, thumbPathFor, renderToJpegBlob, loadBitmapFromUrl } from '../utils/imageRenditions';
 
 const roundField = roundTo;
+
+/**
+ * How long a stored image object may be cached. Safe at a year only because
+ * every stored URL carries a ?v= stamp written at upload time — see
+ * #putVehicleImageObject. Objects predating that carry Supabase Storage's
+ * default of no-cache and revalidate on every page load.
+ */
+const IMAGE_CACHE_SECONDS = 31536000;
 
 /** Normalise a raw data-point object into a clean DB row shape. */
 function normalisePoint(point, runId, frame) {
@@ -403,18 +412,102 @@ class DataService {
     }
   }
 
-  async uploadVehicleImage(vehicleId, blob) {
-    // Always store as JPEG — the blob is produced by the crop/resize canvas step
-    const path = `${vehicleId}.jpg`;
-    const { error: uploadError } = await getSupabase().storage
-      .from('vehicle-images')
-      .upload(path, blob, { upsert: true, contentType: 'image/jpeg' });
-    if (uploadError) throw uploadError;
-    const { data } = getSupabase().storage.from('vehicle-images').getPublicUrl(path);
+  /**
+   * Store both renditions of a vehicle image and point the row at them.
+   *
+   * @param {number} vehicleId
+   * @param {{ full: Blob, thumb: Blob }} renditions from utils/imageRenditions
+   * @returns {Promise<{ image_url: string, image_thumb_url: string }>}
+   */
+  async uploadVehicleImage(vehicleId, renditions) {
+    // Always store as JPEG — both blobs are produced by the crop/resize canvas step
+    const fullPath = `${vehicleId}.jpg`;
+    const thumbPath = thumbPathFor(fullPath);
+
+    const [fullResult, thumbResult] = await Promise.all([
+      this.#putVehicleImageObject(fullPath, renditions.full),
+      this.#putVehicleImageObject(thumbPath, renditions.thumb),
+    ]);
+
+    const patch = { image_url: fullResult, image_thumb_url: thumbResult };
     const { error: updateError } = await getSupabase()
-      .from('vehicles').update({ image_url: data.publicUrl }).eq('id', vehicleId);
+      .from('vehicles').update(patch).eq('id', vehicleId);
     if (updateError) throw updateError;
-    return data.publicUrl;
+    return patch;
+  }
+
+  /**
+   * Upload one image object and return its public URL with a version query.
+   *
+   * The storage path is derived from the vehicle id, so replacing an image
+   * reuses the same key. That is what makes the long cacheControl safe to set:
+   * the ?v= stamp changes on every write, so a replaced image is a new URL to
+   * every cache while the object itself can be held for a year. Without the
+   * stamp a long max-age would pin the old picture in browsers indefinitely.
+   */
+  async #putVehicleImageObject(path, blob) {
+    const { error } = await getSupabase().storage
+      .from('vehicle-images')
+      .upload(path, blob, {
+        upsert: true,
+        contentType: 'image/jpeg',
+        cacheControl: String(IMAGE_CACHE_SECONDS),
+      });
+    if (error) throw error;
+    const { data } = getSupabase().storage.from('vehicle-images').getPublicUrl(path);
+    return `${data.publicUrl}?v=${Date.now()}`;
+  }
+
+  /**
+   * Generate the missing card-sized rendition for vehicles that only have a
+   * full-resolution image — the one-time catch-up for everything uploaded
+   * before migration 051.
+   *
+   * Deliberately leaves image_url alone: the original is the copy we cannot
+   * regenerate, and re-encoding it here would degrade it for no gain.
+   *
+   * @param {(done:number, total:number, label:string) => void} [onProgress]
+   * @returns {Promise<{ updated:number, failures:Array<{id:number,name:string,error:string}> }>}
+   */
+  async backfillVehicleThumbnails(onProgress) {
+    const { data, error } = await getSupabase()
+      .from('vehicles')
+      .select('id, name, image_url, image_thumb_url')
+      .not('image_url', 'is', null)
+      .is('image_thumb_url', null)
+      .order('id');
+    if (error) throw error;
+
+    const pending = data || [];
+    const failures = [];
+    let updated = 0;
+
+    // Sequential on purpose. This runs a handful of times in the life of the
+    // project against ~25 rows; decoding several 1600x900 images at once is a
+    // real memory spike in a browser tab, and a slow correct pass beats a fast
+    // one that dies halfway with no record of where it stopped.
+    for (const [index, vehicle] of pending.entries()) {
+      onProgress?.(index, pending.length, vehicle.name || `#${vehicle.id}`);
+      let bitmap;
+      try {
+        bitmap = await loadBitmapFromUrl(vehicle.image_url);
+        const thumb = await renderToJpegBlob(bitmap, THUMB_MAX, THUMB_QUALITY);
+        const thumbUrl = await this.#putVehicleImageObject(
+          thumbPathFor(`${vehicle.id}.jpg`), thumb,
+        );
+        const { error: updateError } = await getSupabase()
+          .from('vehicles').update({ image_thumb_url: thumbUrl }).eq('id', vehicle.id);
+        if (updateError) throw updateError;
+        updated++;
+      } catch (err) {
+        failures.push({ id: vehicle.id, name: vehicle.name, error: err.message });
+      } finally {
+        bitmap?.close();
+      }
+    }
+
+    onProgress?.(pending.length, pending.length, '');
+    return { updated, failures };
   }
 
   async addVehicle(vehicle) {

--- a/src/utils/imageRenditions.js
+++ b/src/utils/imageRenditions.js
@@ -1,0 +1,110 @@
+// Vehicle images are stored in two renditions: the full-resolution original and
+// a card-sized thumbnail. This module owns both the dimensions and the canvas
+// resize step, so the upload path and the one-time backfill cannot drift apart.
+//
+// Why two: the grid renders images into a ~394 CSS px box, so a 1600×900 JPEG
+// ships roughly 4× the pixels any screen will use (2× the pixels on a HiDPI
+// display). The full copy is still kept — see migration 051 for why.
+
+/** Full rendition. Matches what the crop step has always produced. */
+export const FULL_MAX = { width: 1600, height: 900 };
+
+/**
+ * Thumbnail rendition. 800×450 is 2× the widest box the card uses (~394 CSS px),
+ * so it stays sharp on HiDPI screens and is the smallest size that does.
+ */
+export const THUMB_MAX = { width: 800, height: 450 };
+
+/** JPEG quality per rendition. The thumbnail is displayed small, so it tolerates
+ *  more compression than the original we are keeping for later features. */
+export const FULL_QUALITY = 0.92;
+export const THUMB_QUALITY = 0.82;
+
+/** Storage prefix for thumbnails, relative to the vehicle-images bucket root. */
+export const THUMB_PREFIX = 'thumbs';
+
+/** `24.jpg` → `thumbs/24.jpg`. Kept here so the path shape has one definition. */
+export function thumbPathFor(fullPath) {
+    return `${THUMB_PREFIX}/${fullPath}`;
+}
+
+/**
+ * Draw a source image into a canvas that fits within `max`, preserving aspect
+ * ratio, and return it as a JPEG blob.
+ *
+ * Never upscales: an image already smaller than `max` is re-encoded at its own
+ * size rather than stretched.
+ *
+ * @param {CanvasImageSource & {width:number,height:number}} source
+ *        Anything drawImage accepts that also reports intrinsic dimensions —
+ *        an HTMLImageElement, an ImageBitmap, or another canvas.
+ * @param {{width:number,height:number}} max
+ * @param {number} quality
+ * @returns {Promise<Blob>}
+ */
+export function renderToJpegBlob(source, max, quality) {
+    const sourceW = source.naturalWidth ?? source.width;
+    const sourceH = source.naturalHeight ?? source.height;
+    if (!sourceW || !sourceH) {
+        return Promise.reject(new Error('Source image has no intrinsic size'));
+    }
+
+    const scale = Math.min(1, max.width / sourceW, max.height / sourceH);
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(sourceW * scale));
+    canvas.height = Math.max(1, Math.round(sourceH * scale));
+
+    const ctx = canvas.getContext('2d');
+    // Downscaling by more than 2× with the default filter aliases badly on the
+    // fine detail in a car photo (grille slats, wheel spokes).
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(source, 0, 0, canvas.width, canvas.height);
+
+    return new Promise((resolve, reject) => {
+        canvas.toBlob(
+            blob => blob ? resolve(blob) : reject(new Error('Canvas toBlob failed')),
+            'image/jpeg',
+            quality,
+        );
+    });
+}
+
+/**
+ * Produce both renditions from one source.
+ *
+ * Both come from the same source rather than the thumbnail being re-derived
+ * from the encoded full JPEG: the source is the cropped canvas, so the two
+ * renditions frame an identical region and the thumbnail is not compressed
+ * twice.
+ *
+ * @returns {Promise<{ full: Blob, thumb: Blob }>}
+ */
+export async function buildRenditions(source) {
+    const [full, thumb] = await Promise.all([
+        renderToJpegBlob(source, FULL_MAX, FULL_QUALITY),
+        renderToJpegBlob(source, THUMB_MAX, THUMB_QUALITY),
+    ]);
+    return { full, thumb };
+}
+
+/**
+ * The URL every UI surface should render. Nothing on screen is wider than the
+ * thumbnail, so the full-resolution original is only for features that
+ * explicitly want it.
+ *
+ * Falls back to image_url so rows are correct before the backfill has run and
+ * for anything uploaded by a client older than migration 051.
+ */
+export function displayImageUrl(vehicle) {
+    return vehicle?.image_thumb_url || vehicle?.image_url || '';
+}
+
+/** Load a URL into an ImageBitmap for the backfill path. Storage is public, but
+ *  the fetch is still cross-origin, so this goes through fetch → blob → bitmap
+ *  rather than an <img> that would taint a canvas. */
+export async function loadBitmapFromUrl(url) {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`Fetch failed (${res.status})`);
+    return createImageBitmap(await res.blob());
+}

--- a/supabase/migrations/051_vehicle_image_thumb.sql
+++ b/supabase/migrations/051_vehicle_image_thumb.sql
@@ -1,0 +1,28 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 051: a second, card-sized rendition of each vehicle image.
+--
+-- Every vehicle image is stored at 1600×900 and every place that displays one
+-- renders it into a box no wider than ~394 CSS px. On the Vehicles grid that
+-- meant 4.7 MB of images on a cold first load — 91% of the page's total bytes —
+-- to fill roughly 0.9 MB worth of pixels, and none of it deferred: all 23
+-- requests fire in the same tick once the vehicle list resolves.
+--
+-- The full-resolution original is deliberately KEPT. It is the only copy we
+-- have, it is what future features (lightbox, comparison hero art, print) will
+-- want, and regenerating it from a thumbnail is impossible. So this is a second
+-- object alongside the first, not a replacement:
+--
+--   vehicle-images/<id>.jpg          full,  ≤1600×900   (unchanged, authoritative)
+--   vehicle-images/thumbs/<id>.jpg   thumb, ≤800×450    (new, what the UI renders)
+--
+-- The column is nullable and the UI falls back to image_url when it is null, so
+-- rows are correct before the backfill runs and stay correct for any image
+-- uploaded by an older client.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE vehicles ADD COLUMN IF NOT EXISTS image_thumb_url text;
+
+COMMENT ON COLUMN vehicles.image_url IS
+    'Public URL of the full-resolution vehicle image (<=1600x900). Authoritative original; not what the grid renders.';
+COMMENT ON COLUMN vehicles.image_thumb_url IS
+    'Public URL of the card-sized rendition (<=800x450) derived from image_url. Null means no thumbnail yet — callers fall back to image_url.';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    }
+  ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,33 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        // Split the three large dependencies out of the app chunk. This does not
+        // reduce first-load bytes — every one of them is needed to render the
+        // first screen — it changes how they are CACHED. With /assets/* now
+        // served immutable, a deploy that only touches app code leaves these
+        // three URLs unchanged, so returning visitors re-download ~180KB of app
+        // instead of the whole 400KB bundle.
+        //
+        // Deliberately NOT split by view: tab switching must never wait on a
+        // fetch, so all views and charts stay in the eager app chunk. The
+        // deferred set is utilities only — see components/lazyComponents.js.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          // pdfjs-dist is already dynamically imported by utils/extractPdfText.
+          // Naming a chunk here would pull it back into the static graph.
+          if (id.includes('pdfjs-dist')) return;
+          if (id.includes('chart.js') || id.includes('chartjs')) return 'vendor-charts';
+          if (id.includes('@supabase') || id.includes('realtime-js')) return 'vendor-supabase';
+          if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('/scheduler/')) {
+            return 'vendor-react';
+          }
+        },
+      },
+    },
+  },
   test: {
     // Pure modules only for now: no jsdom, so the suite stays fast enough to
     // run on every save. The wiring suite reads source text rather than


### PR DESCRIPTION
A first-load performance pass, measured against the live site at https://evbench.pluginpath.com/.

Two numbers framed the work: the app sat blank behind **~2.1 s of serialized data fetching**, and **91% of the 5.2 MB cold load was vehicle images** rendered into boxes a quarter of their size.

## 1. Startup queries now run in parallel

`initializeApp` awaited seven independent queries one after another:

| query | gzip payload |
|---|---|
| `vehicles` | 61,790 B |
| `tags` | 234 B |
| `site_settings` | 151 B |
| `manufacturers` | 351 B |
| `chart_help` | 3,270 B |
| `test_sessions` | 865 B |
| `performance_sessions` | 128 B |

Six of the seven return under 4 KB, so the ~900 ms that chain cost on a warm load was almost entirely latency, not transfer. They now run in one `Promise.all`.

Verified in the dev preview: all seven now start within 2 ms of each other (820–822 ms) instead of chaining 200 ms → 1848 ms.

## 2. Preconnect to the Supabase origin

Nothing pointed at that origin until the bundle had parsed and run, so DNS + TLS landed on the critical path at ~1.2 s. `index.html` now carries `preconnect` + `dns-prefetch`, with the URL substituted from `VITE_SUPABASE_URL` at build time so it can't drift.

## 3. Immutable caching for hashed assets

Vercel was serving the content-hashed bundles as `public, max-age=0, must-revalidate`. They 304 correctly, so this was never a bandwidth cost — but every repeat visit paid a revalidation round trip before a single line of script could run. `vercel.json` marks `/assets/*` immutable and leaves `index.html` revalidated, since it's the unfingerprinted file that points at the current hashes.

## 4. Image renditions — the big one

Every vehicle image is stored at ~1600×900 and displayed in a ~394 CSS px box. Worth noting: these were **not** lazy-loading. All 23 requests fire in the same tick once the vehicle list resolves; they merely *arrive* progressively because it's 4.7 MB.

Images are now stored twice:

```
vehicle-images/<id>.jpg          full,  ≤1600×900   unchanged, authoritative
vehicle-images/thumbs/<id>.jpg   thumb, ≤800×450    what the UI renders
```

**The full-resolution original is deliberately kept** — it's the only copy, and later features will want it. 800×450 is 2× the widest box the card uses, so it stays sharp on HiDPI.

Measured on the real stored images, not estimated:

| file | source | before | after | |
|---|---|---|---|---|
| 23.webp | 1920×1124 | 486 KB | 100 KB | 21% |
| 24.jpg | 1600×900 | 437 KB | 76 KB | 17% |
| 73.jpg | 1599×900 | 372 KB | 66 KB | 18% |
| 17.jpg | 1536×864 | 355 KB | 76 KB | 22% |
| 9.jpg | 1536×864 | 331 KB | 71 KB | 21% |
| 47.jpg | 1599×900 | 299 KB | 53 KB | 18% |
| 3.jpg | 746×420 | 68 KB | 39 KB | 57% |
| 19.jpg | 400×267 | 25 KB | 22 KB | 86% |

**4.72× on this sample** — the last two rows are the no-upscale guard working; sources already under the cap are re-encoded, never stretched.

### Post-backfill actuals

The backfill has since been run against production. Measured across the full set of 28, rather than the sample above:

| | bytes |
|---|---|
| 28 originals | 6,108,998 (~5,966 KB) |
| 28 thumbnails | 1,654,206 (~1,615 KB) |
| **saved** | **4,454,792 (~4,350 KB)** |

**3.69× overall**, thumbnails are 27% of originals. The 4.72× sample figure was skewed toward the largest files; 3.69× is the true whole-set number. 28/28 generated, zero failures, all carrying the `?v=` stamp.

New uploads write both renditions. For the ~25 images that predate this, **Admin → Interface Settings → Vehicle image thumbnails** generates the missing ones. It's idempotent (only touches rows where `image_thumb_url` is null), runs in the browser under the admin's own session and RLS, and leaves originals untouched.

Stored URLs now carry a `?v=` stamp, which is what makes a one-year `cacheControl` safe despite the storage path being stable across replacements.

> ⚠️ **The `cacheControl` is currently inert — origin-side, not a code issue.** The value is stored correctly (`/object/info/public/` reports `"cache_control": "max-age=31536000"` on a backfilled thumb) but the Supabase CDN serves `cache-control: no-cache` regardless. It does the same to objects predating this PR, which carry the SDK default `max-age=3600` — so this is not a regression and not caused by this change. Consequence: repeat visitors still pay ~28 revalidation round trips to Storage (they 304, so ~0 bytes). The `?v=` machinery is in place, so this starts working the moment the origin honours object cache-control; that's a Supabase project/plan setting, not something this branch can fix.

## 5. Lazy chunks — utilities only

**Views and charts stay eager.** Tab switching is the interaction users perform constantly and it must not wait on a fetch. The deferred set is utilities: the importers, the EPA wizards, and the vehicle edit form (which carries `react-image-crop` and its stylesheet). The policy lives in one file, `src/components/lazyComponents.js`, so it reads as a decision rather than scattered call sites.

First-load JS: **388 KB → 356 KB gzipped** (1,290 KB → 1,180 KB minified), with ~34 KB gzipped of utilities deferred.

`react` / `chart.js` / `@supabase` also split into their own chunks. This doesn't reduce first-load bytes — all three are needed for the first screen — but combined with the immutable headers, an app-only deploy no longer invalidates ~190 KB gzipped of unchanged vendor code. Vite emits `modulepreload` for them, so the split adds no waterfall.

## Wiring guards

Two additions to the wiring suite, both verified to fail when the seam breaks:

- **`renders vehicle images through the thumbnail resolver`** — fails if any surface puts `image_url` on the wire directly instead of going through `displayImageUrl`. Presence checks (`image_url ? 'Replace' : 'Upload'`) are deliberately not matched.
- **`loads the startup queries in parallel`** — fails if a startup query is awaited outside the `Promise.all`, which is exactly how the waterfall would come back.

## Deploy order

⚠️ **Apply migration `051_vehicle_image_thumb.sql` before merging.** It's additive and backwards-compatible — `displayImageUrl` falls back to `image_url` when the column is null, so the app is correct before the backfill runs — but the upload path and the backfill both write `image_thumb_url` and will error until the column exists.

Then run the backfill once from Admin → Interface Settings.

## Verification

- `npm run lint` — 98 problems / 4 errors, **identical to `main`**; this branch adds none. (The 4 errors are pre-existing in `RunSpecRows.jsx`.)
- `npm test` — 126 passed, up from 124.
- `npm run build` — clean.
- Dev preview — no console errors, 24 cards render, no lazy chunk requested on first paint, all 7 lazy modules confirmed to resolve with a valid default export.

**Not visually signed off yet** — the preview is signed out, so the contributor/admin surfaces (edit form, importers, the new backfill card) could not be exercised end to end.
