### PR TITLE
Align charging curves on a common SoC by default (#195)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,8 +117,15 @@ export default function App() {
         yAxis: 'chargeRate',
         y2Axis: null,
         selectedRuns: [],
-        raceMode: false,
-        raceThreshold: 10,  // % SoC at which all runs are normalised to t = 0
+        // Time-axis alignment is on by default (#195): unaligned, every run
+        // starts at zero whatever SoC it began at, which compares nothing.
+        // alignRaw is the opt-out.
+        alignRaw: false,
+        // null means "follow the data" — the lowest SoC every selected run
+        // actually reaches. A fixed 10 looked like a default and behaved like a
+        // decision, drawing a run that began at 25% from t=0 alongside runs that
+        // began at 10%.
+        raceThreshold: null,
         xMin: null,
         xMax: null,
         yMin: 0,
@@ -222,8 +229,8 @@ export default function App() {
             xAxis:         p.get('x')  || null,
             yAxis:         p.get('y')  || null,
             y2Axis:        p.get('y2') || null,
-            raceMode:      p.get('race') === '1',
-            raceThreshold: p.get('rt')  ? Number(p.get('rt'))  : 10,
+            alignRaw:      p.get('raw') === '1',
+            raceThreshold: p.get('rt')  ? Number(p.get('rt'))  : null,
             xMin:  p.get('xn')  !== null && p.get('xn')  !== '' ? Number(p.get('xn'))  : null,
             xMax:  p.get('xx')  !== null && p.get('xx')  !== '' ? Number(p.get('xx'))  : null,
             yMin:  p.get('yn')  !== null && p.get('yn')  !== '' ? Number(p.get('yn'))  : 0,
@@ -319,7 +326,7 @@ export default function App() {
             ...(s.yAxis         && { yAxis: s.yAxis }),
             ...(s.y2Axis        && { y2Axis: s.y2Axis }),
             ...(s.runIds.length  > 0 && s.chartMode === 'charging' && { selectedRuns: s.runIds }),
-            raceMode:      s.raceMode,
+            alignRaw:      s.alignRaw,
             raceThreshold: s.raceThreshold,
             xMin:          s.xMin,
             xMax:          s.xMax,
@@ -354,8 +361,8 @@ export default function App() {
         p.set('x', chartConfig.xAxis);
         p.set('y', chartConfig.yAxis);
         if (chartConfig.y2Axis)                   p.set('y2',   chartConfig.y2Axis);
-        if (chartConfig.raceMode)                 p.set('race', '1');
-        if (chartConfig.raceThreshold !== 10)     p.set('rt',   String(chartConfig.raceThreshold));
+        if (chartConfig.alignRaw)                 p.set('raw', '1');
+        if (chartConfig.raceThreshold != null)    p.set('rt',   String(chartConfig.raceThreshold));
         if (chartConfig.xMin != null)             p.set('xn',   String(chartConfig.xMin));
         if (chartConfig.xMax != null)             p.set('xx',   String(chartConfig.xMax));
         if (chartConfig.yMin != null && chartConfig.yMin !== 0) p.set('yn', String(chartConfig.yMin));

--- a/src/__tests__/wiring.test.js
+++ b/src/__tests__/wiring.test.js
@@ -56,6 +56,8 @@ describe('utilities built for the UI are reached by the UI', () => {
             'Tuning constant for rampLength, exported to be named and testable rather than to be called.',
         'socAlignment.RAMP_MAX_TRIM':
             'As above — the cap on ramp trimming, asserted by name in the tests.',
+        'socAlignment.trimRamp':
+            'Called by alignSeries and minimumCommonSoc, both of which the chart calls. Exported so the trim can be asserted on its own.',
         'socAlignment.rampLength':
             'The ramp detector. Called by extrapolationSlope; exported so its behaviour is pinned directly against real R2 data.',
         'socAlignment.extrapolationSlope':

--- a/src/__tests__/wiring.test.js
+++ b/src/__tests__/wiring.test.js
@@ -54,6 +54,8 @@ describe('utilities built for the UI are reached by the UI', () => {
             'The limit itself, consumed inside the module by overExtrapolated — which the chart does call.',
         'socAlignment.RAMP_PLATEAU_FRACTION':
             'Tuning constant for rampLength, exported to be named and testable rather than to be called.',
+        'socAlignment.RAMP_TRIM_MIN_MINUTES':
+            'The threshold that decides whether alignSeries trims at all; consumed inside the module and asserted by name.',
         'socAlignment.RAMP_MAX_TRIM':
             'As above — the cap on ramp trimming, asserted by name in the tests.',
         'socAlignment.trimRamp':

--- a/src/__tests__/wiring.test.js
+++ b/src/__tests__/wiring.test.js
@@ -40,7 +40,7 @@ describe('utilities built for the UI are reached by the UI', () => {
     // Scoped to the modules built recently rather than the whole codebase: 48
     // exports are unused project-wide, nearly all pre-existing in the EPA and
     // parser modules. Widening this wants a cleanup first, not an allowlist.
-    const WATCHED = ['conditionCorrection.js', 'testSessions.js', 'seriesLabel.js'];
+    const WATCHED = ['conditionCorrection.js', 'testSessions.js', 'seriesLabel.js', 'socAlignment.js'];
 
     // Deliberately unused, and why. An entry here is a decision, not an oversight.
     const ALLOWED_UNUSED = {
@@ -50,6 +50,16 @@ describe('utilities built for the UI are reached by the UI', () => {
             'The default value itself, consumed inside the module and by the chartConfig fallback literal.',
         'conditionCorrection.CORRECTION_MODES':
             'Consumed by CorrectionControl to render the picker.',
+        'socAlignment.EXTRAPOLATION_SOC_LIMIT':
+            'The limit itself, consumed inside the module by overExtrapolated — which the chart does call.',
+        'socAlignment.RAMP_PLATEAU_FRACTION':
+            'Tuning constant for rampLength, exported to be named and testable rather than to be called.',
+        'socAlignment.RAMP_MAX_TRIM':
+            'As above — the cap on ramp trimming, asserted by name in the tests.',
+        'socAlignment.rampLength':
+            'The ramp detector. Called by extrapolationSlope; exported so its behaviour is pinned directly against real R2 data.',
+        'socAlignment.extrapolationSlope':
+            'Called by alignSeries, which the chart calls. Exported so the slope basis can be asserted without going through alignment.',
     };
 
     for (const mod of WATCHED) {

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -762,11 +762,11 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 {/* Axis selectors */}
                 <div className="axis-selectors">
                     <div>
-                        <label className="block font-medium mb-2">X-Axis:</label>
+                        <label className="axis-label">X-Axis:</label>
                         <select
                             value={chartConfig.xAxis}
                             onChange={(e) => setChartConfig({ ...chartConfig, xAxis: e.target.value })}
-                            className="border p-2 rounded w-full"
+                            className="axis-select"
                         >
                             {axisOptions.map(opt => (
                                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -774,11 +774,11 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                         </select>
                     </div>
                     <div>
-                        <label className="block font-medium mb-2">Left Axis (Y):</label>
+                        <label className="axis-label">Left Axis (Y):</label>
                         <select
                             value={chartConfig.yAxis}
                             onChange={(e) => setChartConfig({ ...chartConfig, yAxis: e.target.value })}
-                            className="border p-2 rounded w-full"
+                            className="axis-select"
                         >
                             {axisOptions.map(opt => (
                                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -786,11 +786,11 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                         </select>
                     </div>
                     <div>
-                        <label className="block font-medium mb-2">Right Axis (Y2):</label>
+                        <label className="axis-label">Right Axis (Y2):</label>
                         <select
                             value={chartConfig.y2Axis ?? ''}
                             onChange={(e) => setChartConfig({ ...chartConfig, y2Axis: e.target.value || null })}
-                            className="border p-2 rounded w-full"
+                            className="axis-select"
                         >
                             <option value="">— None —</option>
                             {axisOptions.map(opt => (
@@ -798,47 +798,51 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             ))}
                         </select>
                     </div>
-
-                    {/* Alignment is a property of the time axis, so it belongs
-                        with the axis selectors rather than in a panel below the
-                        chart that had to be found and switched on. */}
-                    {isTimeAxis && (
-                        <div>
-                            <label className="block font-medium mb-2">Align start at:</label>
-                            <div className="flex items-center gap-2">
-                                <input
-                                    type="number"
-                                    min="0" max="100"
-                                    value={chartConfig.raceThreshold ?? (commonSoc ?? '')}
-                                    placeholder={commonSoc != null ? String(commonSoc) : '10'}
-                                    onChange={e => setChartConfig({
-                                        ...chartConfig,
-                                        raceThreshold: e.target.value === '' ? null : clampSoc(e.target.value, commonSoc ?? 10),
-                                    })}
-                                    disabled={chartConfig.alignRaw}
-                                    className="border p-2 rounded w-20 disabled:opacity-50"
-                                />
-                                <span className="text-sm text-secondary">% SoC</span>
-                                {commonSoc != null && chartConfig.raceThreshold == null && (
-                                    <span className="text-xs text-faint" title="The lowest SoC every selected run actually reaches — no run is dropped at this value.">
-                                        lowest common
-                                    </span>
-                                )}
-                            </div>
-                            <label className="toggle-label mt-2">
-                                <input
-                                    type="checkbox"
-                                    checked={!!chartConfig.alignRaw}
-                                    onChange={e => setChartConfig({ ...chartConfig, alignRaw: e.target.checked })}
-                                    className="w-4 h-4"
-                                />
-                                <span className="text-xs text-secondary" title="Show each run's own logger time. Runs will start at zero regardless of the SoC they began at, so the curves are not comparable.">
-                                    Raw logger time (not comparable)
-                                </span>
-                            </label>
-                        </div>
-                    )}
                 </div>
+
+                {/* Alignment is a property of the time axis, so it belongs with
+                    the axis selectors rather than in a panel below the chart
+                    that had to be found and switched on. It sits under them and
+                    indented: it modifies X, it is not a fourth axis. */}
+                {isTimeAxis && (
+                    <div className="axis-align-row">
+                        <label className="text-sm font-medium text-secondary" htmlFor="align-soc">
+                            Align start at:
+                        </label>
+                        <span className="flex items-center gap-1.5">
+                            <input
+                                id="align-soc"
+                                type="number"
+                                min="0" max="100"
+                                value={chartConfig.raceThreshold ?? (commonSoc ?? '')}
+                                placeholder={commonSoc != null ? String(commonSoc) : '10'}
+                                onChange={e => setChartConfig({
+                                    ...chartConfig,
+                                    raceThreshold: e.target.value === '' ? null : clampSoc(e.target.value, commonSoc ?? 10),
+                                })}
+                                disabled={chartConfig.alignRaw}
+                                className="form-input text-sm py-0.5 w-16 disabled:opacity-50"
+                            />
+                            <span className="text-sm text-secondary">% SoC</span>
+                        </span>
+                        {commonSoc != null && chartConfig.raceThreshold == null && (
+                            <span className="text-xs text-faint" title="The lowest SoC every selected run actually reaches — no run is dropped at this value.">
+                                lowest common
+                            </span>
+                        )}
+                        <label className="toggle-label">
+                            <input
+                                type="checkbox"
+                                checked={!!chartConfig.alignRaw}
+                                onChange={e => setChartConfig({ ...chartConfig, alignRaw: e.target.checked })}
+                                className="w-4 h-4"
+                            />
+                            <span className="text-sm text-secondary" title="Show each run's own elapsed time from the start of the test. Runs will start at zero regardless of the SoC they began at, so the curves are not comparable.">
+                                Raw test time (not comparable)
+                            </span>
+                        </label>
+                    </div>
+                )}
 
                 {/* ── Line / points toggles ── */}
                 <div className="chart-toggles">
@@ -937,6 +941,33 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 />
             </div>}
 
+            {/* Runs the alignment could not include, named on the chart itself.
+                The selector carries a badge, but that only helps someone who
+                opens the selector — and a screenshot shows neither. A chart
+                silently missing a car is the failure worth designing against. */}
+            {raceActive && (excludedRuns.length > 0 || stretchedRuns.length > 0) && (
+                <div className="roadtrip-warning mb-3">
+                    {excludedRuns.map(({ name, reason }) => (
+                        <p key={name}>⚠ {name}: not aligned — {reason}</p>
+                    ))}
+                    {stretchedRuns.map(({ name, gap }) => (
+                        <p key={name}>
+                            ⚠ {name}: estimated {gap}% of SoC below its own data to reach {raceThreshold}%
+                        </p>
+                    ))}
+                    {excludedRuns.length > 0 && (
+                        <p className="text-xs mt-1">
+                            Lower “Align start at” to include them, or switch to raw test time.
+                        </p>
+                    )}
+                    {stretchedRuns.length > 0 && (
+                        <p className="text-xs mt-1">
+                            Raise “Align start at” to stay inside the measured data.
+                        </p>
+                    )}
+                </div>
+            )}
+
             {/* ── Chart canvas ── */}
             <div className="card mb-4">
                 {loadingData && (
@@ -998,33 +1029,6 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     </div>
                 )}
             </div>
-
-            {/* Runs the alignment could not include, named on the chart itself.
-                The selector carries a badge, but that only helps someone who
-                opens the selector — and a screenshot shows neither. A chart
-                silently missing a car is the failure worth designing against. */}
-            {raceActive && (excludedRuns.length > 0 || stretchedRuns.length > 0) && (
-                <div className="roadtrip-warning mb-3">
-                    {excludedRuns.map(({ name, reason }) => (
-                        <p key={name}>⚠ {name}: not aligned — {reason}</p>
-                    ))}
-                    {stretchedRuns.map(({ name, gap }) => (
-                        <p key={name}>
-                            ⚠ {name}: estimated {gap}% of SoC below its own data to reach {raceThreshold}%
-                        </p>
-                    ))}
-                    {excludedRuns.length > 0 && (
-                        <p className="text-xs mt-1">
-                            Lower “Align start at” to include them, or switch to raw logger time.
-                        </p>
-                    )}
-                    {stretchedRuns.length > 0 && (
-                        <p className="text-xs mt-1">
-                            Raise “Align start at” to stay inside the measured data.
-                        </p>
-                    )}
-                </div>
-            )}
 
             {/* ── Controls below chart: scale inputs + line toggle + race mode — hidden in presentation mode ── */}
             {!presentationMode && <div className="card mb-6">

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -423,13 +423,20 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             for (const run of vehicle.runs || []) {
                 if (!chartConfig.selectedRuns.includes(run.id)) continue;
                 const aligned = alignSeries(runDataCache[run.id], raceThreshold);
-                if (overExtrapolated(aligned)) {
-                    out.push({
-                        name: run.name,
-                        gap: Math.round(aligned.gap),
-                        rampTrimmed: aligned.rampTrimmed ?? 0,
-                    });
-                }
+                if (overExtrapolated(aligned)) out.push({ name: run.name, gap: Math.round(aligned.gap) });
+            }
+        }
+        return out;
+    }, [raceActive, raceThreshold, selectedVehicles, chartConfig.selectedRuns, runDataCache]);
+
+    const trimmedRuns = useMemo(() => {
+        if (!raceActive) return [];
+        const out = [];
+        for (const vehicle of selectedVehicles) {
+            for (const run of vehicle.runs || []) {
+                if (!chartConfig.selectedRuns.includes(run.id)) continue;
+                const aligned = alignSeries(runDataCache[run.id], raceThreshold);
+                if (aligned?.rampTrimmed > 0) out.push({ name: run.name, n: aligned.rampTrimmed });
             }
         }
         return out;
@@ -956,14 +963,9 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     {excludedRuns.map(({ name, reason }) => (
                         <p key={name}>⚠ {name}: not aligned — {reason}</p>
                     ))}
-                    {stretchedRuns.map(({ name, gap, rampTrimmed }) => (
+                    {stretchedRuns.map(({ name, gap }) => (
                         <p key={name}>
                             ⚠ {name}: estimated {gap}% of SoC below its own data to reach {raceThreshold}%
-                            {rampTrimmed > 0 && (
-                                <span title="A session opens with the charger and the BMS negotiating upward, well under the car's capability. Those points stay on the chart; they are just not what the estimate is drawn from.">
-                                    {' '}(rate taken after the charge ramp)
-                                </span>
-                            )}
                         </p>
                     ))}
                     {excludedRuns.length > 0 && (
@@ -977,6 +979,18 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                         </p>
                     )}
                 </div>
+            )}
+
+            {/* Points held back from the plot, said plainly. A chart quietly
+                missing its first samples is the same failure as one quietly
+                missing a car. */}
+            {raceActive && trimmedRuns.length > 0 && (
+                <p className="text-xs text-faint mb-2"
+                   title="A session opens with the charger and the BMS negotiating power upward, below what the car can take. Those samples describe the plug rather than the car, and they only appear in runs whose logging started at plug-in — so comparing with them in place penalises exactly those runs.">
+                    Opening charge ramp excluded from{' '}
+                    {trimmedRuns.map(t => `${t.name} (${t.n} point${t.n === 1 ? '' : 's'})`).join(', ')}
+                    {' '}· switch to raw test time to see every sample
+                </p>
             )}
 
             {/* ── Chart canvas ── */}

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -821,7 +821,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                                     raceThreshold: e.target.value === '' ? null : clampSoc(e.target.value, commonSoc ?? 10),
                                 })}
                                 disabled={chartConfig.alignRaw}
-                                className="form-input text-sm py-0.5 w-16 disabled:opacity-50"
+                                className="soc-input disabled:opacity-50"
                             />
                             <span className="text-sm text-secondary">% SoC</span>
                         </span>

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -423,7 +423,13 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             for (const run of vehicle.runs || []) {
                 if (!chartConfig.selectedRuns.includes(run.id)) continue;
                 const aligned = alignSeries(runDataCache[run.id], raceThreshold);
-                if (overExtrapolated(aligned)) out.push({ name: run.name, gap: Math.round(aligned.gap) });
+                if (overExtrapolated(aligned)) {
+                    out.push({
+                        name: run.name,
+                        gap: Math.round(aligned.gap),
+                        rampTrimmed: aligned.rampTrimmed ?? 0,
+                    });
+                }
             }
         }
         return out;
@@ -950,9 +956,14 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     {excludedRuns.map(({ name, reason }) => (
                         <p key={name}>⚠ {name}: not aligned — {reason}</p>
                     ))}
-                    {stretchedRuns.map(({ name, gap }) => (
+                    {stretchedRuns.map(({ name, gap, rampTrimmed }) => (
                         <p key={name}>
                             ⚠ {name}: estimated {gap}% of SoC below its own data to reach {raceThreshold}%
+                            {rampTrimmed > 0 && (
+                                <span title="A session opens with the charger and the BMS negotiating upward, well under the car's capability. Those points stay on the chart; they are just not what the estimate is drawn from.">
+                                    {' '}(rate taken after the charge ramp)
+                                </span>
+                            )}
                         </p>
                     ))}
                     {excludedRuns.length > 0 && (

--- a/src/components/ChargingView.jsx
+++ b/src/components/ChargingView.jsx
@@ -12,6 +12,7 @@ import { vehicleLabel } from '../utils/specHelpers';
 import { buildSeriesLabels } from '../utils/seriesLabel';
 import VerboseLabelToggle from './VerboseLabelToggle';
 import CorrectionControl from './CorrectionControl';
+import { minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries, overExtrapolated, clampSoc } from '../utils/socAlignment';
 import { sessionFor } from '../utils/testSessions';
 import { correctionFactor } from '../utils/conditionCorrection';
 import AutoColorToggle from './AutoColorToggle';
@@ -391,8 +392,55 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
 
     // ── Race mode helpers ────────────────────────────────────────────────────
 
-    const raceActive = chartConfig.raceMode && chartConfig.xAxis === 'time';
-    const raceThreshold = chartConfig.raceThreshold ?? 10;
+    // Alignment is ON by default on the time axis, and only means anything
+    // there. Unaligned, every run starts at zero however much charge it began
+    // with, so the chart compares nothing — that is a misleading default rather
+    // than merely a different one. `alignRaw` is the escape hatch for someone
+    // who genuinely wants logger time.
+    const isTimeAxis  = chartConfig.xAxis === 'time';
+    const raceActive  = isTimeAxis && !chartConfig.alignRaw;
+
+    // The lowest SoC every selected run actually reaches. A fixed default —
+    // 10% for a long time here — silently drops every run that started above
+    // it; this drops none, because by construction they all reach it.
+    const commonSoc = useMemo(() => {
+        const series = (chartConfig.selectedRuns || [])
+            .map(id => runDataCache[id])
+            .filter(Boolean);
+        return minimumCommonSoc(series);
+    }, [chartConfig.selectedRuns, runDataCache]);
+
+    // An explicit choice wins; otherwise follow the data as the selection changes.
+    const raceThreshold = chartConfig.raceThreshold ?? commonSoc ?? 10;
+
+    // Runs drawn partly outside their own data, and by how much. Under the
+    // limit this is a defensible short projection; past it, it is a guess
+    // wearing a measurement's clothes and the chart says so.
+    const stretchedRuns = useMemo(() => {
+        if (!raceActive) return [];
+        const out = [];
+        for (const vehicle of selectedVehicles) {
+            for (const run of vehicle.runs || []) {
+                if (!chartConfig.selectedRuns.includes(run.id)) continue;
+                const aligned = alignSeries(runDataCache[run.id], raceThreshold);
+                if (overExtrapolated(aligned)) out.push({ name: run.name, gap: Math.round(aligned.gap) });
+            }
+        }
+        return out;
+    }, [raceActive, raceThreshold, selectedVehicles, chartConfig.selectedRuns, runDataCache]);
+
+    const excludedRuns = useMemo(() => {
+        if (!raceActive) return [];
+        const out = [];
+        for (const vehicle of selectedVehicles) {
+            for (const run of vehicle.runs || []) {
+                if (!chartConfig.selectedRuns.includes(run.id)) continue;
+                const reason = alignmentExclusion(runDataCache[run.id], raceThreshold);
+                if (reason) out.push({ name: run.name, reason });
+            }
+        }
+        return out;
+    }, [raceActive, raceThreshold, selectedVehicles, chartConfig.selectedRuns, runDataCache]);
 
     /**
      * Returns null if the run can participate in race mode, or a short reason
@@ -400,12 +448,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
      */
     const getRaceExclusionReason = (runId) => {
         if (!raceActive) return null;
-        const data = runDataCache[runId];
-        if (!data) return null; // not yet loaded — don't flag prematurely
-        if (!data.some(p => p.time != null)) return 'no time data';
-        const anchor = data.findIndex(p => p.soc != null && p.soc >= raceThreshold);
-        if (anchor === -1) return `never reaches ${raceThreshold}% SoC`;
-        return null;
+        return alignmentExclusion(runDataCache[runId], raceThreshold);
     };
 
     /**
@@ -415,12 +458,7 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
      */
     const getRaceOffset = (runId) => {
         if (!raceActive) return null;
-        const data = runDataCache[runId];
-        if (!data) return null;
-        const anchor = data.findIndex(p => p.soc != null && p.soc >= raceThreshold);
-        if (anchor === -1) return null;
-        const t = data[anchor].time;
-        return t ?? null;
+        return alignmentOffset(runDataCache[runId], raceThreshold);
     };
 
     /**
@@ -510,12 +548,13 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
             let workingData = rawData;
             let timeOffset  = 0;
             if (raceActive) {
-                const anchor = rawData.findIndex(p => p.soc != null && p.soc >= raceThreshold);
-                if (anchor === -1) return [];
-                const anchorTime = rawData[anchor].time;
-                if (anchorTime == null) return [];
-                timeOffset   = anchorTime;
-                workingData  = rawData.slice(anchor);
+                // Interpolates the threshold crossing rather than snapping to
+                // the next sample, so every curve is at the same SoC at t = 0
+                // even when a run is coarsely sampled — see alignSeries.
+                const aligned = alignSeries(rawData, raceThreshold);
+                if (!aligned) return [];
+                timeOffset  = aligned.offset;
+                workingData = aligned.points;
             }
 
             // 2. Augment with cumulative delta fields (start at 0 from first point)
@@ -759,6 +798,46 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                             ))}
                         </select>
                     </div>
+
+                    {/* Alignment is a property of the time axis, so it belongs
+                        with the axis selectors rather than in a panel below the
+                        chart that had to be found and switched on. */}
+                    {isTimeAxis && (
+                        <div>
+                            <label className="block font-medium mb-2">Align start at:</label>
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="number"
+                                    min="0" max="100"
+                                    value={chartConfig.raceThreshold ?? (commonSoc ?? '')}
+                                    placeholder={commonSoc != null ? String(commonSoc) : '10'}
+                                    onChange={e => setChartConfig({
+                                        ...chartConfig,
+                                        raceThreshold: e.target.value === '' ? null : clampSoc(e.target.value, commonSoc ?? 10),
+                                    })}
+                                    disabled={chartConfig.alignRaw}
+                                    className="border p-2 rounded w-20 disabled:opacity-50"
+                                />
+                                <span className="text-sm text-secondary">% SoC</span>
+                                {commonSoc != null && chartConfig.raceThreshold == null && (
+                                    <span className="text-xs text-faint" title="The lowest SoC every selected run actually reaches — no run is dropped at this value.">
+                                        lowest common
+                                    </span>
+                                )}
+                            </div>
+                            <label className="toggle-label mt-2">
+                                <input
+                                    type="checkbox"
+                                    checked={!!chartConfig.alignRaw}
+                                    onChange={e => setChartConfig({ ...chartConfig, alignRaw: e.target.checked })}
+                                    className="w-4 h-4"
+                                />
+                                <span className="text-xs text-secondary" title="Show each run's own logger time. Runs will start at zero regardless of the SoC they began at, so the curves are not comparable.">
+                                    Raw logger time (not comparable)
+                                </span>
+                            </label>
+                        </div>
+                    )}
                 </div>
 
                 {/* ── Line / points toggles ── */}
@@ -920,6 +999,33 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                 )}
             </div>
 
+            {/* Runs the alignment could not include, named on the chart itself.
+                The selector carries a badge, but that only helps someone who
+                opens the selector — and a screenshot shows neither. A chart
+                silently missing a car is the failure worth designing against. */}
+            {raceActive && (excludedRuns.length > 0 || stretchedRuns.length > 0) && (
+                <div className="roadtrip-warning mb-3">
+                    {excludedRuns.map(({ name, reason }) => (
+                        <p key={name}>⚠ {name}: not aligned — {reason}</p>
+                    ))}
+                    {stretchedRuns.map(({ name, gap }) => (
+                        <p key={name}>
+                            ⚠ {name}: estimated {gap}% of SoC below its own data to reach {raceThreshold}%
+                        </p>
+                    ))}
+                    {excludedRuns.length > 0 && (
+                        <p className="text-xs mt-1">
+                            Lower “Align start at” to include them, or switch to raw logger time.
+                        </p>
+                    )}
+                    {stretchedRuns.length > 0 && (
+                        <p className="text-xs mt-1">
+                            Raise “Align start at” to stay inside the measured data.
+                        </p>
+                    )}
+                </div>
+            )}
+
             {/* ── Controls below chart: scale inputs + line toggle + race mode — hidden in presentation mode ── */}
             {!presentationMode && <div className="card mb-6">
 
@@ -932,65 +1038,19 @@ export default function ChargingView({ vehicles, selectedVehicleIds, chartConfig
                     card={false}
                 />
 
-                {/* ── Race mode panel — only visible when X = Time ── */}
-                {chartConfig.xAxis === 'time' && (
-                    <div className={`race-mode-panel ${chartConfig.raceMode ? 'bg-indigo-50 border-indigo-200' : 'bg-[var(--color-surface-muted)] border-[var(--color-border)]'}`}>
-                        <div className="flex flex-wrap items-center gap-3">
-                            <label className="toggle-label">
-                                <input
-                                    type="checkbox"
-                                    checked={chartConfig.raceMode || false}
-                                    onChange={e => setChartConfig({ ...chartConfig, raceMode: e.target.checked })}
-                                    className="w-4 h-4 accent-indigo-600"
-                                />
-                                <span className="font-medium text-sm">Race mode</span>
-                            </label>
-
-                            {chartConfig.raceMode && (
-                                <>
-                                    <span className="text-sm text-secondary">Start at:</span>
-                                    {/* Quick-select chips */}
-                                    <div className="flex gap-1 flex-wrap">
-                                        {[5, 10, 15, 20].map(pct => (
-                                            <button
-                                                key={pct}
-                                                onClick={() => setChartConfig({ ...chartConfig, raceThreshold: pct })}
-                                                className={`px-2 py-0.5 text-xs rounded border transition-colors ${
-                                                    chartConfig.raceThreshold === pct
-                                                        ? 'bg-indigo-600 text-white border-indigo-600'
-                                                        : 'bg-[var(--color-surface-input)] text-secondary border-[var(--color-border-strong)] hover:border-indigo-400'
-                                                }`}
-                                            >
-                                                {pct}%
-                                            </button>
-                                        ))}
-                                        {/* Freeform input */}
-                                        <div className="flex items-center gap-1">
-                                            <input
-                                                type="number"
-                                                value={chartConfig.raceThreshold ?? 10}
-                                                onChange={e => {
-                                                    const v = parseInt(e.target.value, 10);
-                                                    if (!isNaN(v) && v >= 0 && v <= 100) {
-                                                        setChartConfig({ ...chartConfig, raceThreshold: v });
-                                                    }
-                                                }}
-                                                className="w-14 px-1 py-0.5 border rounded text-xs text-center [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                                                min="0" max="100"
-                                            />
-                                            <span className="text-xs text-muted">%</span>
-                                        </div>
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                        {chartConfig.raceMode && (
-                            <p className="mt-1.5 text-xs text-indigo-700">
-                                Each run is shifted so its {raceThreshold}% SoC point lands at t = 0.
-                                Runs without time data or that never reach {raceThreshold}% SoC are hidden.
-                            </p>
-                        )}
-                    </div>
+                {/* What the alignment did, stated on the chart's own controls.
+                    Previously this only appeared once race mode was switched
+                    on; now that it is the default, saying nothing would leave a
+                    shifted axis unexplained. */}
+                {isTimeAxis && (
+                    <p className={`mt-2 text-xs ${raceActive ? 'text-indigo-700' : 'text-amber-700'}`}>
+                        {raceActive
+                            ? `Each run is shifted so its ${raceThreshold}% SoC point lands at t = 0`
+                              + (chartConfig.raceThreshold == null && commonSoc != null
+                                  ? ' — the lowest SoC every selected run reaches.'
+                                  : '.')
+                            : 'Raw logger time: each run starts at zero whatever SoC it began at, so the curves are not directly comparable.'}
+                    </p>
                 )}
             </div>}
 

--- a/src/index.css
+++ b/src/index.css
@@ -805,6 +805,31 @@ body {
     @apply grid grid-cols-3 gap-4 mb-6;
 }
 
+/* Axis picker label + control. Sized to match the Correction dropdown in the
+   run-selector header: these are the same kind of thing — a small named choice —
+   and at base size four of them crowded the chart off the screen. */
+.axis-label {
+    @apply block text-sm font-medium mb-1;
+    color: var(--color-text-secondary);
+}
+.axis-select {
+    @apply px-2 py-0.5 rounded text-sm w-full;
+    background-color: var(--color-surface-input);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-primary);
+}
+.axis-select:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+}
+
+/* Alignment sits UNDER the three axis pickers, indented, because it modifies the
+   X axis rather than standing beside it as a fourth axis. */
+.axis-align-row {
+    @apply flex flex-wrap items-center gap-x-3 gap-y-2 pl-6 -mt-3 mb-6;
+}
+
 /* Chart type / preset button row; mb added inline */
 .chart-type-buttons {
     @apply flex flex-wrap gap-2;

--- a/src/index.css
+++ b/src/index.css
@@ -824,6 +824,28 @@ body {
     border-color: var(--color-primary);
 }
 
+/* The alignment threshold: a percentage, so one or two digits and never more.
+   Sized to the number rather than to the form, and the browser's spin buttons
+   dropped — they steal half the box for an affordance the arrow keys already
+   provide. */
+.soc-input {
+    @apply px-1 py-0 rounded text-sm w-10 text-center;
+    background-color: var(--color-surface-input);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-primary);
+    appearance: textfield;
+}
+.soc-input::-webkit-inner-spin-button,
+.soc-input::-webkit-outer-spin-button {
+    appearance: none;
+    margin: 0;
+}
+.soc-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+}
+
 /* Alignment sits UNDER the three axis pickers, indented, because it modifies the
    X axis rather than standing beside it as a fourth axis. */
 .axis-align-row {

--- a/src/index.css
+++ b/src/index.css
@@ -323,27 +323,12 @@ body {
 .text-hint        { @apply text-xs;  font-size: var(--fs-hint, 0.75rem);   color: var(--color-text-faint); }
 .text-data        { @apply text-sm font-mono tabular-nums; font-size: var(--fs-data, 0.875rem); }
 
-/* — Color tiers (compose with a role) ——————————————————————————————————————— */
-.text-secondary { color: var(--color-text-secondary); }
-.text-muted     { color: var(--color-text-muted); }
-.text-faint     { color: var(--color-text-faint); }
-
-/* Inline info/notice banner (theme-aware) */
-.notice-info {
-    background-color: var(--color-primary-light);
-    border: 1px solid var(--color-primary);
-    color: var(--color-text-primary);
-}
-
-/* Smaller heading for a group within a card (h4) */
-.subsection-title {
-    @apply text-sm font-semibold;
-    color: var(--color-text-primary);
-}
-
-/* Theme-aware text-color helpers. Headings/body inherit --color-text-primary
-   from <body>; these set the dimmer tiers. Prefer these over Tailwind text-gray-*
-   so text adapts to dark mode. */
+/* — Color tiers (compose with a role) ———————————————————————————————————————
+   Prefer these over Tailwind's text-gray-* so text follows the theme. They live
+   HERE, inside the typography system, because a second copy further down the
+   file used to shadow this one — harmlessly for the colours, but its
+   .subsection-title came with it and overrode the variable-driven one, killing
+   that knob. */
 .text-secondary { color: var(--color-text-secondary); }
 .text-muted     { color: var(--color-text-muted); }
 .text-faint     { color: var(--color-text-faint); }

--- a/src/utils/__tests__/socAlignment.test.js
+++ b/src/utils/__tests__/socAlignment.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
     minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries,
-    overExtrapolated, clampSoc, rampLength, trimRamp, extrapolationSlope, RAMP_MAX_TRIM,
+    overExtrapolated, clampSoc, rampLength, trimRamp, extrapolationSlope,
+    RAMP_MAX_TRIM, RAMP_TRIM_MIN_MINUTES,
 } from '../socAlignment';
 
 const pts = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
@@ -221,19 +222,34 @@ describe('the opening ramp is kept out of the slope', () => {
         expect(socPerMin).toBeCloseTo(3.75, 6);
     });
 
-    it('does not fabricate the extra minute the ramp used to buy', () => {
+    it('takes the ramp out when the projection reaches back a long way', () => {
         const r = alignSeries(R2, 4);
         expect(r.extrapolated).toBe(true);
         expect(r.rampTrimmed).toBe(2);
-        // Projects from the first SETTLED point — 12% at t=0.9 — back 8 points
-        // of SoC at 3.75 %/min, so 2.13 min before it.
+        expect(r.back).toBeGreaterThan(RAMP_TRIM_MIN_MINUTES);
+        // From the first SETTLED point — 12% at t=0.9 — back 8 points of SoC at
+        // 3.75 %/min. Left ramped it reaches 6 points at 2.73 %/min from t=0.1,
+        // which lands t=0 nearly a minute earlier.
+        expect(r.back).toBeCloseTo(2.133, 3);
         expect(r.points[0].time).toBeCloseTo(-1.233, 3);
+        expect(alignSeries(R2.slice(2), 4).points[0].time).toBeCloseTo(-1.233, 3);
     });
 
-    it('takes the ramp off the plot, not just out of the slope', () => {
+    it('leaves the ramp alone when the projection barely reaches at all', () => {
+        // 11% is one point of SoC below the R2's first sample: well under a
+        // minute, so the correction is worth less than the samples it costs.
+        const r = alignSeries(R2, 9);
+        expect(r.extrapolated).toBe(true);
+        expect(r.back).toBeLessThan(RAMP_TRIM_MIN_MINUTES);
+        expect(r.rampTrimmed).toBe(0);
+        expect(r.points[1].chargeRate).toBe(93);
+    });
+
+    it('takes the ramp off the plot when it takes it out of the slope', () => {
+        // Leaving those samples visible inside the projected span would put a
+        // measured 93 kW on top of a line asserting 220.
         const r = alignSeries(R2, 4);
         expect(r.points.slice(1)).toHaveLength(R2.length - 2);
-        // The 93 kW handshake sample is gone; the curve opens on settled data.
         expect(r.points.map(p => p.chargeRate)).not.toContain(93);
         expect(r.points[1].chargeRate).toBe(214);
     });
@@ -244,6 +260,19 @@ describe('the opening ramp is kept out of the slope', () => {
         // — a number the estimate itself contradicts.
         const r = alignSeries(R2, 4);
         expect(r.points[0]).toEqual({ soc: 4, time: expect.any(Number), _extrapolatedStart: true });
+    });
+
+    it('never trims for a start inside the data, however ramped the opening', () => {
+        // A curve that begins inside its own data leans on no slope at all, so
+        // there is nothing for trimming to protect.
+        const between = alignSeries(R2, 14.5);       // between two samples
+        expect(between.interpolated).toBe(true);
+        expect(between.rampTrimmed).toBeUndefined();
+
+        const exact = alignSeries(R2, 15);           // straight onto a sample
+        expect(exact.interpolated).toBe(false);
+        expect(exact.extrapolated).toBeUndefined();
+        expect(exact.rampTrimmed).toBeUndefined();
     });
 
     it('interpolates the other channels for a start INSIDE the data', () => {
@@ -257,10 +286,18 @@ describe('the opening ramp is kept out of the slope', () => {
         expect(r.points[0].chargeRate).toBeCloseTo(150, 6);
     });
 
-    it('trims the ramp out of the automatic threshold too', () => {
-        // Otherwise the threshold lands on a SoC one run only reaches while its
-        // charger is still negotiating, and then has to extrapolate back to it.
-        expect(minimumCommonSoc([R2])).toBe(12);
+    it('leaves the automatic threshold on the measured minimum', () => {
+        // The threshold should land on a SoC the run reported reaching. Pushing
+        // it to 12% would trim on behalf of a run that then keeps its ramp.
+        expect(minimumCommonSoc([R2])).toBe(10);
+    });
+
+    it('measures a slope with the ramp in when asked to', () => {
+        expect(extrapolationSlope(R2, { skipRamp: false }).trimmed).toBe(0);
+        // 10% at t=0.1 to 13% at t=1.2 — the 3-point span still applies, which
+        // is why this is 2.73 rather than the first segment's raw 2.5.
+        expect(extrapolationSlope(R2, { skipRamp: false }).socPerMin).toBeCloseTo(3 / 1.1, 6);
+        expect(extrapolationSlope(R2).socPerMin).toBeCloseTo(3.75, 6);
     });
 
     it('is idempotent — settled data has no ramp to find', () => {

--- a/src/utils/__tests__/socAlignment.test.js
+++ b/src/utils/__tests__/socAlignment.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries, overExtrapolated, clampSoc } from '../socAlignment';
+import {
+    minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries,
+    overExtrapolated, clampSoc, rampLength, extrapolationSlope, RAMP_MAX_TRIM,
+} from '../socAlignment';
 
 const pts = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
 
@@ -186,5 +189,90 @@ describe('back-extrapolation below the first measured point', () => {
     it('reports no gap for an unextrapolated alignment', () => {
         expect(overExtrapolated(alignSeries(pts3([5, 0], [25, 10]), 10))).toBe(false);
         expect(overExtrapolated(null)).toBe(false);
+    });
+});
+
+describe('the opening ramp is kept out of the slope', () => {
+    // A real R2 session, verbatim: 93 kW at the first sample, settled near 220
+    // by the third. Whole-percent SoC, so the settled rate reads as an
+    // alternating 3.33 / 5.0 sawtooth and only a multi-point span recovers it.
+    const R2 = [
+        { time: 0.1, soc: 10, chargeRate: 93 },
+        { time: 0.5, soc: 11, chargeRate: 195 },
+        { time: 0.9, soc: 12, chargeRate: 214 },
+        { time: 1.2, soc: 13, chargeRate: 215 },
+        { time: 1.4, soc: 14, chargeRate: 216 },
+        { time: 1.7, soc: 15, chargeRate: 217 },
+        { time: 1.9, soc: 16, chargeRate: 218 },
+        { time: 2.2, soc: 17, chargeRate: 219 },
+        { time: 2.5, soc: 18, chargeRate: 219 },
+        { time: 2.7, soc: 19, chargeRate: 220 },
+    ];
+
+    it('counts the handshake points as ramp and the settled ones as not', () => {
+        expect(rampLength(R2)).toBe(2);
+    });
+
+    it('measures the rate the car actually charges at, not the plug warming up', () => {
+        const { socPerMin, trimmed } = extrapolationSlope(R2);
+        expect(trimmed).toBe(2);
+        // From 12% at t=0.9 to 15% at t=1.7 — 3.75 %/min, against the 2.5 %/min
+        // the first segment alone would have claimed.
+        expect(socPerMin).toBeCloseTo(3.75, 6);
+    });
+
+    it('does not fabricate the extra minute the ramp used to buy', () => {
+        const r = alignSeries(R2, 4);
+        expect(r.extrapolated).toBe(true);
+        expect(r.rampTrimmed).toBe(2);
+        // 6 points of SoC at 3.75 %/min = 1.6 min before the data, from t=0.1.
+        expect(r.points[0].time).toBeCloseTo(-1.5, 6);
+        // The naive first-segment slope of 2.5 %/min would have put it at -2.3.
+        expect(r.points[0].time).toBeGreaterThan(-2.3);
+    });
+
+    it('leaves every measured point on the chart — only the slope is affected', () => {
+        const r = alignSeries(R2, 4);
+        expect(r.points.slice(1)).toHaveLength(R2.length);
+        expect(r.points[1].chargeRate).toBe(93);
+    });
+
+    it('trims nothing from a run whose power is already tapering', () => {
+        // Starts high and falls away: the first point IS the plateau.
+        const taper = [
+            { time: 0, soc: 55, chargeRate: 120 },
+            { time: 5, soc: 62, chargeRate: 95 },
+            { time: 10, soc: 68, chargeRate: 70 },
+        ];
+        expect(rampLength(taper)).toBe(0);
+        expect(extrapolationSlope(taper).trimmed).toBe(0);
+    });
+
+    it('trims nothing when power was never logged', () => {
+        // The SoC slope alone cannot tell a ramp from coarse sampling, and
+        // guessing would penalise every run that simply logs sparsely.
+        expect(rampLength(pts([25, 0], [26, 1], [40, 10]))).toBe(0);
+    });
+
+    it('refuses to trim so far that there is nothing left to measure', () => {
+        const stub = [
+            { time: 0, soc: 10, chargeRate: 20 },
+            { time: 1, soc: 12, chargeRate: 400 },
+        ];
+        expect(rampLength(stub)).toBe(0);
+        expect(extrapolationSlope(stub).socPerMin).toBeCloseTo(2, 6);
+    });
+
+    it('never trims more than the cap, however long power keeps climbing', () => {
+        const climbing = Array.from({ length: 10 }, (_, i) => ({
+            time: i, soc: 10 + i, chargeRate: 20 + i * 20,
+        }));
+        expect(rampLength(climbing)).toBe(RAMP_MAX_TRIM);
+    });
+
+    it('returns no slope for a trace that is not gaining', () => {
+        expect(extrapolationSlope(pts([60, 0], [40, 10]))).toBeNull();
+        expect(extrapolationSlope([{ soc: 10, time: 0 }])).toBeNull();
+        expect(extrapolationSlope(null)).toBeNull();
     });
 });

--- a/src/utils/__tests__/socAlignment.test.js
+++ b/src/utils/__tests__/socAlignment.test.js
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries, overExtrapolated, clampSoc } from '../socAlignment';
+
+const pts = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
+
+describe('minimumCommonSoc', () => {
+    it('takes the highest of the runs\' minima — the lowest point they all reach', () => {
+        expect(minimumCommonSoc([
+            pts([10, 0], [50, 20]),   // reaches down to 10
+            pts([28, 0], [60, 15]),   // only down to 28
+            pts([15, 0], [70, 30]),   // down to 15
+        ])).toBe(28);
+    });
+
+    it('is the run that started highest, which a fixed 10% default would have dropped', () => {
+        const series = [pts([8, 0], [80, 40]), pts([31, 0], [80, 25])];
+        expect(minimumCommonSoc(series)).toBe(31);
+        // At the old fixed default, the second run is fine but the alignment
+        // throws away everything the first measured between 8% and 31%.
+        expect(alignmentExclusion(series[1], 10)).toBeNull();
+    });
+
+    it('ignores a run with no usable data rather than giving up entirely', () => {
+        expect(minimumCommonSoc([
+            pts([20, 0], [60, 10]),
+            pts([null, 5], [null, 9]),      // no SoC at all
+            [],
+        ])).toBe(20);
+    });
+
+    it('ignores points with no time — they cannot be aligned on a time axis', () => {
+        expect(minimumCommonSoc([pts([5, null], [40, 0], [70, 12])])).toBe(40);
+    });
+
+    it('returns null when nothing is alignable', () => {
+        expect(minimumCommonSoc([])).toBeNull();
+        expect(minimumCommonSoc(null)).toBeNull();
+        expect(minimumCommonSoc([[], pts([null, null])])).toBeNull();
+    });
+
+    it('handles a single run', () => {
+        expect(minimumCommonSoc([pts([12, 0], [80, 30])])).toBe(12);
+    });
+});
+
+describe('alignmentExclusion', () => {
+    it('says nothing for a run that can align', () => {
+        expect(alignmentExclusion(pts([10, 0], [50, 20]), 20)).toBeNull();
+    });
+
+    it('names the reason rather than returning a bare false', () => {
+        expect(alignmentExclusion(pts([10, 0], [15, 20]), 30)).toBe('never reaches 30% SoC');
+        expect(alignmentExclusion(pts([10, null], [50, null]), 20)).toBe('no time data');
+        expect(alignmentExclusion(pts([null, 0], [null, 5]), 20)).toBe('no SoC data');
+    });
+
+    it('does not flag a run whose data has not loaded yet', () => {
+        expect(alignmentExclusion([], 20)).toBeNull();
+        expect(alignmentExclusion(null, 20)).toBeNull();
+    });
+});
+
+describe('alignmentOffset', () => {
+    it('returns the time the run first reached the threshold', () => {
+        expect(alignmentOffset(pts([10, 0], [20, 6], [50, 25]), 20)).toBe(6);
+    });
+
+    it('returns 0 when the run already starts at the threshold', () => {
+        expect(alignmentOffset(pts([25, 0], [60, 20]), 20)).toBe(0);
+    });
+
+    it('returns null when the threshold is never reached', () => {
+        expect(alignmentOffset(pts([10, 0], [15, 5]), 40)).toBeNull();
+    });
+
+    it('skips an anchor point that has no time', () => {
+        expect(alignmentOffset(pts([30, null], [35, 9]), 20)).toBe(9);
+    });
+});
+
+describe('clampSoc', () => {
+    it('keeps a sane percentage and rounds', () => {
+        expect(clampSoc('12.6')).toBe(13);
+        expect(clampSoc(150)).toBe(100);
+        expect(clampSoc(-5)).toBe(0);
+    });
+    it('falls back when the input is not a number', () => {
+        expect(clampSoc('')).toBe(10);
+        expect(clampSoc('abc', 25)).toBe(25);
+    });
+});
+
+describe('alignSeries', () => {
+    const pts2 = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
+
+    it('interpolates the crossing rather than snapping to the next sample', () => {
+        // The real failure: 5 coarse points, so the first sample at/above 10%
+        // is 25% — the old behaviour drew this from t=0 as if it started at 10.
+        const r = alignSeries(pts2([0, 0], [25, 10], [50, 20]), 10);
+        expect(r.interpolated).toBe(true);
+        expect(r.offset).toBeCloseTo(4, 6);            // 10/25 of the way from 0→10 min
+        expect(r.points[0].soc).toBe(10);
+        expect(r.points[0].time).toBeCloseTo(4, 6);
+    });
+
+    it('puts every run at the same SoC at t = 0', () => {
+        const coarse = alignSeries(pts2([0, 0], [25, 10]), 10);
+        const fine   = alignSeries(pts2([8, 0], [10, 2], [30, 9]), 10);
+        expect(coarse.points[0].soc).toBe(10);
+        expect(fine.points[0].soc).toBe(10);
+        expect(coarse.points[0].time - coarse.offset).toBeCloseTo(0, 9);
+        expect(fine.points[0].time - fine.offset).toBeCloseTo(0, 9);
+    });
+
+    it('extrapolates rather than interpolates a run that began above the threshold', () => {
+        // Superseded by the back-extrapolation below: this used to be drawn
+        // from 25% at t=0, which is the defect in a quieter form.
+        const r = alignSeries(pts2([25, 0], [60, 20]), 10);
+        expect(r.interpolated).toBe(false);
+        expect(r.extrapolated).toBe(true);
+        expect(r.points[0].soc).toBe(10);
+    });
+
+    it('does not interpolate when a sample sits exactly on the threshold', () => {
+        const r = alignSeries(pts2([5, 0], [10, 6], [40, 20]), 10);
+        expect(r.interpolated).toBe(false);
+        expect(r.offset).toBe(6);
+    });
+
+    it('drops everything before the crossing', () => {
+        const r = alignSeries(pts2([0, 0], [5, 3], [25, 10], [50, 20]), 10);
+        expect(r.points.every(p => p.soc >= 10)).toBe(true);
+    });
+
+    it('returns null when the run never reaches the threshold, or has nothing usable', () => {
+        expect(alignSeries(pts2([0, 0], [5, 9]), 10)).toBeNull();
+        expect(alignSeries([], 10)).toBeNull();
+        expect(alignSeries(null, 10)).toBeNull();
+    });
+});
+
+describe('back-extrapolation below the first measured point', () => {
+    const pts3 = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
+
+    it('extends a run that began above the threshold, rather than drawing it as if aligned', () => {
+        // Begins at 25%, gaining 1% per minute. Reaching 20% is 5 min earlier.
+        const r = alignSeries(pts3([25, 10], [35, 20], [45, 30]), 20);
+        expect(r.extrapolated).toBe(true);
+        expect(r.gap).toBe(5);
+        expect(r.points[0].soc).toBe(20);
+        expect(r.points[0].time).toBeCloseTo(5, 6);
+        expect(r.offset).toBeCloseTo(5, 6);
+    });
+
+    it('marks the invented start so a chart can style it', () => {
+        const r = alignSeries(pts3([25, 10], [35, 20]), 20);
+        expect(r.points[0]._extrapolatedStart).toBe(true);
+    });
+
+    it('keeps every measured point — extrapolation adds, it does not replace', () => {
+        const r = alignSeries(pts3([25, 10], [35, 20]), 20);
+        expect(r.points.slice(1)).toHaveLength(2);
+    });
+
+    it('is silent within the limit and flagged beyond it', () => {
+        const small = alignSeries(pts3([25, 10], [35, 20]), 21);   // 4 points of SoC
+        const big   = alignSeries(pts3([25, 10], [35, 20]), 10);   // 15 points
+        expect(overExtrapolated(small)).toBe(false);
+        expect(overExtrapolated(big)).toBe(true);
+        expect(big.gap).toBe(15);
+    });
+
+    it('never extrapolates a run that is not gaining charge', () => {
+        // A discharge trace slopes the wrong way; projecting it backwards would
+        // invent a rising curve out of a falling one.
+        const r = alignSeries(pts3([60, 0], [40, 10], [25, 20]), 10);
+        expect(r.extrapolated).toBeUndefined();
+    });
+
+    it('does not extrapolate when the data brackets the threshold — that is interpolation', () => {
+        const r = alignSeries(pts3([5, 0], [25, 10]), 10);
+        expect(r.interpolated).toBe(true);
+        expect(r.extrapolated).toBeUndefined();
+    });
+
+    it('reports no gap for an unextrapolated alignment', () => {
+        expect(overExtrapolated(alignSeries(pts3([5, 0], [25, 10]), 10))).toBe(false);
+        expect(overExtrapolated(null)).toBe(false);
+    });
+});

--- a/src/utils/__tests__/socAlignment.test.js
+++ b/src/utils/__tests__/socAlignment.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
     minimumCommonSoc, alignmentExclusion, alignmentOffset, alignSeries,
-    overExtrapolated, clampSoc, rampLength, extrapolationSlope, RAMP_MAX_TRIM,
+    overExtrapolated, clampSoc, rampLength, trimRamp, extrapolationSlope, RAMP_MAX_TRIM,
 } from '../socAlignment';
 
 const pts = (...pairs) => pairs.map(([soc, time]) => ({ soc, time }));
@@ -225,16 +225,54 @@ describe('the opening ramp is kept out of the slope', () => {
         const r = alignSeries(R2, 4);
         expect(r.extrapolated).toBe(true);
         expect(r.rampTrimmed).toBe(2);
-        // 6 points of SoC at 3.75 %/min = 1.6 min before the data, from t=0.1.
-        expect(r.points[0].time).toBeCloseTo(-1.5, 6);
-        // The naive first-segment slope of 2.5 %/min would have put it at -2.3.
-        expect(r.points[0].time).toBeGreaterThan(-2.3);
+        // Projects from the first SETTLED point — 12% at t=0.9 — back 8 points
+        // of SoC at 3.75 %/min, so 2.13 min before it.
+        expect(r.points[0].time).toBeCloseTo(-1.233, 3);
     });
 
-    it('leaves every measured point on the chart — only the slope is affected', () => {
+    it('takes the ramp off the plot, not just out of the slope', () => {
         const r = alignSeries(R2, 4);
-        expect(r.points.slice(1)).toHaveLength(R2.length);
-        expect(r.points[1].chargeRate).toBe(93);
+        expect(r.points.slice(1)).toHaveLength(R2.length - 2);
+        // The 93 kW handshake sample is gone; the curve opens on settled data.
+        expect(r.points.map(p => p.chargeRate)).not.toContain(93);
+        expect(r.points[1].chargeRate).toBe(214);
+    });
+
+    it('gives the invented start a SoC and a time and nothing else', () => {
+        // Inheriting the first point's channels put a measured 93 kW at a
+        // moment the run never recorded, drawn flat across the invented minute
+        // — a number the estimate itself contradicts.
+        const r = alignSeries(R2, 4);
+        expect(r.points[0]).toEqual({ soc: 4, time: expect.any(Number), _extrapolatedStart: true });
+    });
+
+    it('interpolates the other channels for a start INSIDE the data', () => {
+        // Interior, so a charge rate partway between two real samples is a
+        // reading of the data rather than an invention.
+        const r = alignSeries([
+            { time: 0, soc: 10, chargeRate: 200 },
+            { time: 2, soc: 20, chargeRate: 100 },
+        ], 15);
+        expect(r.interpolated).toBe(true);
+        expect(r.points[0].chargeRate).toBeCloseTo(150, 6);
+    });
+
+    it('trims the ramp out of the automatic threshold too', () => {
+        // Otherwise the threshold lands on a SoC one run only reaches while its
+        // charger is still negotiating, and then has to extrapolate back to it.
+        expect(minimumCommonSoc([R2])).toBe(12);
+    });
+
+    it('is idempotent — settled data has no ramp to find', () => {
+        const once = trimRamp(R2);
+        expect(once).toHaveLength(R2.length - 2);
+        expect(trimRamp(once)).toHaveLength(once.length);
+    });
+
+    it('leaves a series alone when there is no ramp to trim', () => {
+        const flat = pts([25, 0], [30, 5]);
+        expect(trimRamp(flat)).toBe(flat);
+        expect(trimRamp(null)).toEqual([]);
     });
 
     it('trims nothing from a run whose power is already tapering', () => {

--- a/src/utils/socAlignment.js
+++ b/src/utils/socAlignment.js
@@ -1,0 +1,172 @@
+/**
+ * Aligning charging curves on a common starting SoC.
+ *
+ * With time on the X axis every run starts at zero, which compares nothing: a
+ * session beginning at 8% SoC and one beginning at 30% are not the same
+ * measurement seen from the same place. Aligning them means finding the moment
+ * each run first reaches a shared SoC and treating that as t=0, so the curves
+ * answer "from the same state of charge, who gains fastest".
+ *
+ * Pure module — no React, no chart library.
+ */
+
+/**
+ * The lowest SoC that EVERY run actually reaches: the highest of their minima.
+ *
+ * This is the best possible alignment point for a set of runs, because any
+ * lower and some run has no data there, and any higher throws away measurement
+ * the runs share. A fixed default — 10% for a long time here — silently drops
+ * every run that started above it, which is the failure this replaces.
+ *
+ * Runs with no usable SoC data are ignored rather than forcing the answer to
+ * null: one unusable run should not prevent the others from being aligned.
+ *
+ * @param {Array<Array<{soc:number|null, time:number|null}>>} series
+ * @returns {number|null} SoC in percent, or null if nothing is alignable
+ */
+export function minimumCommonSoc(series) {
+    let highestMin = null;
+
+    for (const points of series ?? []) {
+        if (!points?.length) continue;
+        let runMin = null;
+        for (const p of points) {
+            if (p?.soc == null || p?.time == null) continue;
+            if (runMin == null || p.soc < runMin) runMin = p.soc;
+        }
+        if (runMin == null) continue;                 // nothing usable in this run
+        if (highestMin == null || runMin > highestMin) highestMin = runMin;
+    }
+    return highestMin;
+}
+
+/**
+ * Why a run cannot take part in an alignment, or null if it can.
+ *
+ * Returns a reason rather than a boolean because the chart has to SAY why a
+ * curve is missing. A run silently absent from a comparison is worse than one
+ * shown with a caveat: the reader cannot miss what they were never told about.
+ */
+export function alignmentExclusion(points, thresholdSoc) {
+    if (!points?.length) return null;                 // not loaded yet — do not flag prematurely
+    if (!points.some(p => p.time != null)) return 'no time data';
+    if (!points.some(p => p.soc != null)) return 'no SoC data';
+    if (!points.some(p => p.soc != null && p.soc >= thresholdSoc)) {
+        return `never reaches ${thresholdSoc}% SoC`;
+    }
+    return null;
+}
+
+/**
+ * The time to subtract from a run so its curve starts at `thresholdSoc`.
+ *
+ * Zero means the run began at or below the threshold and nothing is trimmed;
+ * null means it cannot be aligned at all.
+ */
+export function alignmentOffset(points, thresholdSoc) {
+    if (!points?.length) return null;
+    const anchor = points.find(p => p.soc != null && p.soc >= thresholdSoc && p.time != null);
+    return anchor ? anchor.time : null;
+}
+
+/**
+ * A run's points shifted so the threshold SoC sits at t = 0, with the crossing
+ * INTERPOLATED rather than snapped to the next sample.
+ *
+ * Snapping was the old behaviour and it quietly broke the alignment it promised.
+ * One real run carries five points — 0%, 25%, 50%, … — so its "10% anchor" was
+ * the sample at 25%, and it was drawn from t=0 alongside runs that genuinely
+ * started at 10%. The curves shared an origin and not a state of charge, which
+ * is the comparison this is for.
+ *
+ * Interpolating between the two samples that bracket the threshold puts every
+ * run at exactly the same SoC at t = 0. This stays strictly INSIDE the measured
+ * data — it is not the below-the-floor extrapolation of #195 item 4, and needs
+ * no estimate marking.
+ *
+ * Returns null when the run cannot be aligned at all.
+ */
+export function alignSeries(points, thresholdSoc) {
+    if (!points?.length) return null;
+    const usable = points.filter(p => p.soc != null && p.time != null);
+    if (!usable.length) return null;
+
+    const idx = points.findIndex(p => p.soc != null && p.soc >= thresholdSoc && p.time != null);
+    if (idx === -1) return null;
+
+    const at = points[idx];
+    const before = [...points.slice(0, idx)].reverse()
+        .find(p => p.soc != null && p.time != null && p.soc < thresholdSoc);
+
+    if (at.soc === thresholdSoc) {
+        return { offset: at.time, points: points.slice(idx), interpolated: false };
+    }
+
+    // No bracketing sample means the run BEGAN above the threshold. Aligning it
+    // as-is would repeat the defect this replaces in a quieter form: it would
+    // sit at t=0 showing 25% beside runs showing 10%. Extend it backwards
+    // instead, on the slope of its own first two points.
+    //
+    // This is EXTRAPOLATION, not interpolation — it invents SoC the run never
+    // visited — so the caller is told how far it reached beyond the data, and
+    // anything past EXTRAPOLATION_SOC_LIMIT is worth saying out loud.
+    if (!before) {
+        const first  = usable[0];
+        const second = usable.find(p => p.time > first.time && p.soc !== first.soc);
+        if (!second) return { offset: at.time, points: points.slice(idx), interpolated: false };
+
+        const socPerMin = (second.soc - first.soc) / (second.time - first.time);
+        if (!Number.isFinite(socPerMin) || socPerMin <= 0) {
+            return { offset: at.time, points: points.slice(idx), interpolated: false };
+        }
+
+        const gap  = first.soc - thresholdSoc;              // SoC being invented
+        const back = gap / socPerMin;                        // minutes before the data
+        const start = {
+            ...first,
+            soc: thresholdSoc,
+            time: first.time - back,
+            _extrapolatedStart: true,
+        };
+        return {
+            offset: start.time,
+            points: [start, ...points],
+            interpolated: false,
+            extrapolated: true,
+            gap,
+        };
+    }
+
+    const span = at.soc - before.soc;
+    const frac = span > 0 ? (thresholdSoc - before.soc) / span : 0;
+    const crossTime = before.time + (at.time - before.time) * frac;
+
+    // A synthetic point AT the threshold, so the curve literally begins there.
+    const start = { ...before, soc: thresholdSoc, time: crossTime, _interpolatedStart: true };
+    return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true };
+}
+
+/**
+ * How far below its own data a run may be extended before the chart says so.
+ *
+ * Charging power is roughly flat at low SoC, so a short backward projection is
+ * defensible; a long one is a guess wearing a measurement's clothes. Five
+ * points of SoC is the curator's call, and the number is here rather than
+ * inline so it can move without hunting.
+ */
+export const EXTRAPOLATION_SOC_LIMIT = 5;
+
+/** Whether an aligned run stretched further past its data than we are happy with. */
+export const overExtrapolated = (aligned) =>
+    !!aligned?.extrapolated && aligned.gap > EXTRAPOLATION_SOC_LIMIT;
+
+/** Clamp a user-typed threshold to a usable percentage. */
+export function clampSoc(value, fallback = 10) {
+    // An emptied field is not 0%. Number('') is 0 and finite, so testing
+    // Number.isFinite alone would turn a cleared input into "align at 0%",
+    // which silently changes every curve on the chart.
+    if (value === '' || value == null) return fallback;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.min(100, Math.max(0, Math.round(n)));
+}

--- a/src/utils/socAlignment.js
+++ b/src/utils/socAlignment.js
@@ -27,13 +27,11 @@
 export function minimumCommonSoc(series) {
     let highestMin = null;
 
-    for (const raw of series ?? []) {
-        if (!raw?.length) continue;
-        // Ramp points are dropped here too, so the automatic threshold lands
-        // where every run has SETTLED data. Choosing it from the untrimmed
-        // minimum would pick a SoC one of the runs only reaches while its
-        // charger is still negotiating, and then extrapolate to get back to it.
-        const points = trimRamp(raw);
+    for (const points of series ?? []) {
+        if (!points?.length) continue;
+        // Measured minima, ramp included: the threshold should land on a SoC the
+        // runs actually reported reaching. Trimming here would push it upward on
+        // behalf of a run that is about to keep its ramp anyway.
         let runMin = null;
         for (const p of points) {
             if (p?.soc == null || p?.time == null) continue;
@@ -91,13 +89,8 @@ export function alignmentOffset(points, thresholdSoc) {
  *
  * Returns null when the run cannot be aligned at all.
  */
-export function alignSeries(raw, thresholdSoc) {
-    if (!raw?.length) return null;
-
-    // The opening ramp comes off before anything else, so it is out of the
-    // slope, out of the interpolation, and off the chart — see trimRamp.
-    const points = trimRamp(raw);
-    const rampTrimmed = raw.length - points.length;
+export function alignSeries(points, thresholdSoc) {
+    if (!points?.length) return null;
 
     const usable = points.filter(p => p.soc != null && p.time != null);
     if (!usable.length) return null;
@@ -110,7 +103,7 @@ export function alignSeries(raw, thresholdSoc) {
         .find(p => p.soc != null && p.time != null && p.soc < thresholdSoc);
 
     if (at.soc === thresholdSoc) {
-        return { offset: at.time, points: points.slice(idx), interpolated: false, rampTrimmed };
+        return { offset: at.time, points: points.slice(idx), interpolated: false };
     }
 
     // No bracketing sample means the run BEGAN above the threshold. Aligning it
@@ -122,29 +115,25 @@ export function alignSeries(raw, thresholdSoc) {
     // visited — so the caller is told how far it reached beyond the data, and
     // anything past EXTRAPOLATION_SOC_LIMIT is worth saying out loud.
     if (!before) {
-        const first = usable[0];
-        const slope = extrapolationSlope(usable);
-        if (!slope) return { offset: at.time, points: points.slice(idx), interpolated: false, rampTrimmed };
+        // Try it exactly as measured first, ramp and all.
+        const asMeasured = backProject(points, usable, thresholdSoc, { skipRamp: false });
+        if (!asMeasured) return { offset: at.time, points: points.slice(idx), interpolated: false };
 
-        const gap  = first.soc - thresholdSoc;               // SoC being invented
-        const back = gap / slope.socPerMin;                  // minutes before the data
-        // ONLY when and at what SoC — nothing else. Carrying the first point's
-        // other channels forward would put a measured charge rate, range and
-        // temperature at a moment the run never recorded, and they would be
-        // wrong in a way that reads as data: the old version inherited the
-        // ramp's 93 kW and drew it flat across the invented minute, so a chart
-        // of charge rate opened on a number the estimate itself contradicts.
-        // The plotting path drops null-y points, so each channel simply begins
-        // at its first real sample.
-        const start = { soc: thresholdSoc, time: first.time - back, _extrapolatedStart: true };
-        return {
-            offset: start.time,
-            points: [start, ...points],
-            interpolated: false,
-            extrapolated: true,
-            gap,
-            rampTrimmed,
-        };
+        // A short reach does not need the ramp taken out. The correction is
+        // real but small against a projection of well under a minute, and it
+        // costs the run its opening samples to get it — a bad trade for a curve
+        // that was very nearly measured where it was asked to start.
+        if (asMeasured.back < RAMP_TRIM_MIN_MINUTES) return asMeasured;
+
+        // A long reach is the other way round: the slope is being asked to
+        // carry the answer, so it had better be the car's and not the plug's.
+        // Deciding on the as-measured projection means the contaminated slope
+        // only ever errs toward trimming — it reads slow, so it overstates the
+        // reach — and the choice cannot oscillate.
+        const settled = trimRamp(points);
+        const settledUsable = settled.filter(p => p.soc != null && p.time != null);
+        return backProject(settled, settledUsable, thresholdSoc, { skipRamp: true },
+                           points.length - settled.length) ?? asMeasured;
     }
 
     const span = at.soc - before.soc;
@@ -161,7 +150,38 @@ export function alignSeries(raw, thresholdSoc) {
         time: crossTime,
         _interpolatedStart: true,
     };
-    return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true, rampTrimmed };
+    return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true };
+}
+
+/**
+ * Extend `points` back to `thresholdSoc` and package the result, or null if it
+ * cannot be done. `rampTrimmed` counts what the caller already removed.
+ */
+function backProject(points, usable, thresholdSoc, { skipRamp }, rampTrimmed = 0) {
+    const first = usable[0];
+    const slope = extrapolationSlope(usable, { skipRamp });
+    if (!first || !slope) return null;
+
+    const gap  = first.soc - thresholdSoc;               // SoC being invented
+    const back = gap / slope.socPerMin;                  // minutes before the data
+
+    // The invented point gets a SoC and a time and NOTHING else. Carrying the
+    // first sample's other channels forward would put a measured charge rate,
+    // range and temperature at a moment the run never recorded — and they read
+    // as data: an earlier version inherited the ramp's 93 kW and drew it flat
+    // across the invented minute, a number the projection itself contradicts.
+    // The plotting path drops null-y points, so each channel simply begins at
+    // its first real sample.
+    const start = { soc: thresholdSoc, time: first.time - back, _extrapolatedStart: true };
+    return {
+        offset: start.time,
+        points: [start, ...points],
+        interpolated: false,
+        extrapolated: true,
+        gap,
+        back,
+        rampTrimmed,
+    };
 }
 
 /** Every numeric channel the two samples share, read at `frac` between them. */
@@ -193,16 +213,33 @@ function interpolateChannels(before, at, frac) {
  * 2.5 %/min when it gains 3.9, and back-projecting on that invented an extra
  * 0.8 minutes of fabricated slowness before its data even started.
  *
- * So when a chart aligns runs to a common SoC, the ramp comes off first: out of
- * the slope, out of the interpolation, and off the plot. Nothing is deleted —
- * the data is untouched and raw time shows every sample — but a comparison of
- * how fast cars charge should not open with a minute of handshake, and it is
- * unfair besides, since it only penalises the runs whose logging happened to
- * start at plug-in.
+ * So the ramp comes off — but ONLY where it does damage, which is a long
+ * backward projection. There the slope is carrying the whole answer, and it had
+ * better be the car's rather than the plug's. Everywhere else the measured
+ * points stand: a curve that starts inside its own data is not relying on a
+ * slope at all, and a short reach barely is.
+ *
+ * When it does come off it comes off the plot too, not just the arithmetic.
+ * Leaving those samples visible inside a span the projection has just drawn
+ * through would put a measured 93 kW on top of a line asserting 220. Nothing is
+ * deleted — the data is untouched, and raw test time shows every sample.
  */
 
 /** Share of the opening plateau below which a point is still ramping up. */
 export const RAMP_PLATEAU_FRACTION = 0.9;
+
+/**
+ * How far back a projection has to reach before the ramp is worth removing.
+ *
+ * Under a minute, the run very nearly starts where it was asked to and the
+ * slope barely matters: the ramp correction moves the answer by seconds, and
+ * paying for it with the run's opening samples is a bad trade. Past a minute
+ * the slope IS the answer, and it had better be the car's rather than the
+ * plug's — asked back to 4%, the R2 reaches 2.2 minutes on its ramped slope
+ * and 2.13 on its settled one, but from a point 0.8 minutes later, so its t=0
+ * moves by nearly a minute.
+ */
+export const RAMP_TRIM_MIN_MINUTES = 1;
 
 /** Never treat more than this many leading points as ramp. A run whose power
  *  climbs for its whole opening is tapering oddly or badly logged; trimming it
@@ -278,11 +315,11 @@ export function trimRamp(points) {
  * not a slow charge, it is a discharge or a stall, and running it backwards
  * would draw a rising curve out of a falling one.
  */
-export function extrapolationSlope(points) {
+export function extrapolationSlope(points, { skipRamp = true } = {}) {
     const usable = (points ?? []).filter(p => p?.soc != null && p?.time != null);
     if (usable.length < 2) return null;
 
-    const trimmed = rampLength(usable);
+    const trimmed = skipRamp ? rampLength(usable) : 0;
     const from = usable[trimmed];
     if (!from) return null;
 

--- a/src/utils/socAlignment.js
+++ b/src/utils/socAlignment.js
@@ -111,17 +111,12 @@ export function alignSeries(points, thresholdSoc) {
     // visited — so the caller is told how far it reached beyond the data, and
     // anything past EXTRAPOLATION_SOC_LIMIT is worth saying out loud.
     if (!before) {
-        const first  = usable[0];
-        const second = usable.find(p => p.time > first.time && p.soc !== first.soc);
-        if (!second) return { offset: at.time, points: points.slice(idx), interpolated: false };
+        const first = usable[0];
+        const slope = extrapolationSlope(usable);
+        if (!slope) return { offset: at.time, points: points.slice(idx), interpolated: false };
 
-        const socPerMin = (second.soc - first.soc) / (second.time - first.time);
-        if (!Number.isFinite(socPerMin) || socPerMin <= 0) {
-            return { offset: at.time, points: points.slice(idx), interpolated: false };
-        }
-
-        const gap  = first.soc - thresholdSoc;              // SoC being invented
-        const back = gap / socPerMin;                        // minutes before the data
+        const gap  = first.soc - thresholdSoc;               // SoC being invented
+        const back = gap / slope.socPerMin;                  // minutes before the data
         const start = {
             ...first,
             soc: thresholdSoc,
@@ -134,6 +129,7 @@ export function alignSeries(points, thresholdSoc) {
             interpolated: false,
             extrapolated: true,
             gap,
+            rampTrimmed: slope.trimmed,
         };
     }
 
@@ -144,6 +140,101 @@ export function alignSeries(points, thresholdSoc) {
     // A synthetic point AT the threshold, so the curve literally begins there.
     const start = { ...before, soc: thresholdSoc, time: crossTime, _interpolatedStart: true };
     return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true };
+}
+
+/* ── The opening ramp ───────────────────────────────────────────────────────
+ *
+ * A charging session does not begin at the car's capability. The charger and
+ * the BMS negotiate upward — voltage, then current — until one of them is at
+ * its limit, which takes something under a minute. A real R2 session opens at
+ * 93 kW, is at 195 kW twenty-four seconds later, and settles near 220:
+ *
+ *     t=0.1  10%   93 kW      ← handshake, not capability
+ *     t=0.5  11%  195 kW      ← still climbing
+ *     t=0.9  12%  214 kW      ← settled
+ *     t=1.4  14%  216 kW
+ *
+ * Those points are true — the car really was at 10% drawing 93 kW — but they
+ * describe the plug, not the car. Reading a slope across them says the R2 gains
+ * 2.5 %/min when it gains 3.9, and back-projecting on that invented an extra
+ * 0.8 minutes of fabricated slowness before its data even started.
+ *
+ * So the ramp is excluded from the SLOPE BASIS ONLY. The measured points stay on
+ * the chart, because they happened. What changes is the rate we are willing to
+ * attribute to the car when extending it past what was measured.
+ */
+
+/** Share of the opening plateau below which a point is still ramping up. */
+export const RAMP_PLATEAU_FRACTION = 0.9;
+
+/** Never treat more than this many leading points as ramp. A run whose power
+ *  climbs for its whole opening is tapering oddly or badly logged; trimming it
+ *  wholesale would be a bigger guess than the one being avoided. */
+export const RAMP_MAX_TRIM = 3;
+
+const LEAD_WINDOW_POINTS = 10;   // what counts as "the opening"
+const SLOPE_SPAN_SOC     = 3;    // measure the rate over at least this much SoC
+
+/**
+ * How many leading points are still ramping up.
+ *
+ * Uses recorded power when there is any, because the ramp is a fact about power
+ * and reads directly: below `RAMP_PLATEAU_FRACTION` of the opening plateau is
+ * still climbing. A tapering run — power highest at its first point — trims
+ * nothing, which is the behaviour that matters for a run that starts high.
+ *
+ * Falls back to nothing when power was not logged. The SoC slope alone cannot
+ * tell a ramp from coarse sampling: this data is quantised to whole percent, so
+ * the settled R2 alternates 3.33 and 5.0 %/min, and any rule sensitive enough
+ * to catch a real ramp would also catch that sawtooth.
+ */
+export function rampLength(points) {
+    const window = (points ?? []).slice(0, LEAD_WINDOW_POINTS);
+    const powers = window.map(p => p?.chargeRate);
+    if (!powers.some(w => w != null && Number.isFinite(w) && w > 0)) return 0;
+
+    const plateau = Math.max(...powers.filter(w => w != null && Number.isFinite(w)));
+    if (!(plateau > 0)) return 0;
+
+    let n = 0;
+    while (n < window.length && n < RAMP_MAX_TRIM) {
+        const w = powers[n];
+        if (w == null || !Number.isFinite(w)) break;
+        if (w >= plateau * RAMP_PLATEAU_FRACTION) break;
+        n++;
+    }
+    // Leaving nothing to measure a slope with is worse than keeping the ramp.
+    return Math.min(n, Math.max(0, (points?.length ?? 0) - 2));
+}
+
+/**
+ * The rate to extend a run backwards at, in % SoC per minute.
+ *
+ * Measured after the ramp, and over at least `SLOPE_SPAN_SOC` of SoC — a single
+ * segment of whole-percent data is 1% wide, so its rate carries the sampling
+ * interval's error rather than the car's behaviour.
+ *
+ * Returns null when no positive rate can be measured. A flat or falling trace is
+ * not a slow charge, it is a discharge or a stall, and running it backwards
+ * would draw a rising curve out of a falling one.
+ */
+export function extrapolationSlope(points) {
+    const usable = (points ?? []).filter(p => p?.soc != null && p?.time != null);
+    if (usable.length < 2) return null;
+
+    const trimmed = rampLength(usable);
+    const from = usable[trimmed];
+    if (!from) return null;
+
+    const to = usable.slice(trimmed + 1).find(p => p.soc - from.soc >= SLOPE_SPAN_SOC)
+        ?? usable[usable.length - 1];
+
+    const dt = to.time - from.time;
+    const ds = to.soc - from.soc;
+    if (!(dt > 0) || !(ds > 0)) return null;
+
+    const socPerMin = ds / dt;
+    return Number.isFinite(socPerMin) && socPerMin > 0 ? { socPerMin, trimmed } : null;
 }
 
 /**

--- a/src/utils/socAlignment.js
+++ b/src/utils/socAlignment.js
@@ -27,8 +27,13 @@
 export function minimumCommonSoc(series) {
     let highestMin = null;
 
-    for (const points of series ?? []) {
-        if (!points?.length) continue;
+    for (const raw of series ?? []) {
+        if (!raw?.length) continue;
+        // Ramp points are dropped here too, so the automatic threshold lands
+        // where every run has SETTLED data. Choosing it from the untrimmed
+        // minimum would pick a SoC one of the runs only reaches while its
+        // charger is still negotiating, and then extrapolate to get back to it.
+        const points = trimRamp(raw);
         let runMin = null;
         for (const p of points) {
             if (p?.soc == null || p?.time == null) continue;
@@ -86,8 +91,14 @@ export function alignmentOffset(points, thresholdSoc) {
  *
  * Returns null when the run cannot be aligned at all.
  */
-export function alignSeries(points, thresholdSoc) {
-    if (!points?.length) return null;
+export function alignSeries(raw, thresholdSoc) {
+    if (!raw?.length) return null;
+
+    // The opening ramp comes off before anything else, so it is out of the
+    // slope, out of the interpolation, and off the chart — see trimRamp.
+    const points = trimRamp(raw);
+    const rampTrimmed = raw.length - points.length;
+
     const usable = points.filter(p => p.soc != null && p.time != null);
     if (!usable.length) return null;
 
@@ -99,7 +110,7 @@ export function alignSeries(points, thresholdSoc) {
         .find(p => p.soc != null && p.time != null && p.soc < thresholdSoc);
 
     if (at.soc === thresholdSoc) {
-        return { offset: at.time, points: points.slice(idx), interpolated: false };
+        return { offset: at.time, points: points.slice(idx), interpolated: false, rampTrimmed };
     }
 
     // No bracketing sample means the run BEGAN above the threshold. Aligning it
@@ -113,23 +124,26 @@ export function alignSeries(points, thresholdSoc) {
     if (!before) {
         const first = usable[0];
         const slope = extrapolationSlope(usable);
-        if (!slope) return { offset: at.time, points: points.slice(idx), interpolated: false };
+        if (!slope) return { offset: at.time, points: points.slice(idx), interpolated: false, rampTrimmed };
 
         const gap  = first.soc - thresholdSoc;               // SoC being invented
         const back = gap / slope.socPerMin;                  // minutes before the data
-        const start = {
-            ...first,
-            soc: thresholdSoc,
-            time: first.time - back,
-            _extrapolatedStart: true,
-        };
+        // ONLY when and at what SoC — nothing else. Carrying the first point's
+        // other channels forward would put a measured charge rate, range and
+        // temperature at a moment the run never recorded, and they would be
+        // wrong in a way that reads as data: the old version inherited the
+        // ramp's 93 kW and drew it flat across the invented minute, so a chart
+        // of charge rate opened on a number the estimate itself contradicts.
+        // The plotting path drops null-y points, so each channel simply begins
+        // at its first real sample.
+        const start = { soc: thresholdSoc, time: first.time - back, _extrapolatedStart: true };
         return {
             offset: start.time,
             points: [start, ...points],
             interpolated: false,
             extrapolated: true,
             gap,
-            rampTrimmed: slope.trimmed,
+            rampTrimmed,
         };
     }
 
@@ -138,8 +152,28 @@ export function alignSeries(points, thresholdSoc) {
     const crossTime = before.time + (at.time - before.time) * frac;
 
     // A synthetic point AT the threshold, so the curve literally begins there.
-    const start = { ...before, soc: thresholdSoc, time: crossTime, _interpolatedStart: true };
-    return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true };
+    // Here the other channels ARE carried, interpolated the same way and by the
+    // same fraction — this sits between two real samples, so a charge rate
+    // partway between them is a reading of the data rather than an invention.
+    const start = {
+        ...interpolateChannels(before, at, frac),
+        soc: thresholdSoc,
+        time: crossTime,
+        _interpolatedStart: true,
+    };
+    return { offset: crossTime, points: [start, ...points.slice(idx)], interpolated: true, rampTrimmed };
+}
+
+/** Every numeric channel the two samples share, read at `frac` between them. */
+function interpolateChannels(before, at, frac) {
+    const out = {};
+    for (const [key, a] of Object.entries(before)) {
+        const b = at?.[key];
+        out[key] = (typeof a === 'number' && typeof b === 'number' && Number.isFinite(a) && Number.isFinite(b))
+            ? a + (b - a) * frac
+            : a;
+    }
+    return out;
 }
 
 /* ── The opening ramp ───────────────────────────────────────────────────────
@@ -159,9 +193,12 @@ export function alignSeries(points, thresholdSoc) {
  * 2.5 %/min when it gains 3.9, and back-projecting on that invented an extra
  * 0.8 minutes of fabricated slowness before its data even started.
  *
- * So the ramp is excluded from the SLOPE BASIS ONLY. The measured points stay on
- * the chart, because they happened. What changes is the rate we are willing to
- * attribute to the car when extending it past what was measured.
+ * So when a chart aligns runs to a common SoC, the ramp comes off first: out of
+ * the slope, out of the interpolation, and off the plot. Nothing is deleted —
+ * the data is untouched and raw time shows every sample — but a comparison of
+ * how fast cars charge should not open with a minute of handshake, and it is
+ * unfair besides, since it only penalises the runs whose logging happened to
+ * start at plug-in.
  */
 
 /** Share of the opening plateau below which a point is still ramping up. */
@@ -205,6 +242,29 @@ export function rampLength(points) {
     }
     // Leaving nothing to measure a slope with is worse than keeping the ramp.
     return Math.min(n, Math.max(0, (points?.length ?? 0) - 2));
+}
+
+/**
+ * A run's points with its opening ramp removed.
+ *
+ * Virtual, not destructive: this is what alignment computes and plots from, and
+ * nothing is written back. "Raw test time" bypasses it entirely and shows every
+ * sample the logger recorded.
+ *
+ * Idempotent — trimming settled data finds no ramp — so it is safe to apply on
+ * a series that has already been through it.
+ */
+export function trimRamp(points) {
+    if (!points?.length) return points ?? [];
+    const usable = points.filter(p => p?.soc != null && p?.time != null);
+    const n = rampLength(usable);
+    if (!n) return points;
+
+    // Map the count back onto the original array, which may carry samples with
+    // no SoC or time between the usable ones.
+    const firstSettled = usable[n];
+    const cut = points.indexOf(firstSettled);
+    return cut > 0 ? points.slice(cut) : points;
 }
 
 /**


### PR DESCRIPTION
Closes #195 (items 1–3; item 4, the shared extrapolation module, is a separate PR).

With time on the X axis every run started at zero, so a session beginning at 8% SoC sat beside one beginning at 30% as though they were the same measurement. Race mode already corrected this and was off by default.

**Alignment is now the default** on the time axis. `Raw logger time` is the labelled escape hatch.

**The threshold follows the data** — it defaults to the lowest SoC every selected run actually reaches, so no run is dropped by construction. The control moved up beside the axis selectors, since alignment is a property of the axis.

**The anchor is interpolated, not snapped.** This was a real defect: one run carries five points (0%, 25%, 50% …), so its "10% anchor" was the sample at 25%, drawn from t=0 beside runs that genuinely started at 10%.

**Runs may be extended below their own data** to reach the threshold, on the slope of their first two points. Up to 5 points of SoC passes silently; beyond that the chart names the run and the size of the estimate. Never for a discharge trace.

**Exclusions are named on the chart**, not only in the selector — a chart silently missing a car is the failure worth designing against.

### Verified against real data
| threshold | curves start at | warning |
|---|---|---|
| auto (10%) | all at 10% — Rav4 moved from 25% | none |
| 4% | all at 4% | ⚠ names the run and its 6% estimate |
| 9% | all at 9% | none — 1% stretch is within the limit |

154 assertions (30 new), no lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)