### PR TITLE
Hoist the inline Missing component out of RunSpecRows' render body

### DIFF
--- a/src/components/RunSpecRows.jsx
+++ b/src/components/RunSpecRows.jsx
@@ -28,6 +28,13 @@ const Item = ({ children, title, className = 'text-secondary' }) => (
     <span className={className} title={title}>{children}</span>
 );
 
+// A missing condition is shown as a gap rather than omitted, so the row keeps
+// its shape from card to card and an unrecorded figure is visibly unrecorded
+// — the correction skips exactly these, and silence looked like zero.
+const Missing = ({ what }) => (
+    <span className="text-faint" title={`No ${what} recorded — correction skips this axis`}>—</span>
+);
+
 function Row({ label, items }) {
     if (!items.length) return null;
     return (
@@ -81,13 +88,6 @@ export default function RunSpecRows({ run, units, socRange, fieldMeta = [], calc
 
     // ── Conditions: what the day imposed ─────────────────────────────────────
     const conditions = [];
-
-    // A missing condition is shown as a gap rather than omitted, so the row keeps
-    // its shape from card to card and an unrecorded figure is visibly unrecorded
-    // — the correction skips exactly these, and silence looked like zero.
-    const Missing = ({ what }) => (
-        <span className="text-faint" title={`No ${what} recorded — correction skips this axis`}>—</span>
-    );
 
     if (run.temperature_f != null) {
         conditions.push(<Item key="tmp" className="text-orange-700">{fmtTemp(run.temperature_f, units)}</Item>);


### PR DESCRIPTION
## What

`Missing` was declared inside `RunSpecRows`' render body and used in four places. The React Compiler rules flag this as `react-hooks/static-components` — a component built during render is a **new component type on every render**, so React unmounts and remounts its subtree instead of updating it.

These were the **only four ESLint errors in the project**, a standing violation of CLAUDE.md's "**Zero errors is the bar**". The fix is the one CLAUDE.md already prescribes: "Module-level (not inline) component definitions to avoid React remounting on every render".

## How

`Missing` closed over nothing — `what` was already a prop — so this is a straight move to module level, explanatory comment included. Rendered markup is unchanged.

`Item` and `Row` in this file were already at module level; `Missing` was the only inline definition.

## Verification

| | before | after |
|---|---|---|
| `npm run lint` | 4 errors, 94 warnings | **0 errors**, 94 warnings |
| `npm test` | 124 passed | 124 passed |

Warning count is untouched — the backlog is unchanged, only the errors are gone.

> Note: the task description cited 126 tests; `main` is at 124, so that baseline is unchanged, not reduced.

## Review note

This is a rendering change, so it wants visual sign-off on the **Tests & Data** run rows (the "Conditions" row, where `—` placeholders appear for unrecorded temperature / wind / altitude / elevation gain) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)